### PR TITLE
show an error if ln invoice has no amount

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -97,6 +97,7 @@ export default function SendForm() {
       }
       if (isLightningInvoice(lowerCaseData)) {
         const satoshis = getInvoiceSatoshis(lowerCaseData)
+        if (!satoshis) return setError('Invoice must have amount defined')
         setAmount(useFiat ? toFiat(satoshis) : satoshis ? satoshis : undefined)
         return setState({ ...sendInfo, address: '', arkAddress: '', invoice: lowerCaseData })
       }


### PR DESCRIPTION
closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Lightning invoices by ensuring that invoices without a defined amount now display an error message and cannot proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->