### PR TITLE
fix wallet balance in fiat

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import { prettyHide, prettyNumber } from '../lib/format'
-import { Satoshis } from '../lib/types'
+import { CurrencyDisplay, Satoshis } from '../lib/types'
 import { FiatContext } from '../providers/fiat'
 import Text from './Text'
 import FlexCol from './FlexCol'
@@ -21,6 +21,12 @@ export default function Balance({ amount }: BalanceProps) {
   const satsBalance = config.showBalance ? prettyNumber(amount) : prettyHide(amount, '')
   const fiatBalance = config.showBalance ? prettyNumber(fiatAmount, 2) : prettyHide(fiatAmount, '')
 
+  const otherBalance = config.currencyDisplay === CurrencyDisplay.Fiat ? satsBalance : fiatBalance
+  const mainBalance = config.currencyDisplay === CurrencyDisplay.Fiat ? fiatBalance : satsBalance
+  const otherUnit = config.currencyDisplay === CurrencyDisplay.Fiat ? 'SATS' : config.fiat
+  const mainUnit = config.currencyDisplay === CurrencyDisplay.Fiat ? config.fiat : 'SATS'
+  const showBoth = config.currencyDisplay === CurrencyDisplay.Both
+
   const toggleShow = () => updateConfig({ ...config, showBalance: !config.showBalance })
 
   return (
@@ -29,18 +35,20 @@ export default function Balance({ amount }: BalanceProps) {
         My balance
       </Text>
       <FlexRow>
-        <Text bigger>{satsBalance}</Text>
+        <Text bigger>{mainBalance}</Text>
         <div style={{ paddingTop: ' 0.75rem' }}>
-          <Text>SATS</Text>
+          <Text>{mainUnit}</Text>
         </div>
         <div onClick={toggleShow} style={{ cursor: 'pointer' }}>
           <EyeIcon />
         </div>
       </FlexRow>
-      <FlexRow>
-        <Text color='dark80'>{fiatBalance}</Text>
-        <Text small>{config.fiat}</Text>
-      </FlexRow>
+      {showBoth ? (
+        <FlexRow>
+          <Text color='dark80'>{otherBalance}</Text>
+          <Text small>{otherUnit}</Text>
+        </FlexRow>
+      ) : null}
     </FlexCol>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Balance supports multiple display modes: sats, fiat, or both.
  * Dynamic unit labels reflect the selected currency (e.g., fiat code or SATS).
  * Option to show a secondary balance line when both currencies are enabled.

* **UI**
  * Primary balance now follows the selected display preference.
  * Cleaner presentation with adaptive units and optional second row for the alternate currency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->