### PR TITLE
perf(ui): fix wallet freeze on large tx history

### DIFF
--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useState } from 'react'
+import { useContext, useState } from 'react'
 import { WalletContext } from '../providers/wallet'
 import Text, { TextLabel, TextSecondary } from './Text'
 import { CurrencyDisplay, Tx } from '../lib/types'
@@ -104,13 +104,7 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
   )
 }
 
-const PassthroughWrapper = ({ children }: { children: ReactNode }) => <>{children}</>
-
-interface TransactionsListProps {
-  ItemWrapper?: React.ComponentType<{ children: ReactNode }>
-}
-
-export default function TransactionsList({ ItemWrapper }: TransactionsListProps) {
+export default function TransactionsList() {
   const { setTxInfo } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
   const { txs } = useContext(WalletContext)
@@ -144,18 +138,14 @@ export default function TransactionsList({ ItemWrapper }: TransactionsListProps)
     navigate(Pages.Transaction)
   }
 
-  const Wrap = ItemWrapper ?? PassthroughWrapper
-
   return (
     <div style={{ width: 'calc(100% + 2rem)', margin: '0 -1rem' }}>
-      <Wrap>
-        <TextLabel>Transaction history</TextLabel>
-      </Wrap>
+      <TextLabel>Transaction history</TextLabel>
       <Focusable id='outer' onEnter={focusOnFirstRow} ariaLabel={ariaLabel()}>
         <div style={{ borderBottom: border }}>
           {txs.map((tx, index) => {
             const k = key(tx, index)
-            const focusable = (
+            return (
               <Focusable
                 id={k}
                 key={k}
@@ -167,7 +157,6 @@ export default function TransactionsList({ ItemWrapper }: TransactionsListProps)
                 <TransactionLine onClick={() => handleClick(tx)} tx={tx} />
               </Focusable>
             )
-            return ItemWrapper ? <ItemWrapper key={k}>{focusable}</ItemWrapper> : focusable
           })}
         </div>
       </Focusable>

--- a/src/screens/Wallet/Index.tsx
+++ b/src/screens/Wallet/Index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import Balance from '../../components/Balance'
 import ErrorMessage from '../../components/Error'
 import TransactionsList from '../../components/TransactionsList'
@@ -31,14 +31,6 @@ export default function Wallet() {
 
   const [error, setError] = useState(false)
   const shouldStagger = isInitialLoad
-
-  const StaggerItem = useMemo(
-    () =>
-      function StaggerItemWrapper({ children }: { children: ReactNode }) {
-        return <WalletStaggerChild animate={shouldStagger}>{children}</WalletStaggerChild>
-      },
-    [shouldStagger],
-  )
 
   useEffect(() => {
     setError(aspInfo.unreachable)
@@ -88,7 +80,9 @@ export default function Wallet() {
                   </div>
                 </WalletStaggerChild>
               ) : (
-                <TransactionsList ItemWrapper={StaggerItem} />
+                <WalletStaggerChild animate={shouldStagger}>
+                  <TransactionsList />
+                </WalletStaggerChild>
               )}
             </FlexCol>
           </WalletStaggerContainer>


### PR DESCRIPTION
## Summary

- Each transaction row was wrapped in its own Framer Motion `motion.div` with `willChange: transform, opacity`
- With 100+ transactions, the stagger queue alone was `N × 60ms` long (100 txs = 6s), blocking the main thread and making the tab bar/buttons unresponsive
- Fix: the entire `TransactionsList` is now wrapped in a single `WalletStaggerChild` that animates as one unit — the per-row `ItemWrapper` prop is removed

## Test plan

- [ ] Open a wallet with a large transaction history — UI should be immediately responsive on load
- [ ] Verify the wallet load-in stagger animation still plays for logo, balance, and action buttons
- [ ] Verify tapping the tab bar and buttons works instantly after opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified component composition and improved internal code structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->