### PR TITLE
hide fiat values if fetching ticker fails

### DIFF
--- a/src/providers/config.tsx
+++ b/src/providers/config.tsx
@@ -20,6 +20,7 @@ interface ConfigContextProps {
   config: Config
   configLoaded: boolean
   resetConfig: () => void
+  setConfig: (c: Config) => void
   showConfig: boolean
   toggleShowConfig: () => void
   updateConfig: (c: Config) => void
@@ -30,6 +31,7 @@ export const ConfigContext = createContext<ConfigContextProps>({
   config: defaultConfig,
   configLoaded: false,
   resetConfig: () => {},
+  setConfig: () => {},
   showConfig: false,
   toggleShowConfig: () => {},
   updateConfig: () => {},
@@ -85,7 +87,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <ConfigContext.Provider
-      value={{ config, configLoaded, resetConfig, showConfig, toggleShowConfig, updateConfig, useFiat }}
+      value={{ config, configLoaded, resetConfig, setConfig, showConfig, toggleShowConfig, updateConfig, useFiat }}
     >
       {children}
     </ConfigContext.Provider>

--- a/src/providers/fiat.tsx
+++ b/src/providers/fiat.tsx
@@ -2,7 +2,7 @@ import { ReactNode, createContext, useContext, useEffect, useRef, useState } fro
 import { FiatPrices, getPriceFeed } from '../lib/fiat'
 import { fromSatoshis, toSatoshis } from '../lib/format'
 import Decimal from 'decimal.js'
-import { Fiats, Satoshis } from '../lib/types'
+import { CurrencyDisplay, Fiats, Satoshis } from '../lib/types'
 import { ConfigContext } from './config'
 
 type FiatContextProps = {
@@ -20,7 +20,7 @@ export const FiatContext = createContext<FiatContextProps>({
 })
 
 export const FiatProvider = ({ children }: { children: ReactNode }) => {
-  const { config } = useContext(ConfigContext)
+  const { config, setConfig } = useContext(ConfigContext)
 
   const [loading, setLoading] = useState(false)
 
@@ -39,6 +39,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
     setLoading(true)
     const pf = await getPriceFeed()
     if (pf) fiatPrices.current = pf
+    else setConfig({ ...config, currencyDisplay: CurrencyDisplay.Sats }) // hide fiat if fetch fails
     setLoading(false)
   }
 


### PR DESCRIPTION
@tiero please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fiat price display fallback: when price data cannot be retrieved, the display now automatically switches to sats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->