### PR TITLE
blured modals

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,29 +1,58 @@
+import { useEffect } from 'react'
+
 export default function Modal({ children }: { children: React.ReactNode }) {
-  const outerStyle = {
+  const overlayStyle = {
     top: '0',
     left: '0',
     zIndex: 21,
-    opacity: 0.95,
+    opacity: 0.5,
+    width: '100%',
+    height: '100%',
+    position: 'absolute' as 'absolute',
+    backgroundColor: 'var(--ion-background-color)',
+  }
+
+  const containerStyle = {
+    top: '0',
+    left: '0',
+    zIndex: 22, // Higher than overlay
     width: '100%',
     height: '100%',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     position: 'absolute' as 'absolute',
-    backgroundColor: 'var(--ion-background-color)',
+    pointerEvents: 'none' as 'none', // Allow clicks to pass through to children
   }
+
   const innerStyle = {
-    zIndex: 21,
     opacity: 1,
     padding: '1rem',
     maxWidth: 'min(22rem, 90%)',
     borderRadius: '0.5rem',
     border: '1px solid rgba(251, 251, 251, 0.10)',
     backgroundColor: 'var(--ion-background-color)',
+    pointerEvents: 'auto' as 'auto', // Enable clicks on the modal content
   }
+
+  useEffect(() => {
+    const rolesToBlur = ['banner', 'main', 'tablist']
+    for (const role of rolesToBlur) {
+      const element = document.querySelector(`[role="${role}"]`) as HTMLElement
+      if (element) element.style.filter = 'blur(10px)'
+    }
+    return () => {
+      for (const role of rolesToBlur) {
+        const element = document.querySelector(`[role="${role}"]`) as HTMLElement
+        if (element) element.style.filter = 'none'
+      }
+    }
+  }, [])
+
   return (
     <>
-      <div style={outerStyle}>
+      <div style={overlayStyle} />
+      <div style={containerStyle}>
         <div style={innerStyle}>{children}</div>
       </div>
     </>


### PR DESCRIPTION
Uses filter blur to hide the background content instead of opacity.

@tiero please review

Before:

<img width="1170" height="2532" alt="localhost_3002_(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/ebc3f41f-f7bf-49a2-9874-2e737e6c521c" />

After:

<img width="1170" height="2532" alt="localhost_3002_(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/596334d0-0797-4780-89d2-1d821fade730" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced modal appearance with a semi-transparent overlay backdrop
  * Added blur effect to background page content when modal is open
  * Improved modal positioning for better visual hierarchy and user focus

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->