### PR TITLE
Add auto theme with system preference + ripple transition

### DIFF
--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -16,8 +16,8 @@ import { NavigationContext, Pages } from '../providers/navigation'
 
 // icon with pretty gradient background
 const PrettyIcon = ({ color, icon }: { color?: string; icon: React.ReactNode }) => {
-  const { config } = useContext(ConfigContext)
-  const defaultColor = config.theme === Themes.Dark ? '#ffffff' : '#000000'
+  const { effectiveTheme } = useContext(ConfigContext)
+  const defaultColor = effectiveTheme === Themes.Dark ? '#ffffff' : '#000000'
   const _color = color?.startsWith('#') ? color : defaultColor
   const circle = 'circle at 50% -70%'
   const gradient = [_color + 'dd 0%', _color + '00 70%']

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -4,12 +4,13 @@ import FlexRow from './FlexRow'
 import Text from './Text'
 
 interface SelectProps {
+  labels?: string[]
   onChange: (value: string) => void
   options: string[]
   selected: string
 }
 
-export default function Select({ onChange, options, selected }: SelectProps) {
+export default function Select({ labels, onChange, options, selected }: SelectProps) {
   useEffect(() => {
     const handleKeyDown = (event: { key: string; keyCode: number }) => {
       const selectedIndex = options.indexOf(selected)
@@ -38,7 +39,7 @@ export default function Select({ onChange, options, selected }: SelectProps) {
             onClick={() => onChange(option)}
             padding='0.8rem 0'
           >
-            <Text thin>{option}</Text>
+            <Text thin>{labels?.[index] ?? option}</Text>
             {option === selected && <GreenStatusIcon small />}
           </FlexRow>
           {index < options.length - 1 && <hr style={{ backgroundColor: 'var(--dark20)', width: '100%' }} />}

--- a/src/index.css
+++ b/src/index.css
@@ -163,3 +163,35 @@ button.reminder-button.action-sheet-button {
     background-color: var(--ion-background-focused);
   }
 }
+
+/* Theme transition ripple */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root) {
+  z-index: 9999;
+  animation: ripple-reveal 400ms ease-out;
+}
+
+@keyframes ripple-reveal {
+  from {
+    clip-path: circle(0px at var(--ripple-x) var(--ripple-y));
+  }
+  to {
+    clip-path: circle(var(--ripple-radius) at var(--ripple-x) var(--ripple-y));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none !important;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -165,17 +165,17 @@ button.reminder-button.action-sheet-button {
 }
 
 /* Theme transition ripple */
-::view-transition-old(root),
-::view-transition-new(root) {
+::view-transition-old(theme-ripple),
+::view-transition-new(theme-ripple) {
   animation: none;
   mix-blend-mode: normal;
 }
 
-::view-transition-old(root) {
+::view-transition-old(theme-ripple) {
   z-index: 1;
 }
 
-::view-transition-new(root) {
+::view-transition-new(theme-ripple) {
   z-index: 9999;
   animation: ripple-reveal 400ms ease-out;
 }
@@ -190,8 +190,8 @@ button.reminder-button.action-sheet-button {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
+  ::view-transition-old(theme-ripple),
+  ::view-transition-new(theme-ripple) {
     animation: none !important;
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,7 @@ export enum SettingsOptions {
 }
 
 export enum Themes {
+  Auto = 'Auto',
   Dark = 'Dark',
   Light = 'Light',
 }

--- a/src/providers/config.tsx
+++ b/src/providers/config.tsx
@@ -49,7 +49,7 @@ export const ConfigContext = createContext<ConfigContextProps>({
 
 export const resolveTheme = (theme: Themes): Themes.Dark | Themes.Light => {
   if (theme === Themes.Auto) {
-    return window?.matchMedia?.('(prefers-color-scheme: dark)').matches ? Themes.Dark : Themes.Light
+    return window?.matchMedia?.('(prefers-color-scheme: dark)')?.matches ? Themes.Dark : Themes.Light
   }
   return theme as Themes.Dark | Themes.Light
 }
@@ -58,12 +58,10 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
   const [config, setConfig] = useState<Config>(defaultConfig)
   const [configLoaded, setConfigLoaded] = useState(false)
   const [showConfig, setShowConfig] = useState(false)
-  const [effectiveTheme, setEffectiveTheme] = useState<Themes.Dark | Themes.Light>(
-    () => resolveTheme(defaultConfig.theme),
+  const [effectiveTheme, setEffectiveTheme] = useState<Themes.Dark | Themes.Light>(() =>
+    resolveTheme(defaultConfig.theme),
   )
-  const [systemTheme, setSystemTheme] = useState<Themes.Dark | Themes.Light>(
-    () => resolveTheme(Themes.Auto),
-  )
+  const [systemTheme, setSystemTheme] = useState<Themes.Dark | Themes.Light>(() => resolveTheme(Themes.Auto))
 
   const backupConfig = async (config: Config) => {
     const backupProvider = new BackupProvider({ pubkey: config.pubkey })

--- a/src/providers/config.tsx
+++ b/src/providers/config.tsx
@@ -45,7 +45,7 @@ export const ConfigContext = createContext<ConfigContextProps>({
   useFiat: false,
 })
 
-const resolveTheme = (theme: Themes): Themes.Dark | Themes.Light => {
+export const resolveTheme = (theme: Themes): Themes.Dark | Themes.Light => {
   if (theme === Themes.Auto) {
     return window?.matchMedia?.('(prefers-color-scheme: dark)').matches ? Themes.Dark : Themes.Light
   }

--- a/src/providers/config.tsx
+++ b/src/providers/config.tsx
@@ -27,6 +27,7 @@ interface ConfigContextProps {
   resetConfig: () => void
   setConfig: (c: Config) => void
   showConfig: boolean
+  systemTheme: Themes.Dark | Themes.Light
   toggleShowConfig: () => void
   updateConfig: (c: Config) => void
   useFiat: boolean
@@ -40,6 +41,7 @@ export const ConfigContext = createContext<ConfigContextProps>({
   resetConfig: () => {},
   setConfig: () => {},
   showConfig: false,
+  systemTheme: Themes.Dark,
   toggleShowConfig: () => {},
   updateConfig: () => {},
   useFiat: false,
@@ -58,6 +60,9 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
   const [showConfig, setShowConfig] = useState(false)
   const [effectiveTheme, setEffectiveTheme] = useState<Themes.Dark | Themes.Light>(
     () => resolveTheme(defaultConfig.theme),
+  )
+  const [systemTheme, setSystemTheme] = useState<Themes.Dark | Themes.Light>(
+    () => resolveTheme(Themes.Auto),
   )
 
   const backupConfig = async (config: Config) => {
@@ -109,11 +114,13 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
     setConfigLoaded(true)
   }, [configLoaded])
 
-  // listen for system theme changes when Auto is selected
+  // always track system theme; apply it when Auto is selected
   useEffect(() => {
-    if (config.theme !== Themes.Auto) return
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-    const handler = () => applyTheme(Themes.Auto)
+    const handler = () => {
+      setSystemTheme(resolveTheme(Themes.Auto))
+      if (config.theme === Themes.Auto) applyTheme(Themes.Auto)
+    }
     mediaQuery.addEventListener('change', handler)
     return () => mediaQuery.removeEventListener('change', handler)
   }, [config.theme])
@@ -130,6 +137,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
         resetConfig,
         setConfig,
         showConfig,
+        systemTheme,
         toggleShowConfig,
         updateConfig,
         useFiat,

--- a/src/screens/Settings/General.tsx
+++ b/src/screens/Settings/General.tsx
@@ -7,12 +7,12 @@ import Text from '../../components/Text'
 import FlexCol from '../../components/FlexCol'
 import FlexRow from '../../components/FlexRow'
 import ArrowIcon from '../../icons/Arrow'
-import { SettingsOptions } from '../../lib/types'
+import { SettingsOptions, Themes } from '../../lib/types'
 import { OptionsContext } from '../../providers/options'
 import Focusable from '../../components/Focusable'
 
 export default function General() {
-  const { config } = useContext(ConfigContext)
+  const { config, effectiveTheme } = useContext(ConfigContext)
   const { setOption } = useContext(OptionsContext)
 
   const Row = ({ option, value }: { option: SettingsOptions; value: string }) => (
@@ -37,7 +37,7 @@ export default function General() {
       <Content>
         <Padded>
           <FlexCol gap='0'>
-            <Row option={SettingsOptions.Theme} value={config.theme} />
+            <Row option={SettingsOptions.Theme} value={config.theme === Themes.Auto ? `Auto (${effectiveTheme})` : config.theme} />
             <hr style={{ backgroundColor: 'var(--dark20)', width: '100%' }} />
             <Row option={SettingsOptions.Fiat} value={config.fiat} />
             <hr style={{ backgroundColor: 'var(--dark20)', width: '100%' }} />

--- a/src/screens/Settings/General.tsx
+++ b/src/screens/Settings/General.tsx
@@ -12,7 +12,7 @@ import { OptionsContext } from '../../providers/options'
 import Focusable from '../../components/Focusable'
 
 export default function General() {
-  const { config, effectiveTheme } = useContext(ConfigContext)
+  const { config, systemTheme } = useContext(ConfigContext)
   const { setOption } = useContext(OptionsContext)
 
   const Row = ({ option, value }: { option: SettingsOptions; value: string }) => (
@@ -37,7 +37,7 @@ export default function General() {
       <Content>
         <Padded>
           <FlexCol gap='0'>
-            <Row option={SettingsOptions.Theme} value={config.theme === Themes.Auto ? `Auto (${effectiveTheme})` : config.theme} />
+            <Row option={SettingsOptions.Theme} value={config.theme === Themes.Auto ? `Auto (${systemTheme})` : config.theme} />
             <hr style={{ backgroundColor: 'var(--dark20)', width: '100%' }} />
             <Row option={SettingsOptions.Fiat} value={config.fiat} />
             <hr style={{ backgroundColor: 'var(--dark20)', width: '100%' }} />

--- a/src/screens/Settings/Theme.tsx
+++ b/src/screens/Settings/Theme.tsx
@@ -7,7 +7,7 @@ import { ConfigContext, resolveTheme } from '../../providers/config'
 import Header from './Header'
 
 export default function Theme() {
-  const { backupConfig, config, effectiveTheme, updateConfig } = useContext(ConfigContext)
+  const { backupConfig, config, effectiveTheme, systemTheme, updateConfig } = useContext(ConfigContext)
   const clickCoords = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
 
   const handleChange = async (theme: string) => {
@@ -35,7 +35,7 @@ export default function Theme() {
 
   const options = [Themes.Auto, Themes.Dark, Themes.Light]
   const labels = options.map((option) =>
-    option === Themes.Auto ? `Auto (${effectiveTheme})` : option,
+    option === Themes.Auto ? `Auto (${systemTheme})` : option,
   )
 
   return (

--- a/src/screens/Settings/Theme.tsx
+++ b/src/screens/Settings/Theme.tsx
@@ -8,42 +8,50 @@ import Header from './Header'
 
 export default function Theme() {
   const { backupConfig, config, effectiveTheme, systemTheme, updateConfig } = useContext(ConfigContext)
-  const clickCoords = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const clickCoords = useRef<{ x: number; y: number } | null>(null)
 
   const handleChange = async (theme: string) => {
     const newConfig = { ...config, theme: theme as Themes }
     if (config.nostrBackup) await backupConfig(newConfig)
 
+    const coords = clickCoords.current
     const newEffective = resolveTheme(newConfig.theme)
     const shouldAnimate =
+      coords &&
       newEffective !== effectiveTheme &&
       typeof document.startViewTransition === 'function' &&
       !window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
     if (shouldAnimate) {
-      const { x, y } = clickCoords.current
+      const { x, y } = coords
       const radius = Math.hypot(Math.max(x, innerWidth - x), Math.max(y, innerHeight - y))
       const root = document.documentElement
       root.style.setProperty('--ripple-x', `${x}px`)
       root.style.setProperty('--ripple-y', `${y}px`)
       root.style.setProperty('--ripple-radius', `${radius}px`)
-      document.startViewTransition(() => updateConfig(newConfig))
+      root.style.viewTransitionName = 'theme-ripple'
+      const transition = document.startViewTransition(() => updateConfig(newConfig))
+      transition.finished.then(() => {
+        root.style.viewTransitionName = ''
+      })
     } else {
       updateConfig(newConfig)
     }
   }
 
   const options = [Themes.Auto, Themes.Dark, Themes.Light]
-  const labels = options.map((option) =>
-    option === Themes.Auto ? `Auto (${systemTheme})` : option,
-  )
+  const labels = options.map((option) => (option === Themes.Auto ? `Auto (${systemTheme})` : option))
 
   return (
     <>
       <Header text='Theme' back />
       <Content>
         <Padded>
-          <div onClickCapture={(e) => { clickCoords.current = { x: e.clientX, y: e.clientY } }}>
+          <div
+            onClickCapture={(e) => {
+              clickCoords.current = { x: e.clientX, y: e.clientY }
+            }}
+          >
             <Select labels={labels} onChange={handleChange} options={options} selected={config.theme} />
           </div>
         </Padded>

--- a/src/screens/Settings/Theme.tsx
+++ b/src/screens/Settings/Theme.tsx
@@ -7,7 +7,7 @@ import { ConfigContext } from '../../providers/config'
 import Header from './Header'
 
 export default function Theme() {
-  const { backupConfig, config, updateConfig } = useContext(ConfigContext)
+  const { backupConfig, config, effectiveTheme, updateConfig } = useContext(ConfigContext)
 
   const handleChange = async (theme: string) => {
     const newConfig = { ...config, theme: theme as Themes }
@@ -15,12 +15,17 @@ export default function Theme() {
     updateConfig(newConfig)
   }
 
+  const options = [Themes.Auto, Themes.Dark, Themes.Light]
+  const labels = options.map((option) =>
+    option === Themes.Auto ? `Auto (${effectiveTheme})` : option,
+  )
+
   return (
     <>
       <Header text='Theme' back />
       <Content>
         <Padded>
-          <Select onChange={handleChange} options={[Themes.Dark, Themes.Light]} selected={config.theme} />
+          <Select labels={labels} onChange={handleChange} options={options} selected={config.theme} />
         </Padded>
       </Content>
     </>

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -48,6 +48,7 @@ export const mockConfigContextValue = {
     theme: Themes.Dark,
   },
   effectiveTheme: Themes.Dark,
+  systemTheme: Themes.Dark,
   useFiat: false,
 }
 

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -47,6 +47,7 @@ export const mockConfigContextValue = {
     notifications: true,
     theme: Themes.Dark,
   },
+  effectiveTheme: Themes.Dark,
   useFiat: false,
 }
 

--- a/src/test/screens/settings/theme.test.tsx
+++ b/src/test/screens/settings/theme.test.tsx
@@ -13,9 +13,11 @@ describe('Theme screen', () => {
     )
     expect(screen.getByText('Theme')).toBeInTheDocument()
     expect(screen.getByTestId('select-option-0')).toBeInTheDocument()
-    expect(screen.getByTestId('select-option-0').querySelector('p')?.textContent).toBe('Dark')
+    expect(screen.getByTestId('select-option-0').querySelector('p')?.textContent).toBe('Auto (Dark)')
     expect(screen.getByTestId('select-option-1')).toBeInTheDocument()
-    expect(screen.getByTestId('select-option-1').querySelector('p')?.textContent).toBe('Light')
+    expect(screen.getByTestId('select-option-1').querySelector('p')?.textContent).toBe('Dark')
+    expect(screen.getByTestId('select-option-2')).toBeInTheDocument()
+    expect(screen.getByTestId('select-option-2').querySelector('p')?.textContent).toBe('Light')
   })
 
   it('renders the theme screen with the correct default selection', () => {
@@ -24,7 +26,9 @@ describe('Theme screen', () => {
         <Theme />
       </ConfigContext.Provider>,
     )
-    expect(screen.getByTestId('select-option-0').querySelector('svg')).toBeInTheDocument()
-    expect(screen.getByTestId('select-option-1').querySelector('svg')).not.toBeInTheDocument()
+    // mock config has theme: Dark, so option-1 (Dark) should have the checkmark
+    expect(screen.getByTestId('select-option-0').querySelector('svg')).not.toBeInTheDocument()
+    expect(screen.getByTestId('select-option-1').querySelector('svg')).toBeInTheDocument()
+    expect(screen.getByTestId('select-option-2').querySelector('svg')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- Adds `Themes.Auto` option that follows the OS `prefers-color-scheme` setting, with a live media query listener that updates the app when the system theme changes
- Theme switches animate with a circular ripple (View Transition API) expanding from the tap point — no animation on reduced motion, unsupported browsers, or when the effective theme doesn't change
- Auto label always shows the system preference ("Auto (Light)" or "Auto (Dark)") regardless of which theme is manually selected

## Changes

**Core (`src/providers/config.tsx`)**
- Add `Themes.Auto` enum value, `resolveTheme()` helper, `effectiveTheme` and `systemTheme` state
- `applyTheme()` resolves Auto → Dark/Light via media query
- Media query listener always tracks system theme; applies it when Auto is selected

**Settings UI**
- `src/screens/Settings/Theme.tsx` — Auto/Dark/Light selector with ripple transition orchestration, uses `systemTheme` for Auto label
- `src/screens/Settings/General.tsx` — theme row shows `systemTheme` in Auto label
- `src/components/Select.tsx` — `labels` prop for display text that differs from option values

**Supporting**
- `src/lib/types.ts` — `Themes.Auto` enum
- `src/components/Announcement.tsx` — uses `effectiveTheme` instead of `config.theme`
- `src/index.css` — `::view-transition` ripple keyframe + `prefers-reduced-motion` guard

## Test plan

- [ ] App loads with Auto selected by default, resolves to system theme
- [ ] Settings > Theme shows Auto (system), Dark, Light with correct checkmark
- [ ] Tapping Dark/Light triggers ripple animation from tap point
- [ ] Auto label stays "Auto (Light)" even when Dark is selected (reflects OS, not selection)
- [ ] Tapping already-selected theme does nothing (no animation)
- [ ] Tapping Auto when it resolves to current theme — no animation
- [ ] Rapid switching between themes — transitions skip cleanly
- [ ] Reduced motion enabled — no animation, instant switch
- [ ] System theme change while Auto is selected — theme updates live
- [ ] `pnpm test` — existing theme tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an Auto theme that follows your system light/dark preference.
  * Added a ripple transition when changing themes (respects reduced-motion settings).
  * Theme settings now show the active system theme when Auto is selected.
  * Select controls can display optional custom labels for options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->