### PR TITLE
fix max send in fiat only mode

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -167,7 +167,7 @@ export default function SendForm() {
 
   // validate recipient addresses
   useEffect(() => {
-    if (!receivingAddresses) return setError('Unable to get receiving addresses')
+    if (!receivingAddresses) return
     const { boardingAddr, offchainAddr } = receivingAddresses
     const { address, arkAddress, invoice } = sendInfo
     // check server limits for onchain transactions
@@ -197,7 +197,7 @@ export default function SendForm() {
     }
     // everything is ok, clean error
     setError('')
-  }, [sendInfo.address, sendInfo.arkAddress, sendInfo.invoice])
+  }, [receivingAddresses, sendInfo.address, sendInfo.arkAddress, sendInfo.invoice])
 
   // set satoshis from amount
   useEffect(() => {


### PR DESCRIPTION
Fixes bug when clicking MAX button in Send when in fiat only mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved amount calculations and synchronization between satoshis and fiat.
  * Enhanced validation and error feedback for limits (insufficient funds, min/max, LNURL).
  * Updated "Send" button labels and messages to reflect validation and server reachability; preserves prior errors when server becomes reachable.
  * Refined "Send All" handling with accurate fee-aware amount computation.
  * Better flow progression when recipient, pending swap, and proceed state are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->