### PR TITLE
Expand logo tap target for easier touch interaction

### DIFF
--- a/src/icons/Logo.tsx
+++ b/src/icons/Logo.tsx
@@ -148,7 +148,7 @@ export default function LogoIcon({ small }: { small?: boolean }) {
       role='button'
       tabIndex={0}
       onKeyDown={() => {}}
-      style={{ cursor: 'pointer', width: size, height: size }}
+      style={{ cursor: 'pointer', width: size, height: size, padding: 8, margin: -8 }}
     >
       <svg width={size} height={size} viewBox='0 0 35 35' fill='none' xmlns='http://www.w3.org/2000/svg'>
         {/* Original SVG paths — visible when settled, fading in during revert */}


### PR DESCRIPTION
Add padding around the logo's clickable area to increase the hit zone
without changing its visual size or layout position.

https://claude.ai/code/session_01HxhDhScVQ1bD9DxNjVfu6k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Logo component's interactive hit area and layout positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->