### PR TITLE
remove useless icon from lendasat header

### DIFF
--- a/src/screens/Apps/Lendasat/Index.tsx
+++ b/src/screens/Apps/Lendasat/Index.tsx
@@ -3,7 +3,6 @@ import Padded from '../../../components/Padded'
 import Header from '../../../components/Header'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
-import { SettingsIconLight } from '../../../icons/Settings'
 import { NavigationContext, Pages } from '../../../providers/navigation'
 import { WalletContext } from '../../../providers/wallet'
 import { AddressType, type LoanAsset, WalletProvider } from '@lendasat/lendasat-wallet-bridge'
@@ -179,12 +178,7 @@ export default function AppLendasat() {
 
   return (
     <>
-      <Header
-        auxFunc={() => navigate(Pages.AppLendasat)}
-        auxIcon={<SettingsIconLight />}
-        text='Lendasat'
-        back={() => navigate(Pages.Apps)}
-      />
+      <Header text='Lendasat' back={() => navigate(Pages.Apps)} />
       <Content>
         <Padded>
           <FlexCol gap='2rem' between>


### PR DESCRIPTION
SettingsIconLight had a bug, where it was rendered in white against white background, making it invisible.

After I fixed the bug on the icon, I realise that Lendasat page had this icon on its top right, and it was not doing anything.

This PR removes the useless icon from the header.

@bonomat please review

<img width="400" height="866" alt="localhost_3002_(iPhone 12 Pro) (2)" src="https://github.com/user-attachments/assets/a1ce5e70-8c77-45d4-9247-9d6970cb84ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed settings button from the Lendasat app header.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->