### PR TITLE
don't show unlock flash screen when has no password

### DIFF
--- a/src/screens/Wallet/Unlock.tsx
+++ b/src/screens/Wallet/Unlock.tsx
@@ -6,6 +6,7 @@ import { NavigationContext, Pages } from '../../providers/navigation'
 import NeedsPassword from '../../components/NeedsPassword'
 import Header from '../../components/Header'
 import { defaultPassword } from '../../lib/constants'
+import Loading from '../../components/Loading'
 
 export default function Unlock() {
   const { initWallet } = useContext(WalletContext)
@@ -13,6 +14,7 @@ export default function Unlock() {
 
   const [error, setError] = useState('')
   const [password, setPassword] = useState('')
+  const [tried, setTried] = useState(false)
 
   useEffect(() => {
     const pass = password ? password : defaultPassword
@@ -20,6 +22,7 @@ export default function Unlock() {
       .then(initWallet)
       .then(() => navigate(Pages.Wallet))
       .catch((err) => {
+        setTried(true)
         if (password) {
           consoleError(err, 'error unlocking wallet')
           setError('Invalid password')
@@ -27,10 +30,12 @@ export default function Unlock() {
       })
   }, [password])
 
-  return (
+  return tried ? (
     <>
       <Header text='Unlock' />
       <NeedsPassword error={error} onPassword={setPassword} />
     </>
+  ) : (
+    <Loading />
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading indicator during wallet unlock attempts for clearer progress feedback.
  * Automatically transitions to the unlock screen after the first attempt, improving flow.

* **Bug Fixes**
  * Displays a clear “Invalid password” message on failed unlock attempts.
  * Improves handling of failed unlocks to prevent confusing states and ensure consistent navigation after success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->