### PR TITLE
fix text wrap on restore

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -13,7 +13,6 @@ interface TextProps {
   children: ReactNode
   color?: string
   copy?: string
-  fullWidth?: boolean
   heading?: boolean
   large?: boolean
   medium?: boolean
@@ -34,7 +33,6 @@ export default function Text({
   children,
   color,
   copy,
-  fullWidth,
   heading,
   large,
   medium,
@@ -64,10 +62,6 @@ export default function Text({
     wordBreak: 'break-word',
   }
 
-  const iStyle: any = {
-    width: fullWidth ? '100%' : undefined,
-  }
-
   const [present] = useIonToast()
 
   const handleClick = () => {
@@ -78,7 +72,7 @@ export default function Text({
   }
 
   return (
-    <IonText style={iStyle}>
+    <IonText>
       <p className={className} onClick={handleClick} style={pStyle}>
         {children}
       </p>

--- a/src/screens/Init/Restore.tsx
+++ b/src/screens/Init/Restore.tsx
@@ -16,7 +16,7 @@ import Button from '../../components/Button'
 import Header from '../../components/Header'
 import Padded from '../../components/Padded'
 import Input from '../../components/Input'
-import Text from '../../components/Text'
+import { TextSecondary } from '../../components/Text'
 import { hex } from '@scure/base'
 import { OnboardStaggerContainer, OnboardStaggerChild } from '../../components/OnboardLoadIn'
 
@@ -79,9 +79,9 @@ export default function InitRestore() {
                   <Input name='private-key' label='Private key' onChange={setSomeKey} />
                   <ErrorMessage error={Boolean(error)} text={error} />
                 </FlexCol>
-                <Text centered color='dark70' fullWidth thin small>
+                <TextSecondary wrap>
                   Your private key should start with the 'nsec' string. Do not share it with anyone.
-                </Text>
+                </TextSecondary>
               </FlexCol>
             </OnboardStaggerChild>
           </OnboardStaggerContainer>


### PR DESCRIPTION
Before:

<img width="300" height="649" alt="arkade money_(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/4823e25f-48c1-4609-a323-973fecd75cba" />

After:

<img width="300" height="649" alt="localhost_3002_(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/24271fac-4333-4faf-8f6e-5a9c00c89143" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated text component structure for improved consistency in styling and rendering across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->