### PR TITLE
use prettyNumber function instead

### DIFF
--- a/src/lib/bip21.ts
+++ b/src/lib/bip21.ts
@@ -2,7 +2,7 @@
 // bitcoin:<address>[?amount=<amount>][?label=<label>][?message=<message>]
 
 import qs from 'qs'
-import { fromSatoshis, toSatoshis } from './format'
+import { fromSatoshis, prettyNumber, toSatoshis } from './format'
 
 export const decode = (uri: string) => {
   if (!isBip21(uri)) throw new Error('Invalid BIP21 URI: ' + uri)
@@ -33,11 +33,7 @@ export const decode = (uri: string) => {
 }
 
 export const encode = (address: string, arkAddress: string, sats: number) => {
-  const amount = fromSatoshis(sats)
-  const amountStr = Number(amount)
-    .toFixed(8)
-    .replace(/\.?0+$/, '')
-  return `bitcoin:${address}` + `?ark=${arkAddress}` + `&amount=${amountStr}`
+  return `bitcoin:${address}` + `?ark=${arkAddress}` + `&amount=${prettyNumber(fromSatoshis(sats))}`
 }
 
 export const isBip21 = (data: string): boolean => {


### PR DESCRIPTION
@tiero @louisinger arkade have some pretty* functions in /lib/format that takes care of this.

This PR reverts the last commit ([fix bug on bip21 amount](https://github.com/ArkLabsHQ/arkade-wallet/commit/f00d72a53bc3a8423d4c1cbf999d33f0d7be0337)) and uses prettyNumber() to fix the issue.