### PR TITLE
fix Swap.tsx

### DIFF
--- a/src/screens/Apps/Boltz/Swap.tsx
+++ b/src/screens/Apps/Boltz/Swap.tsx
@@ -42,7 +42,7 @@ export default function AppBoltzSwap() {
   const amount = isReverse ? swapInfo.response.onchainAmount : decodeInvoice(swapInfo.request.invoice).amountSats
   const invoice = isReverse ? swapInfo.response.invoice : swapInfo.request.invoice
   const direction = isReverse ? 'Lightning to Arkade' : 'Arkade to Lightning'
-  const refunded = !isReverse && swapInfo.refunded
+  const refunded = !isReverse && !swapInfo.refundable
 
   const formatAmount = (amt: number) => (config.showBalance ? prettyAmount(amt) : prettyHide(amt))
 


### PR DESCRIPTION
"refunded" seems to not exist on swapInfo object.

@bordalix please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected swap refund status calculation to accurately reflect refund eligibility and display appropriate actions in the swap interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->