### PR TITLE
chore: update local dev configuration and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
 
     - name: Install pnpm
       uses: pnpm/action-setup@v2

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Arkade Wallet is the entry-point to the Arkade ecosystem—a self-custodial Bitc
 
 ### Prerequisites
 
-- Node.js >=20
+- Node.js v20.19+ or v22.12+ (Required by Vite 7)
 - PNPM >=8
 
 ### Installation
@@ -73,6 +73,15 @@ Your app is ready to be deployed!
 Starts the regtest environment and sets up the arkd instance.\
 Requires Docker to be installed and [Nigiri](https://nigiri.vulpem.com/) to be running with `--ln` flag.
 
+### Funding your local wallet
+To interact with Ark features, you need Regtest coins.
+1. Copy your address from the wallet's **Receive** screen (ensure it starts with bcrt1 for Regtest).
+2. Run the Nigiri faucet command: 
+```bash
+nigiri faucet <bcrt-address>
+```
+
+
 ### e2e tests
 
 > note: e2e tests require a regtest environment to be running.
@@ -98,3 +107,9 @@ Access the playwright code generator tool with:
 ```bash
 pnpm run test:codegen
 ```
+
+## Troubleshooting
+### `address already in use` (Port 5000) on macOS
+macOS AirPlay Receiver uses port 5000 by default, which conflicts with Nigiri.
+- **Fix:** Go to `System Settings > General > AirDrop & Handoff` and disable **AirPlay Receiver**.
+

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "packageManager": "pnpm@10.25.0",
   "engines": {
-    "node": ">=20",
+    "node": ">=20.19.0 || >=22.12.0",
     "pnpm": ">=8"
   }
 }


### PR DESCRIPTION
## Context
I audited the local development setup on a fresh macOS environment and found configuration mismatches and documentation gaps that slowed a successful "Time to First Transaction" for new contributors.

## Changes
*   **build**: Updated `engines` in `package.json` to enforce Node >=20.19.0 || >=22.12.0 (required by Vite 7) to prevent build failures.
*   **ci**: Updated GitHub Actions workflow to use Node 22 to match the new engine requirements.
*   **docs**: Added instructions for funding the wallet via the Nigiri CLI so developers can test transactions immediately.
*   **docs**: Added macOS-specific troubleshooting note regarding Port 5000 (AirPlay) conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js requirements to v20.19+ or v22.12+ for Vite 7 compatibility
  * Added a "Funding your local wallet" guide for obtaining Regtest coins
  * Added a "Troubleshooting" section for common setup issues and reorganized related README content

* **Chores**
  * CI environment updated to use Node.js v22

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->