### PR TITLE
Show success message after settle on coin control

### DIFF
--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -65,11 +65,6 @@ export default function Vtxos() {
     setAboveDust(totalAmount > aspInfo.dust)
   }, [vtxos])
 
-  if (!svcWallet) return <Loading text='Loading...' />
-
-  // Replace the old showSuccess function with a cleaner version:
-  const showSuccess = () => setSuccess(true)
-
   // Automatically reset `success` after 5s, with cleanup on unmount or re-run
   useEffect(() => {
     if (!success) return
@@ -77,12 +72,14 @@ export default function Vtxos() {
     return () => clearTimeout(timeoutId)
   }, [success])
 
+  if (!svcWallet) return <Loading text='Loading...' />
+
   const handleRollover = async () => {
     try {
       setRollingover(true)
       await settleVtxos(svcWallet)
       setRollingover(false)
-      showSuccess()
+      setSuccess(true)
     } catch (err) {
       setError(extractError(err))
       setRollingover(false)


### PR DESCRIPTION
Message stays for 5 seconds

Preview:

https://github.com/user-attachments/assets/f9928191-e129-4125-9789-c1b6b1f8a541

@tiero please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a clear success confirmation in Settings → VTXOs after a renewal/settlement completes: a green success banner appears and auto-dismisses after 5 seconds.
  * Improves on-screen status handling for the renewal flow so users receive immediate, prominent visual feedback when the action succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->