### PR TITLE
fix passkeys

### DIFF
--- a/src/lib/biometrics.ts
+++ b/src/lib/biometrics.ts
@@ -1,17 +1,20 @@
 import { hex } from '@scure/base'
-import { toUint8Array } from './format'
 
-function generateRandomChallenge(): Uint8Array {
-  const array = new Uint8Array(32)
+function generateRandomArray(length: number): Uint8Array {
+  const array = new Uint8Array(length)
   window.crypto.getRandomValues(array)
   return array
 }
 
-function getBrowserId(): string {
-  const userAgent = window.navigator.userAgent
-  const match = userAgent.match(/\(([^)]+)/)
-  if (match?.[1]) return match[1]
-  return 'unknown'
+// used to validate the challenge.
+// webauth api does some transformations to the base64 string
+// so we need to do the same transformations to validate the challenge
+function arrayToBase64(data: Uint8Array | ArrayBuffer): string {
+  const array = data instanceof ArrayBuffer ? new Uint8Array(data) : data
+  return btoa(String.fromCharCode(...array))
+    .replaceAll('=', '')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
 }
 
 export function isBiometricsSupported(): boolean {
@@ -19,14 +22,18 @@ export function isBiometricsSupported(): boolean {
 }
 
 // Function to register a new user
-export async function registerUser(): Promise<string> {
-  const publicKeyCredentialCreationOptions: PublicKeyCredentialCreationOptions = {
+export async function registerUser(): Promise<{ password: string; passkeyId: string }> {
+  const decoder = new TextDecoder()
+  const challenge = generateRandomArray(32)
+  const password = generateRandomArray(21)
+
+  const options: PublicKeyCredentialCreationOptions = {
     authenticatorSelection: {
       authenticatorAttachment: 'platform',
       residentKey: 'required',
       requireResidentKey: true,
     },
-    challenge: generateRandomChallenge(),
+    challenge,
     pubKeyCredParams: [
       {
         type: 'public-key',
@@ -43,25 +50,49 @@ export async function registerUser(): Promise<string> {
     },
     timeout: 60000,
     user: {
-      id: toUint8Array(getBrowserId()),
-      name: getBrowserId(),
-      displayName: 'Arkade',
+      id: password,
+      name: 'Arkade wallet',
+      displayName: 'Arkade wallet',
     },
   }
 
-  const credential = await navigator.credentials.create({ publicKey: publicKeyCredentialCreationOptions })
-  const pubKeyCred = credential as PublicKeyCredential
-  return hex.encode(new Uint8Array(pubKeyCred.rawId)).slice(0, 21)
+  const credentials = (await navigator.credentials.create({ publicKey: options })) as PublicKeyCredential
+  const authResponse = credentials.response as AuthenticatorAttestationResponse
+  const clientDataJSON = JSON.parse(decoder.decode(authResponse.clientDataJSON))
+
+  if (clientDataJSON.type !== 'webauthn.create') throw new Error('Invalid clientDataJSON type')
+  if (clientDataJSON.challenge !== arrayToBase64(challenge)) throw new Error('Invalid challenge')
+  if (clientDataJSON.origin !== window.location.origin) throw new Error('Invalid origin')
+
+  return { password: hex.encode(password), passkeyId: hex.encode(new Uint8Array(credentials.rawId)) }
 }
 
 // Function to authenticate a user
-export async function authenticateUser(): Promise<string> {
-  const publicKeyCredentialRequestOptions: PublicKeyCredentialRequestOptions = {
-    challenge: generateRandomChallenge(),
+export async function authenticateUser(passkeyId: string | undefined): Promise<string> {
+  if (!passkeyId) throw new Error('Missing passkey id')
+  const decoder = new TextDecoder()
+  const challenge = generateRandomArray(32)
+
+  const options: PublicKeyCredentialRequestOptions = {
+    allowCredentials: [
+      {
+        id: hex.decode(passkeyId),
+        type: 'public-key',
+      },
+    ],
+    challenge,
+    rpId: window.location.hostname,
     timeout: 60000,
   }
 
-  const credential = await navigator.credentials.get({ publicKey: publicKeyCredentialRequestOptions })
-  const pubKeyCred = credential as PublicKeyCredential
-  return hex.encode(new Uint8Array(pubKeyCred.rawId)).slice(0, 21)
+  const credentials = (await navigator.credentials.get({ publicKey: options })) as PublicKeyCredential
+  const authResponse = credentials.response as AuthenticatorAssertionResponse
+  const clientDataJSON = JSON.parse(decoder.decode(authResponse.clientDataJSON))
+  const userHandle = new Uint8Array(authResponse.userHandle ?? new ArrayBuffer(0))
+
+  if (clientDataJSON.type !== 'webauthn.get') throw new Error('Invalid clientDataJSON type')
+  if (clientDataJSON.challenge !== arrayToBase64(challenge)) throw new Error('Invalid challenge')
+  if (clientDataJSON.origin !== window.location.origin) throw new Error('Invalid origin')
+
+  return hex.encode(userHandle)
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,7 @@ export type Wallet = {
   lockedByBiometrics?: boolean
   network: string
   nextRollover: number
+  passkeyId?: string
   txs: Tx[]
   vtxos: Vtxos
   wasmVersion: string

--- a/src/screens/Init/Password.tsx
+++ b/src/screens/Init/Password.tsx
@@ -12,6 +12,7 @@ import { WalletContext } from '../../providers/wallet'
 import CenterScreen from '../../components/CenterScreen'
 import FingerprintIcon from '../../icons/Fingerprint'
 import Text from '../../components/Text'
+import { consoleLog } from '../../lib/logs'
 
 export default function InitPassword() {
   const { navigate } = useContext(NavigationContext)
@@ -29,11 +30,11 @@ export default function InitPassword() {
 
   const registerUserBiometrics = () => {
     registerUser()
-      .then((password) => {
-        updateWallet({ ...wallet, lockedByBiometrics: true })
+      .then(({ password, passkeyId }) => {
+        updateWallet({ ...wallet, lockedByBiometrics: true, passkeyId })
         connect(password)
       })
-      .catch(() => {})
+      .catch(consoleLog)
   }
 
   useEffect(() => {

--- a/src/screens/Settings/Lock.tsx
+++ b/src/screens/Settings/Lock.tsx
@@ -24,13 +24,11 @@ export default function Lock() {
   const [password, setPassword] = useState('')
 
   const getPasswordFromBiometrics = () => {
-    authenticateUser()
-      .then(setPassword)
-      .catch(() => {})
+    authenticateUser(wallet.passkeyId).then(setPassword).catch(consoleError)
   }
 
   useEffect(() => {
-    if (!wallet.lockedByBiometrics || !walletUnlocked) return
+    if (!wallet.lockedByBiometrics || !walletUnlocked || !wallet.passkeyId) return
     getPasswordFromBiometrics()
   }, [wallet.lockedByBiometrics])
 

--- a/src/screens/Wallet/Unlock.tsx
+++ b/src/screens/Wallet/Unlock.tsx
@@ -26,9 +26,7 @@ export default function Unlock() {
   const [password, setPassword] = useState('')
 
   const getPasswordFromBiometrics = () => {
-    authenticateUser()
-      .then(setPassword)
-      .catch(() => {})
+    authenticateUser(wallet.passkeyId).then(setPassword).catch(consoleError)
   }
 
   useEffect(() => {


### PR DESCRIPTION
With this PR the app stores on local storage the rawId of the passkey created and when authenticating this rawId is passed, making the list of available passkeys to be single.

No more several passkeys to choose from, which generated confusion to the end user.

@tiero please review.