### PR TITLE
Consider edge cases for UTXO expiration, add tests. Closes #275

### DIFF
--- a/src/lib/utxo.ts
+++ b/src/lib/utxo.ts
@@ -1,18 +1,18 @@
-import {
-  ExtendedCoin,
-  hasBoardingTxExpired,
-  TapLeafScript,
-  IWallet,
-  CSVMultisigTapscript,
-  VtxoScript,
-} from '@arkade-os/sdk'
+import { ExtendedCoin, hasBoardingTxExpired, IWallet, VtxoScript, RelativeTimelock } from '@arkade-os/sdk'
 
 const isExpiredUtxo = (utxo: ExtendedCoin) => {
-  const leaf = VtxoScript.decode(utxo.tapTree).leaves[1] as TapLeafScript
-  const script = leaf[1].subarray(0, leaf[1].length - 1) // remove the version byte
-  const exitScript = CSVMultisigTapscript.decode(script)
-  const boardingTimelock = exitScript.params.timelock
-  return hasBoardingTxExpired(utxo, boardingTimelock)
+  const vtxoScript = VtxoScript.decode(utxo.tapTree)
+  const exitPaths = vtxoScript.exitPaths()
+  let earliestTimelock: RelativeTimelock | undefined = undefined
+  for (const path of exitPaths) {
+    earliestTimelock = earliestTimelock
+      ? path.params.timelock.value < earliestTimelock.value
+        ? path.params.timelock
+        : earliestTimelock
+      : path.params.timelock
+  }
+
+  return earliestTimelock ? hasBoardingTxExpired(utxo, earliestTimelock) : false
 }
 
 export const getConfirmedAndNotExpiredUtxos = async (wallet: IWallet) => {

--- a/src/test/lib/utxo.test.ts
+++ b/src/test/lib/utxo.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+
+let exitPaths = [{ params: { timelock: { value: 42 } } }]
+
+vi.mock('@arkade-os/sdk', () => {
+  return {
+    VtxoScript: {
+      decode: vi.fn(() => ({ exitPaths: vi.fn(() => exitPaths) })),
+    },
+    hasBoardingTxExpired: vi.fn((utxo: any) => Boolean(utxo.__expired)),
+  }
+})
+
+import { hasBoardingTxExpired, VtxoScript } from '@arkade-os/sdk'
+import { getConfirmedAndNotExpiredUtxos } from '../../lib/utxo'
+
+const mkUtxo = ({ confirmed, expired, tapTree }: { confirmed: boolean; expired: boolean; tapTree: number[] }) =>
+  ({
+    status: { confirmed },
+    __expired: expired,
+    tapTree: new Uint8Array(tapTree),
+  }) as any
+
+describe('getConfirmedAndNotExpiredUtxos', () => {
+  it('returns only utxos that are confirmed and not expired', async () => {
+    const confirmedNotExpired = mkUtxo({
+      confirmed: true,
+      expired: false,
+      tapTree: [1, 2, 3, 99],
+    })
+    const confirmedExpired = mkUtxo({
+      confirmed: true,
+      expired: true,
+      tapTree: [9, 9, 9, 100],
+    })
+    const unconfirmedNotExpired = mkUtxo({
+      confirmed: false,
+      expired: false,
+      tapTree: [7, 7, 7, 101],
+    })
+
+    const wallet = {
+      getBoardingUtxos: vi.fn().mockResolvedValue([confirmedNotExpired, confirmedExpired, unconfirmedNotExpired]),
+    } as any
+
+    const result = await getConfirmedAndNotExpiredUtxos(wallet)
+
+    expect(wallet.getBoardingUtxos).toHaveBeenCalledTimes(1)
+    expect(result).toEqual([confirmedNotExpired])
+    expect(VtxoScript.decode).toHaveBeenCalledWith(confirmedNotExpired.tapTree)
+    expect(VtxoScript.decode).toHaveBeenCalledWith(confirmedExpired.tapTree)
+    expect(hasBoardingTxExpired).toHaveBeenCalledTimes(2)
+  })
+
+  it('always uses the earliest timelock', async () => {
+    const confirmedNotExpired = mkUtxo({
+      confirmed: true,
+      expired: false,
+      tapTree: [1, 2, 3, 99],
+    })
+
+    exitPaths = [
+      { params: { timelock: { value: 5 } } },
+      { params: { timelock: { value: 3 } } },
+      { params: { timelock: { value: 9 } } },
+    ]
+
+    const wallet = {
+      getBoardingUtxos: vi.fn().mockResolvedValue([confirmedNotExpired]),
+    } as any
+
+    const result = await getConfirmedAndNotExpiredUtxos(wallet)
+
+    expect(result).toEqual([confirmedNotExpired])
+    expect(hasBoardingTxExpired).toHaveBeenCalledWith(confirmedNotExpired, { value: 3 })
+  })
+
+  it('it returns UTXO without exit paths', async () => {
+    const confirmedNotExpired = mkUtxo({
+      confirmed: true,
+      expired: false,
+      tapTree: [1, 2, 3, 99],
+    })
+
+    exitPaths = []
+    const wallet = {
+      getBoardingUtxos: vi.fn().mockResolvedValue([confirmedNotExpired]),
+    } as any
+
+    const result = await getConfirmedAndNotExpiredUtxos(wallet)
+
+    expect(result).toEqual([confirmedNotExpired])
+    expect(hasBoardingTxExpired).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/test/lib/utxo.test.ts
+++ b/src/test/lib/utxo.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 let exitPaths = [{ params: { timelock: { value: 42 } } }]
 
@@ -22,6 +22,10 @@ const mkUtxo = ({ confirmed, expired, tapTree }: { confirmed: boolean; expired: 
   }) as any
 
 describe('getConfirmedAndNotExpiredUtxos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('returns only utxos that are confirmed and not expired', async () => {
     const confirmedNotExpired = mkUtxo({
       confirmed: true,


### PR DESCRIPTION
I realized there is an edge case where `exitPaths` can be empty. It shouldn't happen but the case exists, therefore I decided for an execution path (no expiration) and blinded it with a test.

We can consider throwing an error instead if this is a _must never happen_ scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved UTXO expiration detection to determine boarding timelocks from multiple exit paths, using the earliest timelock and safely handling cases with no exit paths.

* **Tests**
  * Added unit tests covering confirmed/non-expired filtering, earliest-timelock selection, and behavior when exit paths are absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->