### PR TITLE
perf(animations): compositor-friendly animation pipeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,10 +35,9 @@ import WalletIcon from './icons/Wallet'
 import AppsIcon from './icons/Apps'
 import Focusable from './components/Focusable'
 import { useReducedMotion } from './hooks/useReducedMotion'
+import { EASE_SPRING, DUR_STANDARD } from './lib/animations'
 
 setupIonicReact()
-
-import { EASE_SPRING, DUR_STANDARD } from './lib/animations'
 
 function AnimatedTabIcon({
   children,
@@ -54,10 +53,11 @@ function AnimatedTabIcon({
 
   useEffect(() => {
     if (!animating || !ref.current || reduced) return
-    ref.current.animate(
+    const anim = ref.current.animate(
       [{ transform: 'scale(1)' }, { transform: 'scale(1.18)', offset: 0.4 }, { transform: 'scale(1)' }],
-      { duration: DUR_STANDARD, easing: EASE_SPRING, fill: 'forwards' },
+      { duration: DUR_STANDARD, easing: EASE_SPRING },
     )
+    return () => anim.cancel()
   }, [animating, animKey, reduced])
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,21 +38,27 @@ import { useReducedMotion } from './hooks/useReducedMotion'
 
 setupIonicReact()
 
-const animClass = 'tab-anim-pop'
+import { EASE_SPRING, DUR_STANDARD } from './lib/animations'
 
-function AnimatedTabIcon({ children, animating }: { children: React.ReactNode; animating: boolean }) {
+function AnimatedTabIcon({
+  children,
+  animating,
+  animKey,
+}: {
+  children: React.ReactNode
+  animating: boolean
+  animKey: number
+}) {
   const ref = useRef<HTMLDivElement>(null)
+  const reduced = useReducedMotion()
 
   useEffect(() => {
-    if (!animating || !ref.current) return
-    const el = ref.current
-    el.classList.remove(animClass)
-    void el.offsetWidth // Force reflow so removing + re-adding the class triggers the animation
-    el.classList.add(animClass)
-    const handleEnd = () => el.classList.remove(animClass)
-    el.addEventListener('animationend', handleEnd)
-    return () => el.removeEventListener('animationend', handleEnd)
-  }, [animating])
+    if (!animating || !ref.current || reduced) return
+    ref.current.animate(
+      [{ transform: 'scale(1)' }, { transform: 'scale(1.18)', offset: 0.4 }, { transform: 'scale(1)' }],
+      { duration: DUR_STANDARD, easing: EASE_SPRING, fill: 'forwards' },
+    )
+  }, [animating, animKey, reduced])
 
   return (
     <div ref={ref} className='tab-icon-animated'>
@@ -72,6 +78,7 @@ export default function App() {
   const [isCapable, setIsCapable] = useState(false)
   const [jsCapabilitiesChecked, setJsCapabilitiesChecked] = useState(false)
   const [animatingTab, setAnimatingTab] = useState<string | null>(null)
+  const animKeyRef = useRef(0)
 
   // refs for the tabs to be able to programmatically activate them
   const appsRef = useRef<HTMLIonTabElement>(null)
@@ -142,8 +149,8 @@ export default function App() {
   }, [tab])
 
   const triggerTabAnim = useCallback((tabName: string) => {
-    setAnimatingTab(null)
-    requestAnimationFrame(() => setAnimatingTab(tabName))
+    animKeyRef.current++
+    setAnimatingTab(tabName)
   }, [])
 
   const handleWallet = () => {
@@ -223,7 +230,7 @@ export default function App() {
               <IonTabButton tab={Tabs.Wallet} onClick={handleWallet} selected={tab === Tabs.Wallet}>
                 <Focusable>
                   <FlexCol centered gap='6px' padding='5px' testId='tab-wallet'>
-                    <AnimatedTabIcon animating={animatingTab === 'wallet'}>
+                    <AnimatedTabIcon animating={animatingTab === 'wallet'} animKey={animKeyRef.current}>
                       <WalletIcon />
                     </AnimatedTabIcon>
                     Wallet
@@ -233,7 +240,7 @@ export default function App() {
               <IonTabButton tab={Tabs.Apps} onClick={handleApps} selected={tab === Tabs.Apps}>
                 <Focusable>
                   <FlexCol centered gap='6px' padding='5px' testId='tab-apps'>
-                    <AnimatedTabIcon animating={animatingTab === 'apps'}>
+                    <AnimatedTabIcon animating={animatingTab === 'apps'} animKey={animKeyRef.current}>
                       <AppsIcon />
                     </AnimatedTabIcon>
                     Apps
@@ -243,7 +250,7 @@ export default function App() {
               <IonTabButton tab={Tabs.Settings} onClick={handleSettings} selected={tab === Tabs.Settings}>
                 <Focusable>
                   <FlexCol centered gap='6px' padding='5px' testId='tab-settings'>
-                    <AnimatedTabIcon animating={animatingTab === 'settings'}>
+                    <AnimatedTabIcon animating={animatingTab === 'settings'} animKey={animKeyRef.current}>
                       <SettingsIcon />
                     </AnimatedTabIcon>
                     Settings

--- a/src/components/OnboardLoadIn.tsx
+++ b/src/components/OnboardLoadIn.tsx
@@ -35,7 +35,7 @@ export function OnboardStaggerChild({ children }: { children: ReactNode }) {
   if (prefersReduced) return <>{children}</>
 
   return (
-    <motion.div variants={onboardStaggerChild} style={{ willChange: 'transform, opacity' }}>
+    <motion.div variants={onboardStaggerChild}>
       {children}
     </motion.div>
   )

--- a/src/components/OnboardLoadIn.tsx
+++ b/src/components/OnboardLoadIn.tsx
@@ -34,9 +34,5 @@ export function OnboardStaggerChild({ children }: { children: ReactNode }) {
 
   if (prefersReduced) return <>{children}</>
 
-  return (
-    <motion.div variants={onboardStaggerChild}>
-      {children}
-    </motion.div>
-  )
+  return <motion.div variants={onboardStaggerChild}>{children}</motion.div>
 }

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion'
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { NavigationDirection } from '../providers/navigation'
 import { pageTransitionVariants } from '../lib/animations'
 import { useReducedMotion } from '../hooks/useReducedMotion'
@@ -13,6 +13,7 @@ interface PageTransitionProps {
 export default function PageTransition({ children, direction, pageKey }: PageTransitionProps) {
   const prefersReduced = useReducedMotion()
   const effectiveDirection = prefersReduced ? 'none' : direction
+  const [animating, setAnimating] = useState(true)
 
   return (
     <motion.div
@@ -22,12 +23,14 @@ export default function PageTransition({ children, direction, pageKey }: PageTra
       initial='initial'
       animate='animate'
       exit='exit'
+      onAnimationComplete={() => setAnimating(false)}
       style={{
         position: 'absolute',
         inset: 0,
         display: 'flex',
         flexDirection: 'column',
-        willChange: 'transform, opacity',
+        willChange: animating ? 'transform, opacity' : 'auto',
+        contain: 'content',
       }}
     >
       {children}

--- a/src/components/SettingsPageTransition.tsx
+++ b/src/components/SettingsPageTransition.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'framer-motion'
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { SettingsDirection } from '../providers/options'
 import { pageTransitionVariants } from '../lib/animations'
 import { useReducedMotion } from '../hooks/useReducedMotion'
@@ -13,6 +13,7 @@ interface SettingsPageTransitionProps {
 export default function SettingsPageTransition({ children, direction, optionKey }: SettingsPageTransitionProps) {
   const prefersReduced = useReducedMotion()
   const effectiveDirection = prefersReduced ? 'none' : direction
+  const [animating, setAnimating] = useState(true)
 
   return (
     <AnimatePresence mode='sync' initial={false} custom={effectiveDirection}>
@@ -23,12 +24,14 @@ export default function SettingsPageTransition({ children, direction, optionKey 
         initial='initial'
         animate='animate'
         exit='exit'
+        onAnimationComplete={() => setAnimating(false)}
         style={{
           position: 'absolute',
           inset: 0,
           display: 'flex',
           flexDirection: 'column',
-          willChange: 'transform, opacity',
+          willChange: animating ? 'transform, opacity' : 'auto',
+          contain: 'content',
         }}
       >
         {children}

--- a/src/components/WalletLoadIn.tsx
+++ b/src/components/WalletLoadIn.tsx
@@ -28,7 +28,7 @@ export function WalletStaggerChild({ children, animate = true }: { children: Rea
   if (skip) return <div style={{ width: '100%' }}>{children}</div>
 
   return (
-    <motion.div variants={walletLoadInChild} style={{ width: '100%', willChange: 'transform, opacity' }}>
+    <motion.div variants={walletLoadInChild} style={{ width: '100%' }}>
       {children}
     </motion.div>
   )

--- a/src/icons/LoadingBar.tsx
+++ b/src/icons/LoadingBar.tsx
@@ -1,17 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
-
-function useReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(
-    () => typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
-  )
-  useEffect(() => {
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const handler = (e: MediaQueryListEvent) => setReduced(e.matches)
-    mql.addEventListener('change', handler)
-    return () => mql.removeEventListener('change', handler)
-  }, [])
-  return reduced
-}
+import { useEffect, useRef } from 'react'
+import { useReducedMotion } from '../hooks/useReducedMotion'
 
 const FILLED_BODY = '#7652E1'
 const FILLED_SHADOW = '#391998'

--- a/src/icons/Logo.tsx
+++ b/src/icons/Logo.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { usePixelMorph } from './usePixelMorph'
 import { CELL, GAP, MORPH_MS, SCALE_CLOSED } from './pixel-shapes'
 import { hapticLight } from '../lib/haptics'
@@ -23,7 +23,7 @@ export default function LogoIcon({ small }: { small?: boolean }) {
     ? `transform ${MORPH_MS}ms ${EASE_SPRING}, opacity ${DUR_STANDARD}ms ${EASE_REVEAL}`
     : `transform ${MORPH_MS}ms ${EASE_SPRING}`
 
-  const pixelOrigin = useMemo(() => `${(CELL - GAP) / 2}px ${(CELL - GAP) / 2}px`, [])
+  const pixelOrigin = `${(CELL - GAP) / 2}px ${(CELL - GAP) / 2}px`
 
   return (
     <div

--- a/src/icons/Logo.tsx
+++ b/src/icons/Logo.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { usePixelMorph } from './usePixelMorph'
 import { CELL, GAP, MORPH_MS, SCALE_CLOSED } from './pixel-shapes'
 import { hapticLight } from '../lib/haptics'
+import { EASE_SPRING, EASE_REVEAL, DUR_STANDARD } from '../lib/animations'
 
 export default function LogoIcon({ small }: { small?: boolean }) {
   const { settled, reverting, advance, slots } = usePixelMorph()
@@ -13,16 +14,16 @@ export default function LogoIcon({ small }: { small?: boolean }) {
 
   // Paths: visible when settled or reverting (fading in during revert)
   const pathsOpacity = settled || reverting ? 1 : 0
-  const pathsTransition = reverting ? 'opacity 250ms ease-out' : 'none'
+  const pathsTransition = reverting ? `opacity ${DUR_STANDARD}ms ${EASE_REVEAL}` : 'none'
 
   // Pixels: visible when active, fading out + scaling up during revert
   const pixelScale = reverting ? SCALE_CLOSED : 1
   const pixelOpacity = settled ? 0 : reverting ? 0 : 1
   const pixelTransition = reverting
-    ? `transform ${MORPH_MS}ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 250ms ease-out`
-    : `transform ${MORPH_MS}ms cubic-bezier(0.34, 1.56, 0.64, 1)`
+    ? `transform ${MORPH_MS}ms ${EASE_SPRING}, opacity ${DUR_STANDARD}ms ${EASE_REVEAL}`
+    : `transform ${MORPH_MS}ms ${EASE_SPRING}`
 
-  const pixelOrigin = `${(CELL - GAP) / 2}px ${(CELL - GAP) / 2}px`
+  const pixelOrigin = useMemo(() => `${(CELL - GAP) / 2}px ${(CELL - GAP) / 2}px`, [])
 
   return (
     <div

--- a/src/index.css
+++ b/src/index.css
@@ -207,7 +207,6 @@ button.reminder-button.action-sheet-button {
 /* Tab icon animation wrapper — WAAPI handles the actual animation in App.tsx */
 .tab-icon-animated {
   display: inline-flex;
-  will-change: transform;
 }
 
 /* Page transition container for animated sub-page navigation */

--- a/src/index.css
+++ b/src/index.css
@@ -185,7 +185,7 @@ button.reminder-button.action-sheet-button {
 
 ::view-transition-new(theme-ripple) {
   z-index: 9999;
-  animation: ripple-reveal 400ms ease-out;
+  animation: ripple-reveal var(--dur-reveal) var(--ease-reveal);
 }
 
 @keyframes ripple-reveal {
@@ -204,35 +204,10 @@ button.reminder-button.action-sheet-button {
   }
 }
 
-/* Tab icon animation wrapper */
+/* Tab icon animation wrapper — WAAPI handles the actual animation in App.tsx */
 .tab-icon-animated {
   display: inline-flex;
-}
-
-/* Tab icon pop animation */
-@keyframes tab-pop {
-  0% {
-    transform: scale(1);
-  }
-  40% {
-    transform: scale(1.18);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-.tab-anim-pop {
-  animation: tab-pop 250ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-}
-
-/* Respect reduced motion */
-@media (prefers-reduced-motion: reduce) {
-  .tab-icon-animated {
-    animation: none !important;
-  }
-  [class*='tab-anim-'] {
-    animation: none !important;
-  }
+  will-change: transform;
 }
 
 /* Page transition container for animated sub-page navigation */

--- a/src/ionic.css
+++ b/src/ionic.css
@@ -38,7 +38,16 @@
     'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
   --heading-font: 'TT Firs Neue', 'Geist', sans-serif;
-  --animation-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  /* Animation tokens */
+  --ease-interactive: cubic-bezier(0.165, 0.84, 0.44, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-loop: cubic-bezier(0.4, 0, 0.6, 1);
+  --ease-reveal: ease-out;
+  --dur-micro: 100ms;
+  --dur-standard: 250ms;
+  --dur-morph: 350ms;
+  --dur-reveal: 400ms;
+  --animation-pulse: pulse 2s var(--ease-loop) infinite;
 }
 
 .ion-palette-dark {
@@ -99,9 +108,8 @@ ion-button {
   width: 100%;
   transform: translateY(0);
   box-shadow: 0 4px 0 0 var(--btn-shadow-color);
-  transition:
-    transform 100ms cubic-bezier(0.165, 0.84, 0.44, 1),
-    box-shadow 100ms cubic-bezier(0.165, 0.84, 0.44, 1);
+  transition: transform var(--dur-micro) var(--ease-interactive);
+  will-change: transform;
   &::part(native) {
     box-shadow: none !important;
   }
@@ -122,7 +130,6 @@ ion-button {
     --color: var(--black);
 
     box-shadow: none;
-
     &.pressed {
       transform: scale(0.97);
       box-shadow: none;
@@ -164,6 +171,7 @@ ion-button {
     transition: none;
     &.pressed {
       transform: none;
+      box-shadow: 0 0 0 0 var(--btn-shadow-color);
     }
   }
 }

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -1,18 +1,30 @@
 import { Variants } from 'framer-motion'
 
-// Easing: Emil Kowalski's ease-out quint
-export const EASE_OUT_QUINT = [0.23, 1, 0.32, 1]
+// Easing: Emil Kowalski's ease-out quint (Framer Motion tuple format)
+export const EASE_OUT_QUINT: [number, number, number, number] = [0.23, 1, 0.32, 1]
 
-// Page transition timing
-export const PAGE_TRANSITION_DURATION = 0.3
-export const PAGE_TRANSITION_EXIT_DURATION = 0.24 // 20% faster exit
+// CSS-side easing curves (string format for WAAPI / inline styles)
+export const EASE_INTERACTIVE = 'cubic-bezier(0.165, 0.84, 0.44, 1)'
+export const EASE_SPRING = 'cubic-bezier(0.34, 1.56, 0.64, 1)'
+export const EASE_LOOP = 'cubic-bezier(0.4, 0, 0.6, 1)'
+export const EASE_REVEAL = 'ease-out'
+
+// Duration tokens (ms — for WAAPI / inline styles)
+export const DUR_MICRO = 100
+export const DUR_STANDARD = 250
+export const DUR_MORPH = 350
+export const DUR_REVEAL = 400
+
+// Page transition timing — tuned for WebView performance (shorter = less time for jank)
+export const PAGE_TRANSITION_DURATION = 0.2
+export const PAGE_TRANSITION_EXIT_DURATION = 0.15
 
 // Stagger timing for wallet load-in
 export const STAGGER_DELAY = 0.06
-export const STAGGER_DURATION = 0.4
+export const STAGGER_DURATION = 0.35
 
-// Slide distance (% of container)
-const SLIDE_OFFSET = '20%'
+// Slide distance (% of container) — smaller = less compositing area per frame
+const SLIDE_OFFSET = '12%'
 
 // Dynamic page transition variants — direction is passed via Framer Motion's `custom` prop.
 // AnimatePresence's `custom` overrides the child's `custom` for exiting elements,


### PR DESCRIPTION
## Summary

- **Page transitions**: Add CSS `contain: content` isolation, dynamic `willChange` cleanup after animation settles, tighter durations (0.3→0.2s enter, 0.24→0.15s exit), and smaller slide offset (20%→12%) for snappier feel with less compositing work
- **Tab icon animation**: Replace CSS class toggle + reflow hack with Web Animations API (`el.animate()`), fully compositor-driven, fixes repeated same-tab taps not re-animating
- **Button press**: Transition only `transform` (not `box-shadow`) to avoid paint, add `will-change: transform` for compositor promotion
- **Stagger load-in**: Remove persistent `willChange` from stagger children that leaked GPU layers after animation settled
- **Token centralization**: CSS custom properties (`--ease-*`, `--dur-*`) in `:root`, JS-side string tokens in `animations.ts` for WAAPI/inline styles, migrate Logo, LoadingBar, index.css, ionic.css to shared tokens, delete duplicate `useReducedMotion` from LoadingBar

## What changed

| File | Change |
|------|--------|
| `src/lib/animations.ts` | Add CSS-side easing/duration tokens, tune page transition timing, fix tuple type |
| `src/components/PageTransition.tsx` | `contain: content`, willChange cleanup via `onAnimationComplete` |
| `src/components/SettingsPageTransition.tsx` | Same containment + willChange pattern |
| `src/components/WalletLoadIn.tsx` | Remove persistent `willChange` from stagger children |
| `src/components/OnboardLoadIn.tsx` | Remove persistent `willChange` from stagger children |
| `src/App.tsx` | WAAPI tab icon animation, animKey for re-triggers, remove reflow hack |
| `src/ionic.css` | CSS animation tokens in `:root`, button transitions only `transform` |
| `src/index.css` | Remove `@keyframes tab-pop` + CSS overrides, migrate to CSS tokens |
| `src/icons/Logo.tsx` | Use shared tokens, `useMemo` for static values |
| `src/icons/LoadingBar.tsx` | Import shared `useReducedMotion` hook, delete local duplicate |

## Test plan

- [ ] Page transitions: wallet → receive, wallet → send, settings drill-in/back — should feel snappy, no visible jank
- [ ] Button press: shadow visible at rest, press animation shows translateY with shadow disappearing, clear/outline/dark variants all work
- [ ] Tab icon pop: tap wallet/apps/settings icons — scale bounce animation fires, repeated taps re-trigger
- [ ] Wallet stagger load-in: balance + rows animate in with stagger, no stuck GPU layers after settling
- [ ] Onboard stagger: onboarding screens animate children in sequence
- [ ] Logo morph: tap logo — pixel morph plays with spring easing, paths fade back with ease-out
- [ ] Loading bar: traveling wave animation plays, respects reduced motion
- [ ] Theme toggle ripple: uses CSS token durations
- [ ] `prefers-reduced-motion`: all animations skip when system reduced motion is enabled
- [ ] Mobile (cloudflared tunnel): test all above on real device over HTTPS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab icons now use JS-driven animations that reliably re-trigger on tab switches.

* **Performance**
  * Animation timing and easing tokens standardized for snappier, smoother transitions.
  * Reduced rendering work during page animations for improved responsiveness.

* **Improvements**
  * Better respect for reduced-motion preferences across UI animations.
  * Refined page, loading, logo, ripple, and button animation behavior for visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->