### PR TITLE
fix sending to base58 addresses

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -111,8 +111,8 @@ export default function SendForm() {
         setAmount(useFiat ? toFiat(satoshis) : satoshis ? satoshis : undefined)
         return setState({ ...sendInfo, address: '', arkAddress: '', invoice: lowerCaseData })
       }
-      if (isBTCAddress(lowerCaseData)) {
-        return setState({ ...sendInfo, address: lowerCaseData, arkAddress: '' })
+      if (isBTCAddress(recipient)) {
+        return setState({ ...sendInfo, address: recipient, arkAddress: '' })
       }
       if (isArkNote(lowerCaseData)) {
         try {


### PR DESCRIPTION
This fix sending to P2SH addresses ("3...")

@Kukks please review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BTC address detection in the wallet send form for more accurate address recognition and handling during transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->