### PR TITLE
feat(logo): add bitcoin icon to Easter egg, make morph system reusable

### DIFF
--- a/src/icons/Logo.tsx
+++ b/src/icons/Logo.tsx
@@ -23,7 +23,12 @@ export default function LogoIcon({ small }: { small?: boolean }) {
       onClick={advance}
       role='button'
       tabIndex={0}
-      onKeyDown={() => {}}
+      onKeyDown={(e) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault()
+          advance()
+        }
+      }}
       style={{ cursor: 'pointer', width: size, height: size }}
     >
       <svg width={size} height={size} viewBox='0 0 35 35' fill='none' xmlns='http://www.w3.org/2000/svg'>

--- a/src/icons/Logo.tsx
+++ b/src/icons/Logo.tsx
@@ -1,133 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-
-// 8x8 grid on 35x35 viewBox — each cell is 4.375px
-const GRID = 8
-const CELL = 35 / GRID
-const GAP = 0.3
-const REVERT_DELAY = 3000
-const MORPH_MS = 350
-const SCALE_CLOSED = CELL / (CELL - GAP) // ≈1.074 — closes the gap exactly
-
-type Pixel = { x: number; y: number }
-
-function parseShape(str: string): Pixel[] {
-  const pixels: Pixel[] = []
-  str
-    .trim()
-    .split('\n')
-    .forEach((line, row) => {
-      line
-        .trim()
-        .split('')
-        .forEach((ch, col) => {
-          if (ch === 'X') pixels.push({ x: col, y: row })
-        })
-    })
-  return pixels.sort((a, b) => a.y - b.y || a.x - b.x)
-}
-
-// Pixel positions approximating the Arkade logo shape.
-// These are only used as morph anchor points — the actual logo
-// is always rendered with its original SVG paths.
-const SHAPES = [
-  parseShape(`
-    ..XXXX..
-    .XXXXXX.
-    XX....XX
-    XX....XX
-    ..XXXX..
-    ..XXXX..
-    XX....XX
-    XX....XX
-  `),
-  // Space invader
-  parseShape(`
-    ..X..X..
-    ...XX...
-    ..XXXX..
-    .XX..XX.
-    XXXXXXXX
-    X.XXXX.X
-    X.X..X.X
-    .X.XX.X.
-  `),
-  // Heart
-  parseShape(`
-    .XX..XX.
-    XXXXXXXX
-    XXXXXXXX
-    .XXXXXX.
-    ..XXXX..
-    ...XX...
-    ...XX...
-    ........
-  `),
-]
-
-type Slot = { x: number; y: number; id: string }
-const SLOT_SHAPES: Slot[][] = SHAPES.map((shape) => shape.map((p, i) => ({ x: p.x, y: p.y, id: `s${i}` })))
+import { usePixelMorph } from './usePixelMorph'
+import { CELL, GAP, MORPH_MS, SCALE_CLOSED } from './pixel-shapes'
 
 export default function LogoIcon({ small }: { small?: boolean }) {
-  const [shapeIdx, setShapeIdx] = useState(0)
-  const [settled, setSettled] = useState(true)
-  const [reverting, setReverting] = useState(false)
-  const revertRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const settleRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { settled, reverting, advance, slots } = usePixelMorph()
   const size = small ? 35 : 50
-  const slots = SLOT_SHAPES[shapeIdx]
-
-  useEffect(() => {
-    return () => {
-      if (revertRef.current) clearTimeout(revertRef.current)
-      if (settleRef.current) clearTimeout(settleRef.current)
-    }
-  }, [])
-
-  const startRevert = useCallback(() => {
-    if (settleRef.current) clearTimeout(settleRef.current)
-    setReverting(true)
-    setShapeIdx(0)
-    settleRef.current = setTimeout(() => {
-      setSettled(true)
-      setReverting(false)
-    }, MORPH_MS + 50)
-  }, [])
-
-  const handleClick = useCallback(() => {
-    if (revertRef.current) clearTimeout(revertRef.current)
-    if (settleRef.current) clearTimeout(settleRef.current)
-
-    if (reverting) {
-      // Tapped during revert — cancel and go to invader
-      setReverting(false)
-      setSettled(false)
-      requestAnimationFrame(() => {
-        setShapeIdx(1)
-        revertRef.current = setTimeout(startRevert, REVERT_DELAY)
-      })
-      return
-    }
-
-    if (settled) {
-      // Leaving the original logo: show pixels at logo positions,
-      // then on the next frame morph to the target shape
-      setSettled(false)
-      requestAnimationFrame(() => {
-        setShapeIdx(1)
-        revertRef.current = setTimeout(startRevert, REVERT_DELAY)
-      })
-      return
-    }
-
-    // Currently showing pixel shapes — advance
-    const next = (shapeIdx + 1) % SHAPES.length
-    if (next === 0) {
-      startRevert()
-    } else {
-      setShapeIdx(next)
-      revertRef.current = setTimeout(startRevert, REVERT_DELAY)
-    }
-  }, [settled, reverting, shapeIdx, startRevert])
 
   // Paths: visible when settled or reverting (fading in during revert)
   const pathsOpacity = settled || reverting ? 1 : 0
@@ -144,7 +20,7 @@ export default function LogoIcon({ small }: { small?: boolean }) {
 
   return (
     <div
-      onClick={handleClick}
+      onClick={advance}
       role='button'
       tabIndex={0}
       onKeyDown={() => {}}

--- a/src/icons/pixel-shapes.ts
+++ b/src/icons/pixel-shapes.ts
@@ -1,0 +1,89 @@
+// 8x8 grid on 35x35 viewBox — each cell is 4.375px
+export const GRID = 8
+export const CELL = 35 / GRID
+export const GAP = 0.3
+export const REVERT_DELAY = 3000
+export const MORPH_MS = 350
+export const SCALE_CLOSED = CELL / (CELL - GAP) // ≈1.074 — closes the gap exactly
+
+export type Pixel = { x: number; y: number }
+export type Slot = { x: number; y: number; id: string }
+
+export function parseShape(str: string): Pixel[] {
+  const pixels: Pixel[] = []
+  str
+    .trim()
+    .split('\n')
+    .forEach((line, row) => {
+      line
+        .trim()
+        .split('')
+        .forEach((ch, col) => {
+          if (ch === 'X') pixels.push({ x: col, y: row })
+        })
+    })
+  return pixels.sort((a, b) => a.y - b.y || a.x - b.x)
+}
+
+// Shape 0 is the "home" state (Arkade logo pixel approximation).
+// Shapes can have different pixel counts — they get padded to the max below.
+const SHAPES_RAW: Pixel[][] = [
+  // 0: Arkade logo (home — only used as morph anchor; real logo uses SVG paths)
+  parseShape(`
+    ..XXXX..
+    .XXXXXX.
+    XX....XX
+    XX....XX
+    ..XXXX..
+    ..XXXX..
+    XX....XX
+    XX....XX
+  `),
+  // 1: Space invader
+  parseShape(`
+    ..X..X..
+    ...XX...
+    ..XXXX..
+    .XX..XX.
+    XXXXXXXX
+    X.XXXX.X
+    X.X..X.X
+    .X.XX.X.
+  `),
+  // 2: Bitcoin
+  parseShape(`
+    ...XX...
+    .XXXXXX.
+    .XX..XXX
+    .XXXXXX.
+    .XX..XXX
+    .XXXXXX.
+    ...XX...
+    ........
+  `),
+  // 3: Heart
+  parseShape(`
+    .XX..XX.
+    XXXXXXXX
+    XXXXXXXX
+    .XXXXXX.
+    ..XXXX..
+    ...XX...
+    ...XX...
+    ........
+  `),
+]
+
+// Pad all shapes to the same pixel count so CSS transitions work smoothly.
+// Shorter shapes get phantom pixels stacked on existing pixels so they're invisible.
+const MAX_PIXELS = Math.max(...SHAPES_RAW.map((s) => s.length))
+export const SHAPES: Pixel[][] = SHAPES_RAW.map((shape) => {
+  if (shape.length >= MAX_PIXELS) return shape
+  const padding: Pixel[] = Array.from({ length: MAX_PIXELS - shape.length }, (_, i) => {
+    const donor = shape[i % shape.length]
+    return { x: donor.x, y: donor.y }
+  })
+  return [...shape, ...padding]
+})
+
+export const SLOT_SHAPES: Slot[][] = SHAPES.map((shape) => shape.map((p, i) => ({ x: p.x, y: p.y, id: `s${i}` })))

--- a/src/icons/usePixelMorph.ts
+++ b/src/icons/usePixelMorph.ts
@@ -15,9 +15,11 @@ export function usePixelMorph(): UsePixelMorphResult {
   const [reverting, setReverting] = useState(false)
   const revertRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const settleRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const mountedRef = useRef(true)
 
   useEffect(() => {
     return () => {
+      mountedRef.current = false
       if (revertRef.current) clearTimeout(revertRef.current)
       if (settleRef.current) clearTimeout(settleRef.current)
     }
@@ -37,19 +39,11 @@ export function usePixelMorph(): UsePixelMorphResult {
     if (revertRef.current) clearTimeout(revertRef.current)
     if (settleRef.current) clearTimeout(settleRef.current)
 
-    if (reverting) {
-      setReverting(false)
+    if (reverting || settled) {
+      if (reverting) setReverting(false)
       setSettled(false)
       requestAnimationFrame(() => {
-        setShapeIdx(1)
-        revertRef.current = setTimeout(startRevert, REVERT_DELAY)
-      })
-      return
-    }
-
-    if (settled) {
-      setSettled(false)
-      requestAnimationFrame(() => {
+        if (!mountedRef.current) return
         setShapeIdx(1)
         revertRef.current = setTimeout(startRevert, REVERT_DELAY)
       })

--- a/src/icons/usePixelMorph.ts
+++ b/src/icons/usePixelMorph.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { SHAPES, SLOT_SHAPES, MORPH_MS, REVERT_DELAY, type Slot } from './pixel-shapes'
+
+export interface UsePixelMorphResult {
+  shapeIdx: number
+  settled: boolean
+  reverting: boolean
+  advance: () => void
+  slots: Slot[]
+}
+
+export function usePixelMorph(): UsePixelMorphResult {
+  const [shapeIdx, setShapeIdx] = useState(0)
+  const [settled, setSettled] = useState(true)
+  const [reverting, setReverting] = useState(false)
+  const revertRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const settleRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (revertRef.current) clearTimeout(revertRef.current)
+      if (settleRef.current) clearTimeout(settleRef.current)
+    }
+  }, [])
+
+  const startRevert = useCallback(() => {
+    if (settleRef.current) clearTimeout(settleRef.current)
+    setReverting(true)
+    setShapeIdx(0)
+    settleRef.current = setTimeout(() => {
+      setSettled(true)
+      setReverting(false)
+    }, MORPH_MS + 50)
+  }, [])
+
+  const advance = useCallback(() => {
+    if (revertRef.current) clearTimeout(revertRef.current)
+    if (settleRef.current) clearTimeout(settleRef.current)
+
+    if (reverting) {
+      setReverting(false)
+      setSettled(false)
+      requestAnimationFrame(() => {
+        setShapeIdx(1)
+        revertRef.current = setTimeout(startRevert, REVERT_DELAY)
+      })
+      return
+    }
+
+    if (settled) {
+      setSettled(false)
+      requestAnimationFrame(() => {
+        setShapeIdx(1)
+        revertRef.current = setTimeout(startRevert, REVERT_DELAY)
+      })
+      return
+    }
+
+    const next = (shapeIdx + 1) % SHAPES.length
+    if (next === 0) {
+      startRevert()
+    } else {
+      setShapeIdx(next)
+      revertRef.current = setTimeout(startRevert, REVERT_DELAY)
+    }
+  }, [settled, reverting, shapeIdx, startRevert])
+
+  return {
+    shapeIdx,
+    settled,
+    reverting,
+    advance,
+    slots: SLOT_SHAPES[shapeIdx],
+  }
+}

--- a/src/screens/Settings/General.tsx
+++ b/src/screens/Settings/General.tsx
@@ -37,7 +37,10 @@ export default function General() {
       <Content>
         <Padded>
           <FlexCol gap='0'>
-            <Row option={SettingsOptions.Theme} value={config.theme === Themes.Auto ? `Auto (${systemTheme})` : config.theme} />
+            <Row
+              option={SettingsOptions.Theme}
+              value={config.theme === Themes.Auto ? `Auto (${systemTheme})` : config.theme}
+            />
             <hr style={{ backgroundColor: 'var(--dark20)', width: '100%' }} />
             <Row option={SettingsOptions.Fiat} value={config.fiat} />
             <hr style={{ backgroundColor: 'var(--dark20)', width: '100%' }} />


### PR DESCRIPTION
## Summary
- Adds bitcoin (₿) pixel art to the logo tap Easter egg
- Extracts shape definitions and morph logic into reusable modules (`pixel-shapes.ts`, `usePixelMorph.ts`) so the animation can be used elsewhere (loading screens, etc.)
- Supports variable pixel counts across shapes — no more fixed 34-pixel restriction
- Cycle order: logo → space invader → bitcoin → heart → logo

## Changes
- `src/icons/pixel-shapes.ts` — shared shape definitions, `parseShape()`, grid constants, auto-padding for variable pixel counts
- `src/icons/usePixelMorph.ts` — `usePixelMorph()` hook encapsulating the morph state machine
- `src/icons/Logo.tsx` — simplified to consume the hook and shared constants

## Test plan
- [ ] Tap logo on wallet screen, verify cycle: logo → space invader → bitcoin → heart → logo
- [ ] Verify 3-second auto-revert timer works
- [ ] Verify morph animations are smooth between all transitions
- [ ] Verify `LogoIconAnimated` in AlertBox still pulses correctly
- [ ] Build passes with no type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the logo pixel-morph implementation for smoother, more consistent animations and fewer glitches during rapid interactions; visual behavior and accessibility (click, Space/Enter) remain unchanged.
  * Expanded and normalized pixel shapes to enable fluid transitions between icon states.

* **Style**
  * Minor formatting tweak in Settings display with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->