### PR TITLE
Fix PWA padding issue on iOS

### DIFF
--- a/src/ionic.css
+++ b/src/ionic.css
@@ -158,6 +158,18 @@ ion-tab-bar {
     }
     & .focusable:focus {
       background-color: transparent;
+      outline: none;
+    }
+    & .focusable:focus-visible {
+      background-color: transparent;
+      outline: 2px solid var(--purple);
+      outline-offset: 2px;
+      border-radius: 4px;
+    }
+    @media (prefers-reduced-motion: no-preference) {
+      & .focusable:focus-visible {
+        transition: outline-offset 0.15s ease;
+      }
     }
   }
   & svg {


### PR DESCRIPTION
Fixes the iOS PWA bottom padding adding `env(safe-area-inset-bottom)` padding to ion-tab-bar for iOS home indicator and set background-color on tab bar to fill safe area with consistent color

The recently introduced tab bar item background highlighting was giving a bad effect, we opted to remove that.

- Remove background highlighting from tab buttons (transparent backgrounds)
- Disable .focusable background color on tab buttons to prevent visual disconnect

The bottom navigation now properly accounts for the iOS safe area while
maintaining a clean, consistent appearance across light and dark modes.
Other platforms remain unchanged as env(safe-area-inset-bottom) returns 0.

## Testing
Tested on iOS PWA installation - the bottom tab bar now sits properly above the home indicator with consistent background color and no unwanted highlighting effects.

| Before | Now |
|--------|-----|
| ![image](https://github.com/user-attachments/assets/d2df3bbe-52a4-4599-8a2f-45d2722f816e) | ![image](https://github.com/user-attachments/assets/750546c2-ebd2-460b-839d-4e250b6aee5c) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved tab bar safe-area padding for devices with notches or home indicators.
  * Switched tab buttons to transparent backgrounds for a cleaner, consistent look.
  * Refined focus states: clearer visible outline for keyboard focus, no outline on generic focus, and subtle outline-offset transitions that respect reduced-motion preferences.
  * Preserved existing hover and selected styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->