### PR TITLE
Improve WarningBox readability: white on red and green, dark on orange

### DIFF
--- a/src/components/Warning.tsx
+++ b/src/components/Warning.tsx
@@ -11,14 +11,13 @@ interface WarningProps {
 
 export default function WarningBox({ green, red, text }: WarningProps) {
   const backgroundColor = red ? 'var(--redbg)' : green ? 'var(--greenbg)' : 'var(--orangebg)'
-  const textColor = red ? 'white' : green ? 'white' : 'var(--dark)'
-  const borderColor = red ? 'var(--red)' : green ? 'var(--green)' : 'var(--orange)'
   const Icon = () => (red ? <ForbidIcon /> : <InfoIconDark />)
+  const color = red || green ? 'white' : 'var(--orange)'
 
   const style: React.CSSProperties = {
     backgroundColor,
     borderRadius: '0.5rem',
-    color: 'var(--orange)',
+    color,
     padding: '0.75rem 1rem',
     width: '100%',
   }
@@ -26,10 +25,10 @@ export default function WarningBox({ green, red, text }: WarningProps) {
   return (
     <div style={style}>
       <FlexRow alignItems='flex-start' gap='1rem'>
-        <div style={{ color: borderColor }}>
+        <div style={{ color }}>
           <Icon />
         </div>
-        <Text small wrap color={textColor}>
+        <Text small wrap>
           {text}
         </Text>
       </FlexRow>

--- a/src/components/Warning.tsx
+++ b/src/components/Warning.tsx
@@ -11,6 +11,7 @@ interface WarningProps {
 
 export default function WarningBox({ green, red, text }: WarningProps) {
   const backgroundColor = red ? 'var(--redbg)' : green ? 'var(--greenbg)' : 'var(--orangebg)'
+  const textColor = red ? 'white' : green ? 'white' : 'var(--dark)'
   const borderColor = red ? 'var(--red)' : green ? 'var(--green)' : 'var(--orange)'
   const Icon = () => (red ? <ForbidIcon /> : <InfoIconDark />)
 
@@ -28,7 +29,7 @@ export default function WarningBox({ green, red, text }: WarningProps) {
         <div style={{ color: borderColor }}>
           <Icon />
         </div>
-        <Text small wrap>
+        <Text small wrap color={textColor}>
           {text}
         </Text>
       </FlexRow>


### PR DESCRIPTION
It currently defaults on dark orange, which is difficult to read on red and green backgrounds:

<img width="481" height="422" alt="Screenshot from 2025-12-09 12-18-37" src="https://github.com/user-attachments/assets/93104811-fc96-476a-83a5-03dde8b9e10e" />
<img width="481" height="422" alt="Screenshot from 2025-12-09 12-26-44" src="https://github.com/user-attachments/assets/3ba70637-9bc5-4c8c-8825-bdd189b6a079" />

With white:

<img width="481" height="422" alt="image" src="https://github.com/user-attachments/assets/fabdb572-38a7-42b2-8318-a0d142f78854" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the warning component's visual presentation by refining color styling. Text and icon colors now display dynamically based on status conditions—showing white for specific alert states and orange for others. This improvement enhances visual distinction between warning types and strengthens overall interface consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->