### PR TITLE
refactor pwa install prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "homepage": ".",
   "dependencies": {
     "@arkade-os/sdk": "^0.1.1",
-    "@dotmind/react-use-pwa": "^1.0.4",
     "@ionic/react": "^8.5.6",
     "@scure/base": "^1.2.5",
     "@scure/bip32": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   '@arkade-os/sdk':
     specifier: ^0.1.1
     version: 0.1.1
-  '@dotmind/react-use-pwa':
-    specifier: ^1.0.4
-    version: 1.0.4
   '@ionic/react':
     specifier: ^8.5.6
     version: 8.5.6(react-dom@18.3.1)(react@18.3.1)
@@ -325,10 +322,6 @@ packages:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
     dev: true
-
-  /@dotmind/react-use-pwa@1.0.4:
-    resolution: {integrity: sha512-qZauJLQu9hbdy6eAIm49YfI+8Dxty9tr8Zmv99M4rV37zwT7LVSdohXlGmFXXo19v5YV/Ig0Mnn5hRGPCxWDrA==}
-    dev: false
 
   /@esbuild/aix-ppc64@0.21.5:
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import Loading from './components/Loading'
 import AppsIcon from './icons/Apps'
 import { WalletContext } from './providers/wallet'
 import { FlowContext } from './providers/flow'
-import { usePwa } from '@dotmind/react-use-pwa'
+import { pwaIsInstalled } from './lib/pwa'
 
 setupIonicReact()
 
@@ -42,7 +42,6 @@ export default function App() {
   const { setOption } = useContext(OptionsContext)
   const { wallet, initialized, svcWallet } = useContext(WalletContext)
   const [loadingError, setLoadingError] = useState('')
-  const { isInstalled: isPwaInstalled } = usePwa()
 
   // lock screen orientation to portrait
   // this is a workaround for the issue with the screen orientation API
@@ -51,7 +50,6 @@ export default function App() {
   if (orientation && typeof orientation.lock === 'function') {
     orientation.lock('portrait').catch(() => {})
   }
-
   useEffect(() => {
     if (!configLoaded) {
       setLoadingError('')
@@ -68,7 +66,7 @@ export default function App() {
     // avoid redirect if the user is still setting up the wallet
     if (initInfo.password || initInfo.privateKey) return
     if (!svcWallet || initialized === undefined) navigate(Pages.Loading)
-    else if (wallet.network === '') navigate(isPwaInstalled ? Pages.Init : Pages.Onboard)
+    else if (wallet.network === '') navigate(pwaIsInstalled() ? Pages.Init : Pages.Onboard)
     else if (!initialized) navigate(Pages.Unlock)
   }, [wallet, initialized, svcWallet, initInfo])
 

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,0 +1,7 @@
+const isServer = (): boolean => typeof window === 'undefined'
+
+const isStandalone = () => navigator.standalone || window.matchMedia('(display-mode: standalone)').matches
+
+export const pwaCanInstall = () => 'serviceWorker' in navigator && !isServer() && !isStandalone()
+
+export const pwaIsInstalled = () => !isServer() && isStandalone()

--- a/src/screens/Wallet/Onboard.tsx
+++ b/src/screens/Wallet/Onboard.tsx
@@ -17,47 +17,40 @@ import FlexRow from '../../components/FlexRow'
 import Shadow from '../../components/Shadow'
 import AddIcon from '../../icons/Add'
 import ShareIcon from '../../icons/Share'
-import { usePwa } from '@dotmind/react-use-pwa'
+import { pwaCanInstall } from '../../lib/pwa'
 
 export default function Onboard() {
   const { navigate } = useContext(NavigationContext)
   const [step, setStep] = useState(1)
-  const { installPrompt, canInstall } = usePwa()
-  const steps = canInstall ? 4 : 3
+
+  const steps = pwaCanInstall() ? 4 : 3
 
   const handleContinue = () => setStep(step + 1)
 
   const handleSkip = () => navigate(Pages.Init)
 
   const ImageContainer = () => {
-    const Image = () => {
-      if (step === 1) return <OnboardImage1 />
-      if (step === 2) return <OnboardImage2 />
-      if (step === 3) return <OnboardImage3 />
-      return <OnboardImage4 />
-    }
-    const style: any = {
-      alignItems: 'center',
-      display: 'flex',
-      justifyContent: 'center',
-      margin: '0 auto',
-      maxHeight: '50%',
-    }
-
-    if (step === 4) {
-      style.cursor = 'pointer'
-      return (
-        <div style={style} onClick={installPrompt}>
-          <Image />
-        </div>
-      )
-    } else {
-      return (
-        <div style={style}>
-          <Image />
-        </div>
-      )
-    }
+    return (
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          justifyContent: 'center',
+          margin: '0 auto',
+          maxHeight: '50%',
+        }}
+      >
+        {step === 1 ? (
+          <OnboardImage1 />
+        ) : step === 2 ? (
+          <OnboardImage2 />
+        ) : step === 3 ? (
+          <OnboardImage3 />
+        ) : (
+          <OnboardImage4 />
+        )}
+      </div>
+    )
   }
 
   const InfoContainer = (): ReactNode => {
@@ -123,7 +116,7 @@ export default function Onboard() {
       <Content>
         <Padded>
           <FlexCol between>
-            {step < 4 ? <StepBars active={step} length={steps - 1} /> : <div />}
+            <StepBars active={step} length={steps} />
             <ImageContainer />
             <InfoContainer />
           </FlexCol>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,3 +9,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+interface Navigator {
+  standalone?: boolean
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import eslint from 'vite-plugin-eslint';
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import eslint from 'vite-plugin-eslint'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -24,4 +24,4 @@ export default defineConfig({
   worker: {
     format: 'es',
   },
-}); 
+})


### PR DESCRIPTION
This PR enhances the UX for PWA installation.

Previously, we started by assuming the app was NOT installable and relied on the browser to trigger a [beforeinstallprompt](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeinstallprompt_event) event for the app to know that it was installable as a PWA.

This approach had a significant issue: the event depends on undocumented and inaccessible user heuristics, leading to inconsistent behaviour. On the same URL, the event would sometimes fire and sometimes not. Additionally, this event is not supported in Firefox and Safari, so I decided to get rid of this. There were too many **false negatives**., i.e. we were not nudging the user to install the app when he could.

What changed:
- We now assume the app is installable by default, unless is running as standalone (i.e. in PWA context) or there's no service worker support in navigator
- We will now generate **false positives**, i.e. if the user is accessing the website in the browser, and also have it installed as PWA, the website will not know that and will nudge the user to install the app

What we loose with this PR:
- The possibility of "click-to-install" the PWA, the user must click the icon on the browser bar or follow the instructions

@Kukks @tiero what do you guys think?

