### PR TITLE
remove auto unlock with biometrics

### DIFF
--- a/src/components/NeedsPassword.tsx
+++ b/src/components/NeedsPassword.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useState } from 'react'
 import Text from './Text'
 import Error from './Error'
 import Button from './Button'
@@ -25,10 +25,6 @@ export default function NeedsPassword({ error, onPassword }: NeedsPasswordProps)
   const handleBiometrics = () => {
     authenticateUser(wallet.passkeyId).then(onPassword).catch(consoleError)
   }
-
-  useEffect(() => {
-    if (wallet.lockedByBiometrics) handleBiometrics()
-  }, [wallet.lockedByBiometrics])
 
   const handleChange = (ev: any) => setPassword(ev.target.value)
   const handleClick = () => onPassword(password)


### PR DESCRIPTION
This PR removes the annoying biometrics request that appears periodically.

- When a wallet is created, a password (either string or via biometrics) is collected and used to encrypt the private key and store it on local storage;
- Every time the wallet on the service worker is initialised, it needs to receive the private key from the app;
- To do this, the app needs the collect the password used to encrypt the private key and use it to decrypt the private key and then pass it to the wallet on the service worker;
- Service workers suspends after some idle time, so it looses the private key, which means it needs to be passed again to the wallet in the service worker; 
- The UI that handles this is managed by the component NeedsPassword;
- This component was automatically triggering the biometrics prompt when the service worker went idle and the wallet went to the locked stated again;
- This PR removes this automation: the app goes to locked state again, but this not trigger the system wide (and so really annoying) biometrics prompt.

@tiero please review