### PR TITLE
feat(button): add 3D press effect with per-variant shadow colors

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,7 +1,8 @@
 import { IonButton } from '@ionic/react'
-import { ReactElement } from 'react'
+import { ReactElement, useCallback, useState } from 'react'
 import FlexRow from './FlexRow'
 import ArrowIcon from '../icons/Arrow'
+import { hapticTap } from '../lib/haptics'
 
 interface ButtonProps {
   clear?: boolean
@@ -32,12 +33,40 @@ export default function Button({
   secondary,
   small,
 }: ButtonProps) {
+  const [pressed, setPressed] = useState(false)
+
+  const variant = red ? 'red' : secondary ? 'secondary' : clear ? 'clear' : outline ? 'outline' : 'dark'
+  const className = `${variant}${pressed ? ' pressed' : ''}`
+
+  const handlePressStart = useCallback(() => {
+    if (disabled || loading) return
+    setPressed(true)
+  }, [disabled, loading])
+
+  const handlePressEnd = useCallback(() => {
+    setPressed(false)
+  }, [])
+
+  const handleClick = useCallback(
+    (event: any) => {
+      hapticTap()
+      onClick(event)
+    },
+    [onClick],
+  )
+
   return (
     <IonButton
-      className={red ? 'red' : secondary ? 'secondary' : clear ? 'clear' : outline ? 'outline' : 'dark'}
+      className={className}
       disabled={disabled}
       fill={clear ? 'clear' : outline ? 'outline' : 'solid'}
-      onClick={onClick}
+      onClick={handleClick}
+      onMouseDown={handlePressStart}
+      onMouseUp={handlePressEnd}
+      onMouseLeave={handlePressEnd}
+      onTouchStart={handlePressStart}
+      onTouchEnd={handlePressEnd}
+      onTouchCancel={handlePressEnd}
       size={small ? 'small' : 'default'}
       style={{ margin: '4px 0' }}
     >

--- a/src/ionic.css
+++ b/src/ionic.css
@@ -83,6 +83,12 @@
 
 ion-button {
   --border-radius: 0.5rem;
+  --ripple-color: transparent;
+  --ion-color-activated: transparent;
+  --ion-color-focused: transparent;
+  --box-shadow: none;
+  --btn-shadow-color: rgba(0, 0, 0, 0.25);
+  border-radius: 0.5rem;
   font-family: 'Geist Mono';
   font-size: 0.875rem;
   font-weight: 400;
@@ -90,35 +96,71 @@ ion-button {
   min-height: 40px;
   text-transform: uppercase;
   width: 100%;
+  transform: translateY(0);
+  box-shadow: 0 4px 0 0 var(--btn-shadow-color);
+  transition:
+    transform 100ms cubic-bezier(0.165, 0.84, 0.44, 1),
+    box-shadow 100ms cubic-bezier(0.165, 0.84, 0.44, 1);
+  &::part(native) {
+    box-shadow: none !important;
+  }
+  &::part(native):focus {
+    outline: none;
+  }
+  &::part(native)::after {
+    display: none !important;
+  }
+  &.pressed {
+    transform: translateY(4px);
+    box-shadow: 0 0 0 0 var(--btn-shadow-color);
+  }
   &.clear {
     --background: none;
     --border-color: none;
     --color: var(--black);
+    box-shadow: none;
+    &.pressed {
+      transform: scale(0.97);
+      box-shadow: none;
+    }
   }
   &.dark {
     --background: var(--purple);
     --border-color: var(--purple);
+    --btn-shadow-color: #1a0b4a;
     --color: white;
   }
   &.outline {
     --background: none;
     --border-color: var(--dark50);
+    --btn-shadow-color: rgba(0, 0, 0, 0.10);
     --color: var(--dark50);
   }
   &.red {
     --background: var(--red);
     --border-color: var(--red);
+    --btn-shadow-color: #6b0e0e;
     --color: white;
   }
   &.secondary {
     --background: var(--dark20);
     --border-color: var(--black);
+    --btn-shadow-color: rgba(0, 0, 0, 0.10);
     --color: var(--black);
   }
   &[size='small'] {
     min-height: 16px;
     --padding-top: 0.5rem;
     --padding-bottom: 0.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ion-button {
+    transition: none;
+    &.pressed {
+      transform: none;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Add 3D press-down effect to all buttons: `translateY(4px)` with shadow collapse on press, `scale(0.97)` for clear buttons
- Fix gray line under buttons by using per-variant shadow colors instead of generic `rgba(0,0,0,0.25)`: dark purple `#1a0b4a` under purple, dark red `#6b0e0e` under red, subtle `rgba(0,0,0,0.10)` under secondary/outline
- Add `border-radius: 0.5rem` to outer `ion-button` so shadow follows rounded corners (previously shadow was rectangular under rounded button)
- Suppress Ionic's internal ripple, activated state, focus ring, and `::after` overlay
- Pressed state uses `onTouchStart/End` + `onMouseDown/Up` (not `:active` — unreliable on mobile)
- Includes `prefers-reduced-motion` media query to disable transitions

## Files changed

- `src/ionic.css` — button shadow, transition, pressed state, per-variant colors, reduced motion
- `src/components/Button.tsx` — pressed state logic via touch/mouse events, `hapticTap()` on click

## Base branch

Based on `feat/haptics-system` (#325) since `Button.tsx` imports `hapticTap` from the haptics utility.

## Test plan

- [ ] `pnpm test` passes (127/127 unit tests)
- [ ] SEND/RECEIVE buttons: shadow is dark purple, reads as 3D depth, no gray line
- [ ] Press down: shadow collapses, button moves down 4px smoothly
- [ ] Release: button springs back
- [ ] Clear buttons (e.g. back): subtle scale(0.97) on press
- [ ] Check in dark mode: shadow still visible and correct
- [ ] Check secondary/outline buttons if visible
- [ ] Verify no blue flash or focus ring on tap (mobile)
- [ ] Verify reduced motion: no animation when prefers-reduced-motion is set