### PR TITLE
passkey: use PRF extension

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,95 @@
+export type PasskeyCredentials = {
+  // TODO: JS migration should encrypt the seed itself instead of password
+  // now, with WASM sdk, we need a password.
+  encryptedPassword: string
+  passkeyId: string
+}
+
+export interface CredentialsRepository {
+  get(): Promise<PasskeyCredentials>
+  set(credentials: PasskeyCredentials): Promise<void>
+}
+
+const DB_NAME = 'arkade'
+
+export class IndexedDbCredentials implements CredentialsRepository {
+  static STORE_NAME = 'credentials'
+  static DB_VERSION = 1
+
+  private db: IDBDatabase | null = null
+
+  static async create(): Promise<IndexedDbCredentials> {
+    const instance = new IndexedDbCredentials()
+    await instance.init()
+    return instance
+  }
+
+  private async init(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, IndexedDbCredentials.DB_VERSION)
+
+      request.onerror = () => {
+        reject(request.error)
+      }
+
+      request.onsuccess = () => {
+        this.db = request.result
+        resolve()
+      }
+
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result
+        if (!db.objectStoreNames.contains(IndexedDbCredentials.STORE_NAME)) {
+          db.createObjectStore(IndexedDbCredentials.STORE_NAME)
+        }
+      }
+    })
+  }
+
+  async get(): Promise<PasskeyCredentials> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const transaction = this.db.transaction(IndexedDbCredentials.STORE_NAME, 'readonly')
+      const store = transaction.objectStore(IndexedDbCredentials.STORE_NAME)
+      const request = store.get('credentials')
+
+      request.onerror = () => {
+        reject(request.error)
+      }
+
+      request.onsuccess = () => {
+        const result = request.result
+        if (!result) {
+          reject(new Error('No credentials found'))
+          return
+        }
+        resolve(result)
+      }
+    })
+  }
+
+  async set(credentials: PasskeyCredentials): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'))
+        return
+      }
+
+      const transaction = this.db.transaction(IndexedDbCredentials.STORE_NAME, 'readwrite')
+      const store = transaction.objectStore(IndexedDbCredentials.STORE_NAME)
+      const request = store.put(credentials, 'credentials')
+
+      request.onerror = () => {
+        reject(request.error)
+      }
+
+      request.onsuccess = () => {
+        resolve()
+      }
+    })
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,7 +103,6 @@ export type Wallet = {
   lockedByBiometrics?: boolean
   network: string
   nextRollover: number
-  passkeyId?: string
   txs: Tx[]
   vtxos: Vtxos
   wasmVersion: string

--- a/src/screens/Init/Password.tsx
+++ b/src/screens/Init/Password.tsx
@@ -28,8 +28,8 @@ export default function InitPassword() {
 
   const registerUserBiometrics = () => {
     registerUser()
-      .then(({ password, passkeyId }) => {
-        updateWallet({ ...wallet, lockedByBiometrics: true, passkeyId })
+      .then(({ password }) => {
+        updateWallet({ ...wallet, lockedByBiometrics: true })
         setInitInfo({ ...initInfo, password })
         setShowSheet(true)
       })

--- a/src/screens/Wallet/Unlock.tsx
+++ b/src/screens/Wallet/Unlock.tsx
@@ -26,7 +26,7 @@ export default function Unlock() {
   const [password, setPassword] = useState('')
 
   const getPasswordFromBiometrics = () => {
-    authenticateUser(wallet.passkeyId).then(setPassword).catch(consoleError)
+    authenticateUser().then(setPassword).catch(consoleError)
   }
 
   useEffect(() => {


### PR DESCRIPTION
This PR adds the [PRF extension](https://gist.github.com/louisinger/89073a94eeee3afe030b95afb3ec668a) to `biometrics.ts`.

Because the current version is using the WASM go-sdk, we _need a pasword_ so we are generating a random password, and we use the encrypting key from passkey to store it encrypted in IndexedDB.

Once https://github.com/ArkLabsHQ/arkade-wallet/pull/70 is merged, we should drop password and encrypt the seed itself.

@bordalix @tiero please review