### PR TITLE
fix input password not showing in backup

### DIFF
--- a/src/components/NewPassword.tsx
+++ b/src/components/NewPassword.tsx
@@ -52,7 +52,7 @@ export default function NewPassword({ onNewPassword, setLabel }: NewPasswordProp
 
   return (
     <FlexCol gap='1.5em'>
-      <FlexCol>
+      <FlexCol testId='new-password'>
         <InputPassword
           focus={focus === 'password'}
           label='Password'
@@ -62,12 +62,14 @@ export default function NewPassword({ onNewPassword, setLabel }: NewPasswordProp
         <StrengthProgress strength={strength} />
         <CheckList data={passwordChecks} />
       </FlexCol>
-      <InputPassword
-        focus={focus === 'confirm'}
-        label='Confirm password'
-        onChange={handleChangeConfirm}
-        onEnter={handleEnter}
-      />
+      <FlexCol testId='confirm-password'>
+        <InputPassword
+          focus={focus === 'confirm'}
+          label='Confirm password'
+          onChange={handleChangeConfirm}
+          onEnter={handleEnter}
+        />
+      </FlexCol>
     </FlexCol>
   )
 }

--- a/src/screens/Settings/Backup.tsx
+++ b/src/screens/Settings/Backup.tsx
@@ -116,7 +116,7 @@ export default function Backup() {
             <Text centered>Unlock with your passkey</Text>
           </FlexCol>
         ) : (
-          <FlexCol gap='0.5rem'>
+          <FlexCol gap='0.5rem' testId='backup-password-input'>
             <TextSecondary>Enter your password</TextSecondary>
             <InputPassword onChange={onChangePassword} />
             <ErrorMessage error={Boolean(error)} text={error} />

--- a/src/test/e2e/backup.test.ts
+++ b/src/test/e2e/backup.test.ts
@@ -8,7 +8,7 @@ test('should be able to get nsec without password', async ({ page }) => {
   // Go to Settings > Backup
   await page.getByTestId('tab-settings').click()
   await page.getByText('Backup').click()
-  expect(page.getByText('This is enough to restore your wallet')).toBeVisible()
+  await expect(page.getByText('This is enough to restore your wallet')).toBeVisible()
 
   // Verify password input is not shown
   const obfuscated = await page.getByTestId('private-key').textContent()
@@ -16,7 +16,7 @@ test('should be able to get nsec without password', async ({ page }) => {
 
   // Reveal private key
   await page.getByText('View private key').click()
-  expect(page.getByText('Keep your private key safe')).toBeVisible()
+  await expect(page.getByText('Keep your private key safe')).toBeVisible()
   await page.getByText('Confirm').click()
 
   // Verify nsec is shown
@@ -31,7 +31,7 @@ test('should be able to get nsec with password', async ({ page }) => {
   // Go to Settings > Backup
   await page.getByTestId('tab-settings').click()
   await page.getByText('Backup').click()
-  expect(page.getByText('This is enough to restore your wallet')).toBeVisible()
+  await expect(page.getByText('This is enough to restore your wallet')).toBeVisible()
 
   // Verify password input is not shown
   const obfuscated = await page.getByTestId('private-key').textContent()
@@ -39,8 +39,8 @@ test('should be able to get nsec with password', async ({ page }) => {
 
   // Reveal private key
   await page.getByText('View private key').click()
-  expect(page.getByText('Keep your private key safe')).toBeVisible()
-  await page.locator('input[name="ion-input-3"]').fill('testpassword')
+  await expect(page.getByText('Keep your private key safe')).toBeVisible()
+  await page.locator('div[data-testid="backup-password-input"] input').fill('testpassword')
   await page.getByText('Confirm').click()
   await page.waitForTimeout(500) // wait for modal to close
 

--- a/src/test/e2e/utils.ts
+++ b/src/test/e2e/utils.ts
@@ -18,8 +18,8 @@ export async function createWalletWithPassword(page: Page, password: string): Pr
   await page.getByTestId('tab-settings').click()
   await page.getByText('Advanced').click()
   await page.getByText('Change password').click()
-  await page.locator('input[name="ion-input-1"]').fill(password)
-  await page.locator('input[name="ion-input-2"]').fill(password)
+  await page.locator('div[data-testid="new-password"] input').fill(password)
+  await page.locator('div[data-testid="confirm-password"] input').fill(password)
   await page.getByText('Save password').click()
   await page.getByTestId('tab-wallet').click()
 }


### PR DESCRIPTION
@tiero please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked password entry in Backup settings to use a dedicated password input, updated value handling, and added test identifiers for password fields.

* **Tests**
  * Added end-to-end tests for the backup flow both with and without a password, including reveal and secret-format assertions.

* **Chores**
  * Added an E2E helper to create a wallet pre-configured with a password.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->