### PR TITLE
[Exploration] BIP-177: replace SATS with ₿ prefix format

### DIFF
--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -169,7 +169,7 @@ export function LendaSatAnnouncement({ close }: { close: () => void }) {
       title='LendaSat'
       page={Pages.AppLendasat}
       icon={<LendasatIcon big />}
-      message='Borrow against your sats.'
+      message='Borrow against your bitcoin.'
       bulletPoints={[
         [
           'Choose a loan',

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -18,14 +18,15 @@ export default function Balance({ amount }: BalanceProps) {
 
   const fiatAmount = toFiat(amount)
 
-  const satsBalance = config.showBalance ? prettyNumber(amount) : prettyHide(amount, '')
-  const fiatBalance = config.showBalance ? prettyNumber(fiatAmount, 2) : prettyHide(fiatAmount, '')
-
-  const otherBalance = config.currencyDisplay === CurrencyDisplay.Fiat ? satsBalance : fiatBalance
-  const mainBalance = config.currencyDisplay === CurrencyDisplay.Fiat ? fiatBalance : satsBalance
-  const otherUnit = config.currencyDisplay === CurrencyDisplay.Fiat ? 'SATS' : config.fiat
-  const mainUnit = config.currencyDisplay === CurrencyDisplay.Fiat ? config.fiat : 'SATS'
+  const isBitcoinMain = config.currencyDisplay !== CurrencyDisplay.Fiat
+  const isFiatMain = config.currencyDisplay === CurrencyDisplay.Fiat
   const showBoth = config.currencyDisplay === CurrencyDisplay.Both
+
+  const satsDisplay = config.showBalance ? `₿${prettyNumber(amount)}` : `₿${prettyHide(amount)}`
+  const fiatDisplay = config.showBalance ? prettyNumber(fiatAmount, 2) : prettyHide(fiatAmount)
+
+  const mainBalance = isFiatMain ? fiatDisplay : satsDisplay
+  const otherBalance = isFiatMain ? satsDisplay : fiatDisplay
 
   const toggleShow = () => updateConfig({ ...config, showBalance: !config.showBalance })
 
@@ -35,20 +36,36 @@ export default function Balance({ amount }: BalanceProps) {
         My balance
       </Text>
       <FlexRow>
-        <Text bigger heading medium>
-          {mainBalance}
-        </Text>
-        <div style={{ paddingTop: ' 0.75rem' }}>
-          <Text heading>{mainUnit}</Text>
-        </div>
+        {isBitcoinMain ? (
+          <Text bigger heading medium className='bitcoin-symbol'>
+            {mainBalance}
+          </Text>
+        ) : (
+          <>
+            <Text bigger heading medium>
+              {mainBalance}
+            </Text>
+            <div style={{ paddingTop: ' 0.75rem' }}>
+              <Text heading>{config.fiat}</Text>
+            </div>
+          </>
+        )}
         <div onClick={toggleShow} style={{ cursor: 'pointer' }}>
           <EyeIcon />
         </div>
       </FlexRow>
       {showBoth ? (
         <FlexRow>
-          <Text color='dark80'>{otherBalance}</Text>
-          <Text small>{otherUnit}</Text>
+          {isBitcoinMain ? (
+            <>
+              <Text color='dark80'>{otherBalance}</Text>
+              <Text small>{config.fiat}</Text>
+            </>
+          ) : (
+            <Text color='dark80' className='bitcoin-symbol'>
+              {otherBalance}
+            </Text>
+          )}
         </FlexRow>
       ) : null}
     </FlexCol>

--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -68,11 +68,11 @@ export default function InputAmount({
   const minimumSats = min ? Math.max(min, minSwapAllowed()) : 0
   const maximumSats = max ? Math.min(max, maxSwapAllowed()) : 0
 
-  const leftLabel = useFiat ? config.fiat : 'SATS'
-  const rightLabel = `${otherValue} ${useFiat ? 'SATS' : config.fiat}`
+  const leftLabel = useFiat ? config.fiat : '₿'
+  const rightLabel = useFiat ? `₿${otherValue}` : `${otherValue} ${config.fiat}`
   const fontStyle = { color: 'var(--dark50)', fontSize: '13px' }
-  const bottomLeft = minimumSats ? `Min: ${prettyNumber(minimumSats)} ${minimumSats === 1 ? 'SAT' : 'SATS'}` : ''
-  const bottomRight = maximumSats ? `Max: ${prettyNumber(maximumSats)} ${maximumSats === 1 ? 'SAT' : 'SATS'}` : ''
+  const bottomLeft = minimumSats ? `Min: ₿${prettyNumber(minimumSats)}` : ''
+  const bottomRight = maximumSats ? `Max: ₿${prettyNumber(maximumSats)}` : ''
 
   return (
     <>
@@ -88,10 +88,10 @@ export default function InputAmount({
           type='number'
           value={value}
         >
-          <IonText slot='start' style={{ ...fontStyle, marginRight: '0.5rem' }}>
+          <IonText slot='start' style={{ ...fontStyle, marginRight: '0.5rem' }} className={!useFiat ? 'bitcoin-symbol' : ''}>
             {leftLabel}
           </IonText>
-          <IonText slot='end' style={{ ...fontStyle, marginLeft: '0.5rem' }}>
+          <IonText slot='end' style={{ ...fontStyle, marginLeft: '0.5rem' }} className={useFiat ? 'bitcoin-symbol' : ''}>
             {rightLabel}
           </IonText>
         </IonInput>

--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -88,10 +88,18 @@ export default function InputAmount({
           type='number'
           value={value}
         >
-          <IonText slot='start' style={{ ...fontStyle, marginRight: '0.5rem' }} className={!useFiat ? 'bitcoin-symbol' : ''}>
+          <IonText
+            slot='start'
+            style={{ ...fontStyle, marginRight: '0.5rem' }}
+            className={!useFiat ? 'bitcoin-symbol' : ''}
+          >
             {leftLabel}
           </IonText>
-          <IonText slot='end' style={{ ...fontStyle, marginLeft: '0.5rem' }} className={useFiat ? 'bitcoin-symbol' : ''}>
+          <IonText
+            slot='end'
+            style={{ ...fontStyle, marginLeft: '0.5rem' }}
+            className={useFiat ? 'bitcoin-symbol' : ''}
+          >
             {rightLabel}
           </IonText>
         </IonInput>

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -105,7 +105,7 @@ export default function Keyboard({ back, hideBalance, onSats, value }: KeyboardP
 
   // Display amounts based on input mode
   const amount = {
-    primary: `${textValue || '0'} ${inputMode === 'fiat' ? config.fiat : 'SATS'}`,
+    primary: inputMode === 'fiat' ? `${textValue || '0'} ${config.fiat}` : `₿${textValue || '0'}`,
     secondary: inputMode === 'fiat' ? prettyAmount(amountInSats) : prettyAmount(toFiat(amountInSats), config.fiat),
     balance: inputMode === 'fiat' ? prettyAmount(toFiat(available), config.fiat) : prettyAmount(available),
   }
@@ -143,7 +143,7 @@ export default function Keyboard({ back, hideBalance, onSats, value }: KeyboardP
       <Content>
         <FlexCol centered gap='0.5rem'>
           <ErrorMessage error={Boolean(error)} text={error} />
-          <Text big centered heading>
+          <Text big centered heading className={inputMode !== 'fiat' ? 'bitcoin-symbol' : ''}>
             {amount.primary}
           </Text>
           <TextSecondary centered>{amount.secondary}</TextSecondary>

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -11,6 +11,7 @@ interface TextProps {
   capitalize?: boolean
   centered?: boolean
   children: ReactNode
+  className?: string
   color?: string
   copy?: string
   fullWidth?: boolean
@@ -32,6 +33,7 @@ export default function Text({
   capitalize,
   centered,
   children,
+  className: extraClassName,
   color,
   copy,
   fullWidth,
@@ -47,7 +49,7 @@ export default function Text({
 }: TextProps) {
   const fontSize = tiny ? 12 : smaller ? 13 : small ? 14 : big ? 24 : bigger ? 32 : large ? 18 : 16
 
-  const className = capitalize ? 'first-letter' : ''
+  const className = [capitalize ? 'first-letter' : '', extraClassName].filter(Boolean).join(' ')
 
   const pStyle: any = {
     color: color ? `var(--${color})` : undefined,

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -83,7 +83,7 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
     <div style={{ textAlign: 'right' }}>
       {config.currencyDisplay === CurrencyDisplay.Fiat ? (
         <Fiat />
-      ) : config.currencyDisplay === CurrencyDisplay.Sats ? (
+      ) : config.currencyDisplay === CurrencyDisplay.Bitcoin ? (
         <Sats />
       ) : (
         <>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
+/* BIP-177: System sans-serif for ₿ symbol rendering.
+   Geist's unicode-range ends at U+20AC (€); ₿ is U+20BF. */
+.bitcoin-symbol {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
 /* from tailwindcss/base */
 blockquote,
 dl,

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -27,10 +27,7 @@ export const prettyAgo = (timestamp: number | string, long = false): string => {
 export const prettyAmount = (amount: string | number, suffix?: string): string => {
   const sats = typeof amount === 'string' ? Number(amount) : amount
   if (suffix) return `${prettyNumber(sats, 2)} ${suffix}`
-  if (sats >= 100_000_000_000) return `${prettyNumber(fromSatoshis(sats), 0)} BTC`
-  if (sats >= 100_000_000) return `${prettyNumber(fromSatoshis(sats), 3)} BTC`
-  if (sats >= 1_000_000) return `${prettyNumber(sats / 1_000_000, 3)}M SATS`
-  return `${prettyNumber(sats)} ${sats === 1 ? 'SAT' : 'SATS'}`
+  return `₿${prettyNumber(sats, 0)}`
 }
 
 export const prettyDelta = (seconds: number, long = true): string => {
@@ -66,11 +63,12 @@ export const prettyDate = (num: number): string => {
   }).format(date)
 }
 
-export const prettyHide = (value: string | number, suffix = 'SATS'): string => {
+export const prettyHide = (value: string | number, suffix = ''): string => {
   if (!value) return ''
   const str = typeof value === 'string' ? value : value.toString()
   const length = str.length * 2 > 6 ? str.length * 2 : 6
-  return Array(length).fill('·').join('') + ' ' + suffix
+  const dots = Array(length).fill('·').join('')
+  return suffix ? `${dots} ${suffix}` : dots
 }
 
 export const prettyLongText = (str?: string, showChars = 11): string => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,7 +28,7 @@ export type Config = {
 export enum CurrencyDisplay {
   Both = 'Show both',
   Fiat = 'Fiat only',
-  Sats = 'Sats only',
+  Bitcoin = 'Bitcoin only',
 }
 
 export enum Fiats {

--- a/src/providers/fiat.tsx
+++ b/src/providers/fiat.tsx
@@ -49,7 +49,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
     setLoading(true)
     const pf = await getPriceFeed()
     if (pf) fiatPrices.current = pf
-    else setConfig({ ...config, currencyDisplay: CurrencyDisplay.Sats }) // hide fiat if fetch fails
+    else setConfig({ ...config, currencyDisplay: CurrencyDisplay.Bitcoin }) // hide fiat if fetch fails
     setLoading(false)
   }
 

--- a/src/providers/notifications.tsx
+++ b/src/providers/notifications.tsx
@@ -32,13 +32,13 @@ export const NotificationsProvider = ({ children }: { children: ReactNode }) => 
   }
 
   const notifyPaymentReceived = (sats: number) => {
-    const body = `You received ${prettyNumber(sats)} sats`
+    const body = `You received ₿${prettyNumber(sats)}`
     const title = 'Payment received'
     sendSystemNotification(title, body)
   }
 
   const notifyPaymentSent = (sats: number) => {
-    const body = `You sent ${prettyNumber(sats)} sats`
+    const body = `You sent ₿${prettyNumber(sats)}`
     const title = 'Payment sent'
     sendSystemNotification(title, body)
   }

--- a/src/screens/Settings/About.tsx
+++ b/src/screens/Settings/About.tsx
@@ -23,7 +23,7 @@ export default function About() {
     ['Server pubkey', aspInfo.signerPubkey],
     ['Forfeit address', aspInfo.forfeitAddress],
     ['Network', aspInfo.network],
-    ['Dust', `${aspInfo.dust} SATS`],
+    ['Dust', `₿${aspInfo.dust}`],
     ['Session duration', prettyDelta(Number(aspInfo.sessionDuration), true)],
     ['Boarding exit delay', prettyDelta(Number(aspInfo.boardingExitDelay), true)],
     ['Unilateral exit delay', prettyDelta(Number(aspInfo.unilateralExitDelay), true)],

--- a/src/screens/Settings/Display.tsx
+++ b/src/screens/Settings/Display.tsx
@@ -22,7 +22,7 @@ export default function Display() {
         <Padded>
           <Select
             onChange={handleChange}
-            options={[CurrencyDisplay.Both, CurrencyDisplay.Sats, CurrencyDisplay.Fiat]}
+            options={[CurrencyDisplay.Both, CurrencyDisplay.Bitcoin, CurrencyDisplay.Fiat]}
             selected={config.currencyDisplay}
           />
         </Padded>

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -219,7 +219,7 @@ export default function Vtxos() {
                 : null}
       </FlexRow>
     )
-    return <CoinLine amount={`${amount} SATS`} tags={tags} expiry={expiry} />
+    return <CoinLine amount={`₿${amount}`} tags={tags} expiry={expiry} />
   }
 
   const UtxoLine = ({ utxo }: { utxo: ExtendedCoin }) => {
@@ -231,7 +231,7 @@ export default function Vtxos() {
         {!utxo.status.block_time ? Tags.unconfirmed : utxo.value < aspInfo.dust ? Tags.subdust : null}
       </FlexRow>
     )
-    return <CoinLine amount={`${amount} SATS`} tags={tags} expiry={expiry} />
+    return <CoinLine amount={`₿${amount}`} tags={tags} expiry={expiry} />
   }
 
   return (

--- a/src/screens/Wallet/Receive/Amount.tsx
+++ b/src/screens/Wallet/Receive/Amount.tsx
@@ -81,7 +81,7 @@ export default function ReceiveAmount() {
       !satoshis
         ? defaultButtonLabel
         : satoshis < 1
-          ? 'Amount below 1 satoshi'
+          ? 'Amount below ₿1'
           : amountIsAboveMaxLimit(satoshis)
             ? 'Amount above max limit'
             : amountIsBelowMinLimit(satoshis)

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -73,7 +73,7 @@ export default function SendDetails() {
     })
     if (balance < total) {
       setButtonLabel('Insufficient funds')
-      setError(`Insufficient funds, you just have ${prettyNumber(balance)} sats`)
+      setError(`Insufficient funds, you only have ₿${prettyNumber(balance)}`)
     } else {
       setButtonLabel('Tap to Sign')
     }

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -256,7 +256,7 @@ export default function SendForm() {
           : lnUrlLimits.max && satoshis > lnUrlLimits.max
             ? 'Amount above LNURL max limit'
             : satoshis && satoshis < 1
-              ? 'Amount below 1 satoshi'
+              ? 'Amount below ₿1'
               : amountIsAboveMaxLimit(satoshis)
                 ? 'Amount above max limit'
                 : satoshis && amountIsBelowMinLimit(satoshis)

--- a/src/test/e2e/init.test.ts
+++ b/src/test/e2e/init.test.ts
@@ -7,7 +7,7 @@ test('should create a new wallet', async ({ page }) => {
 
   // Verify wallet main page
   await page.waitForSelector('text=My balance')
-  await expect(page.getByText('0SATS')).toBeVisible()
+  await expect(page.getByText('₿0')).toBeVisible()
   await expect(page.getByText('0USD')).toBeVisible()
   await expect(page.getByRole('button', { name: 'Send' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Receive' })).toBeVisible()

--- a/src/test/e2e/keyboard.test.ts
+++ b/src/test/e2e/keyboard.test.ts
@@ -18,7 +18,7 @@ async function clearAmount(page: Page, maxClicks = 10) {
   }
 }
 
-test('should toggle between SATS and FIAT on mobile keyboard', async ({ page, isMobile }) => {
+test('should toggle between bitcoin and fiat on mobile keyboard', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'This test is only for mobile')
 
   // setup wallet and open keyboard
@@ -28,14 +28,14 @@ test('should toggle between SATS and FIAT on mobile keyboard', async ({ page, is
   await expect(page.getByText('Amount')).toBeVisible()
   await expect(page.getByTestId('keyboard-1')).toBeVisible()
 
-  // initially should be in SATS mode - enter 100 sats
+  // initially should be in bitcoin mode - enter 100
   await page.getByTestId('keyboard-1').click()
   const btn0 = page.getByTestId('keyboard-0')
   await btn0.click()
   await btn0.click()
 
-  // verify SATS amount is displayed
-  await expect(page.getByText('100 SATS')).toBeVisible()
+  // verify bitcoin amount is displayed
+  await expect(page.getByText('₿100')).toBeVisible()
 
   // find and click the swap icon to toggle to FIAT
   // the swap icon is in the header area
@@ -47,11 +47,11 @@ test('should toggle between SATS and FIAT on mobile keyboard', async ({ page, is
   // the exact USD amount will depend on the exchange rate, but we can verify the format
   await expect(page.locator('text=/[0-9.]+\\s+(USD|EUR)/')).toBeVisible()
 
-  // click swap again to go back to SATS
+  // click swap again to go back to bitcoin
   await swapButton.click()
 
-  // should show SATS again
-  await expect(page.getByText(/SATS/)).toBeVisible()
+  // should show ₿ again
+  await expect(page.getByText(/₿/)).toBeVisible()
 
   // test decimal input in FIAT mode
   await swapButton.click() // Switch to FIAT
@@ -68,11 +68,11 @@ test('should toggle between SATS and FIAT on mobile keyboard', async ({ page, is
   // verify decimal amount is displayed in FIAT
   await expect(page.locator('text=/1\\.50\\s+(USD|EUR)/')).toBeVisible()
 
-  // switch back to SATS to verify conversion
+  // switch back to bitcoin to verify conversion
   await swapButton.click()
 
-  // should show the converted SATS value
-  await expect(page.getByText(/SATS/)).toBeVisible()
+  // should show the converted bitcoin value
+  await expect(page.getByText(/₿/)).toBeVisible()
 
   // save the amount
   await page.getByText('Save').click()
@@ -81,23 +81,23 @@ test('should toggle between SATS and FIAT on mobile keyboard', async ({ page, is
   await expect(page.getByText('Continue')).toBeVisible()
 })
 
-test('should prevent decimal input in SATS mode', async ({ page, isMobile }) => {
+test('should prevent decimal input in bitcoin mode', async ({ page, isMobile }) => {
   test.skip(!isMobile, 'This test is only for mobile')
 
   // setup wallet and open keyboard
   await setupWalletAndOpenKeyboard(page)
 
-  // enter a number in SATS mode
+  // enter a number in bitcoin mode
   await page.getByTestId('keyboard-5').click()
 
-  // try to enter a decimal point - should be ignored in SATS mode
+  // try to enter a decimal point - should be ignored in bitcoin mode
   await page.getByTestId('keyboard-.').click()
 
   // try to enter another number
   await page.getByTestId('keyboard-0').click()
 
-  // should show 50 SATS (decimal point ignored)
-  await expect(page.getByText('50 SATS')).toBeVisible()
+  // should show ₿50 (decimal point ignored)
+  await expect(page.getByText('₿50')).toBeVisible()
 })
 
 test('should limit FIAT decimals to 2 places', async ({ page, isMobile }) => {

--- a/src/test/e2e/nostr.test.ts
+++ b/src/test/e2e/nostr.test.ts
@@ -84,11 +84,11 @@ test('should save swaps to nostr', async ({ page, isMobile }) => {
   await page.getByTestId('tab-apps').click()
   await expect(page.getByText('Boltz', { exact: true })).toBeVisible()
   await page.getByTestId('app-boltz').click()
-  await expect(page.getByText('+ 1,992 SATS', { exact: true })).toBeVisible()
+  await expect(page.getByText('+ ₿1,992', { exact: true })).toBeVisible()
 
   // transaction should be visible on main page
   await page.getByTestId('tab-wallet').click()
-  await expect(page.getByText('+ 1,992 SATS')).toBeVisible()
+  await expect(page.getByText('+ ₿1,992')).toBeVisible()
 
   // generate lightning invoice to pay
   const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt 1000`)
@@ -109,11 +109,11 @@ test('should save swaps to nostr', async ({ page, isMobile }) => {
   await page.getByTestId('tab-apps').click()
   await expect(page.getByText('Boltz', { exact: true })).toBeVisible()
   await page.getByTestId('app-boltz').click()
-  await expect(page.getByText('- 1,001 SATS', { exact: true })).toBeVisible()
+  await expect(page.getByText('- ₿1,001', { exact: true })).toBeVisible()
 
   // transaction should be visible on main page
   await page.getByTestId('tab-wallet').click()
-  await expect(page.getByText('- 1,001 SATS')).toBeVisible()
+  await expect(page.getByText('- ₿1,001')).toBeVisible()
 
   // enable nostr backups
   await page.getByTestId('tab-settings').click()
@@ -127,6 +127,6 @@ test('should save swaps to nostr', async ({ page, isMobile }) => {
   await page.getByTestId('tab-apps').click()
   await expect(page.getByText('Boltz', { exact: true })).toBeVisible()
   await page.getByTestId('app-boltz').click()
-  await expect(page.getByText('- 1,001 SATS', { exact: true })).toBeVisible()
-  await expect(page.getByText('+ 1,992 SATS', { exact: true })).toBeVisible()
+  await expect(page.getByText('- ₿1,001', { exact: true })).toBeVisible()
+  await expect(page.getByText('+ ₿1,992', { exact: true })).toBeVisible()
 })

--- a/src/test/e2e/receive.test.ts
+++ b/src/test/e2e/receive.test.ts
@@ -32,5 +32,5 @@ test('should receive offchain funds', async ({ page }) => {
 
   // wait for payment received
   await waitForPaymentReceived(page)
-  await expect(page.getByText('SATS received successfully')).toBeVisible()
+  await expect(page.getByText('received successfully')).toBeVisible()
 })

--- a/src/test/e2e/send.test.ts
+++ b/src/test/e2e/send.test.ts
@@ -18,19 +18,19 @@ test('should send to ark address', async ({ page, isMobile }) => {
   // main page
   await page.getByTestId('tab-wallet').click()
   await expect(page.getByText('5,000', { exact: true })).toBeVisible()
-  await expect(page.getByText('+ 5,000 SATS')).toBeVisible()
+  await expect(page.getByText('+ ₿5,000')).toBeVisible()
 
   // send page
   const someArkAddress =
     'tark1qr340xg400jtxat9hdd0ungyu6s05zjtdf85uj9smyzxshf98nda' +
     'h6u2nredqtn0cr4p4zqz53gsmhju4l9t7x47kzleesa9dprx7e56xhzlen'
   await pay(page, someArkAddress, isMobile, 2000)
-  await expect(page.getByText('SATS sent successfully')).toBeVisible()
+  await expect(page.getByText('sent successfully')).toBeVisible()
 
   // main page
   await page.getByTestId('tab-wallet').click()
-  await expect(page.getByText('3,000SATS')).toBeVisible()
-  await expect(page.getByText('- 2,000 SATS')).toBeVisible()
+  await expect(page.getByText('₿3,000')).toBeVisible()
+  await expect(page.getByText('- ₿2,000')).toBeVisible()
   await expect(page.getByText('Sent')).toBeVisible()
 })
 
@@ -53,17 +53,17 @@ test('should send to onchain address', async ({ page, isMobile }) => {
   // main page
   await page.getByTestId('tab-wallet').click()
   await expect(page.getByText('5,000', { exact: true })).toBeVisible()
-  await expect(page.getByText('+ 5,000 SATS')).toBeVisible()
+  await expect(page.getByText('+ ₿5,000')).toBeVisible()
 
   // send page
   const someOnchainAddress = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
   await pay(page, someOnchainAddress, isMobile, 2000)
-  await expect(page.getByText('SATS sent successfully')).toBeVisible()
+  await expect(page.getByText('sent successfully')).toBeVisible()
 
   // main page
   await page.getByTestId('tab-wallet').click()
-  await expect(page.getByText('2,800SATS')).toBeVisible()
-  await expect(page.getByText('- 2,200 SATS')).toBeVisible()
+  await expect(page.getByText('₿2,800')).toBeVisible()
+  await expect(page.getByText('- ₿2,200')).toBeVisible()
   await expect(page.getByText('Sent')).toBeVisible()
 
   // clear fees

--- a/src/test/e2e/swap.test.ts
+++ b/src/test/e2e/swap.test.ts
@@ -36,7 +36,7 @@ test('should receive funds from Lightning', async ({ page, isMobile }) => {
 
   // main page
   await expect(page.getByText('1,992', { exact: true })).toBeVisible()
-  await expect(page.getByText('+ 1,992 SATS')).toBeVisible()
+  await expect(page.getByText('+ ₿1,992')).toBeVisible()
 
   // should be visible in Boltz app
   await page.getByTestId('tab-apps').click()
@@ -63,7 +63,7 @@ test('should send funds to Lightning', async ({ page }) => {
   // main page
   await page.getByTestId('tab-wallet').click()
   await expect(page.getByText('5,000', { exact: true })).toBeVisible()
-  await expect(page.getByText('+ 5,000 SATS')).toBeVisible()
+  await expect(page.getByText('+ ₿5,000')).toBeVisible()
 
   const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt 1000`)
   const output = stdout.trim()
@@ -104,7 +104,7 @@ test('should refund failing swap', async ({ page }) => {
   // main page
   await page.getByTestId('tab-wallet').click()
   await expect(page.getByText('5,000', { exact: true })).toBeVisible()
-  await expect(page.getByText('+ 5,000 SATS')).toBeVisible()
+  await expect(page.getByText('+ ₿5,000')).toBeVisible()
 
   const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt 1000`)
   const output = stdout.trim()

--- a/src/test/lib/format.test.ts
+++ b/src/test/lib/format.test.ts
@@ -31,16 +31,16 @@ describe('format utilities', () => {
   })
 
   describe('prettyAmount', () => {
-    it('should format small amounts correctly', () => {
-      expect(prettyAmount(0)).toBe('0 SATS')
-      expect(prettyAmount(100)).toBe('100 SATS')
-      expect(prettyAmount(999)).toBe('999 SATS')
+    it('should format amounts with ₿ prefix', () => {
+      expect(prettyAmount(0)).toBe('₿0')
+      expect(prettyAmount(100)).toBe('₿100')
+      expect(prettyAmount(999)).toBe('₿999')
     })
 
-    it('should format amounts in BTC for large values', () => {
-      expect(prettyAmount(50000000)).toBe('50M SATS')
-      expect(prettyAmount(100000000)).toBe('1 BTC')
-      expect(prettyAmount(150000000)).toBe('1.5 BTC')
+    it('should format large amounts as integers with ₿ prefix', () => {
+      expect(prettyAmount(50000000)).toBe('₿50,000,000')
+      expect(prettyAmount(100000000)).toBe('₿100,000,000')
+      expect(prettyAmount(150000000)).toBe('₿150,000,000')
     })
 
     it('should handle fiat currency formatting', () => {
@@ -115,8 +115,12 @@ describe('format utilities', () => {
   describe('prettyHide', () => {
     it('should return masked value', () => {
       expect(prettyHide(0)).toBe('')
-      expect(prettyHide(12345)).toBe('·········· SATS')
-      expect(prettyHide(999999999)).toBe('·················· SATS')
+      expect(prettyHide(12345)).toBe('··········')
+      expect(prettyHide(999999999)).toBe('··················')
+    })
+
+    it('should append fiat suffix when provided', () => {
+      expect(prettyHide(12345, 'USD')).toBe('·········· USD')
     })
   })
 

--- a/src/test/screens/settings/about.test.tsx
+++ b/src/test/screens/settings/about.test.tsx
@@ -15,7 +15,7 @@ describe('About screen', () => {
     expect(screen.getByText('About')).toBeInTheDocument()
     expect(screen.getByText('Network')).toBeInTheDocument()
     expect(screen.getByText('regtest')).toBeInTheDocument()
-    expect(screen.getByText('333 SATS')).toBeInTheDocument()
+    expect(screen.getByText('₿333')).toBeInTheDocument()
     expect(screen.getByText('Server URL')).toBeInTheDocument()
     expect(screen.getByText('17 minutes')).toBeInTheDocument()
     expect(screen.getByText('Server pubkey')).toBeInTheDocument()

--- a/src/test/screens/settings/display.test.tsx
+++ b/src/test/screens/settings/display.test.tsx
@@ -15,7 +15,7 @@ describe('Display screen', () => {
     expect(screen.getByTestId('select-option-0')).toBeInTheDocument()
     expect(screen.getByTestId('select-option-0').querySelector('p')?.textContent).toBe('Show both')
     expect(screen.getByTestId('select-option-1')).toBeInTheDocument()
-    expect(screen.getByTestId('select-option-1').querySelector('p')?.textContent).toBe('Sats only')
+    expect(screen.getByTestId('select-option-1').querySelector('p')?.textContent).toBe('Bitcoin only')
     expect(screen.getByTestId('select-option-2')).toBeInTheDocument()
     expect(screen.getByTestId('select-option-2').querySelector('p')?.textContent).toBe('Fiat only')
   })

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -5,7 +5,7 @@ import Wallet from '../../../screens/Wallet/Index'
 describe('Wallet screen', () => {
   it('renders the wallet screen with the correct elements', () => {
     render(<Wallet />)
-    expect(screen.getByText('SATS')).toBeInTheDocument()
+    expect(screen.getByText(/₿/)).toBeInTheDocument()
     expect(screen.getByText('Send')).toBeInTheDocument()
     expect(screen.getByText('Receive')).toBeInTheDocument()
     expect(screen.getByText('My balance')).toBeInTheDocument()

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -77,7 +77,7 @@ describe('Send screen', () => {
     expect(screen.getByText('Max')).toBeInTheDocument()
     expect(screen.getByText('Send')).toBeInTheDocument()
     expect(screen.getByText('Amount')).toBeInTheDocument()
-    expect(screen.getByText('0 SATS available')).toBeInTheDocument()
+    expect(screen.getByText('₿0 available')).toBeInTheDocument()
     expect(screen.getByText('Recipient address')).toBeInTheDocument()
     expect(screen.getByText('Continue')).toBeInTheDocument()
   })

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -41,7 +41,7 @@ describe('Transaction screen', () => {
     expect(screen.getByText('When')).toBeInTheDocument()
     // right side of the table
     expect(await screen.findByText('Received')).toBeInTheDocument()
-    expect(await screen.findByText('0 SATS')).toBeInTheDocument()
+    expect(await screen.findByText('₿0')).toBeInTheDocument()
   })
 
   it('renders the preconfirmed transaction screen correctly', async () => {
@@ -79,7 +79,7 @@ describe('Transaction screen', () => {
     expect(screen.getByText('When')).toBeInTheDocument()
     // right side of the table
     expect(screen.getByText('Received')).toBeInTheDocument()
-    expect(screen.getByText('0 SATS')).toBeInTheDocument()
+    expect(screen.getByText('₿0')).toBeInTheDocument()
     // buttons
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
     expect(screen.queryByText('Add reminder')).not.toBeInTheDocument()
@@ -114,7 +114,7 @@ describe('Transaction screen', () => {
     expect(screen.getByText('When')).toBeInTheDocument()
     // right side of the table
     expect(screen.getByText('Received')).toBeInTheDocument()
-    expect(screen.getByText('0 SATS')).toBeInTheDocument()
+    expect(screen.getByText('₿0')).toBeInTheDocument()
     // buttons should not be present
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
     expect(screen.queryByText('Add reminder')).not.toBeInTheDocument()
@@ -149,7 +149,7 @@ describe('Transaction screen', () => {
     expect(screen.getByText('When')).toBeInTheDocument()
     // right side of the table
     expect(screen.getByText('Received')).toBeInTheDocument()
-    expect(screen.getByText('0 SATS')).toBeInTheDocument()
+    expect(screen.getByText('₿0')).toBeInTheDocument()
     // buttons should be present
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
     expect(screen.queryByText('Add reminder')).not.toBeInTheDocument()
@@ -184,7 +184,7 @@ describe('Transaction screen', () => {
     expect(screen.getByText('When')).toBeInTheDocument()
     // right side of the table
     // expect(screen.getByText('Received')).toBeInTheDocument()
-    expect(screen.getByText('0 SATS')).toBeInTheDocument()
+    expect(screen.getByText('₿0')).toBeInTheDocument()
     // buttons should be present
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
     expect(screen.queryByText('Add reminder')).not.toBeInTheDocument()
@@ -221,7 +221,7 @@ describe('Transaction screen', () => {
     expect(screen.getByText('When')).toBeInTheDocument()
     // right side of the table
     expect(screen.getByText('Received')).toBeInTheDocument()
-    expect(screen.getByText('0 SATS')).toBeInTheDocument()
+    expect(screen.getByText('₿0')).toBeInTheDocument()
     // buttons should not be present
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
     expect(screen.queryByText('Add reminder')).not.toBeInTheDocument()


### PR DESCRIPTION
## Exploration: BIP-177 display format

This is an **exploration** of what the wallet would look like if we adopted the [BIP-177](https://github.com/bitcoin/bips/blob/master/bip-0177.mediawiki) standard, which redefines "1 bitcoin" as the base unit (formerly "1 satoshi") and uses the ₿ symbol as a prefix.

**This is not a proposal to merge** — just saving the work to revisit later.

### What changed
- `prettyAmount()` returns `₿10,000` instead of `10,000 SATS`
- `prettyHide()` returns just dots (no SATS suffix)
- `CurrencyDisplay.Sats` → `CurrencyDisplay.Bitcoin` ("Bitcoin only" in settings)
- Balance, InputAmount, Keyboard components restructured for ₿ prefix
- All user-facing strings updated (notifications, errors, settings copy)
- `.bitcoin-symbol` CSS class for ₿ font rendering (Geist doesn't cover U+20BF)
- All unit tests and E2E tests updated

### What works
- Visually verified in browser: balance, transaction list, send flow, settings
- ₿ symbol renders correctly via system sans-serif fallback
- Unit tests pass
- 29 files changed, ~124 insertions, ~97 deletions

### What's left to decide
- Whether BIP-177 is the right direction at all (controversial)
- Large number readability (e.g. ₿1,000,000,000 vs abbreviations)
- Hidden balance format (currently `₿··········`)
- Internal variable naming (left as `sats`/`amountInSats` — display-layer only change)