### PR TITLE
Fix e2e

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,7 +33,6 @@ export const defaultDelegate = (): Delegate => {
     }
     return mainServer
   }
-  console.log('Default delegate URL:', getDefaultUrl())
   return {
     name: 'Arkade Default',
     url: getDefaultUrl(),

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,7 +22,7 @@ export const defaultArkServer = () => {
 }
 
 export const defaultDelegate = (): Delegate => {
-  const devServer = 'http://localhost:7004'
+  const devServer = 'http://localhost:7002'
   const mainServer = 'https://delegate.arkade.computer'
   const getDefaultUrl = () => {
     if (import.meta.env.VITE_DELEGATOR_URL) return import.meta.env.VITE_DELEGATOR_URL
@@ -33,6 +33,7 @@ export const defaultDelegate = (): Delegate => {
     }
     return mainServer
   }
+  console.log('Default delegate URL:', getDefaultUrl())
   return {
     name: 'Arkade Default',
     url: getDefaultUrl(),

--- a/src/test/e2e/delegate.test.ts
+++ b/src/test/e2e/delegate.test.ts
@@ -9,12 +9,23 @@ test('should toggle delegates', async ({ page }) => {
   await page.getByText('advanced', { exact: true }).click()
   await page.getByText('delegates', { exact: true }).click()
 
-  const toggle = page.getByTestId('toggle-delegates')
+  let toggle = page.getByTestId('toggle-delegates')
   await expect(toggle).toHaveAttribute('checked', 'true')
   await expect(page.getByTestId('delegate-card')).toBeVisible()
 
   await toggle.click()
 
+  const maybeLater = page.getByRole('button', { name: 'Maybe later' })
+  await maybeLater.waitFor({ state: 'visible', timeout: 15000 }).catch(() => {})
+  if (await maybeLater.isVisible()) {
+    await maybeLater.click({ force: true })
+    await maybeLater.waitFor({ state: 'hidden' }).catch(() => {})
+  }
+
+  await page.getByTestId('tab-settings').click()
+  await page.getByText('advanced', { exact: true }).click()
+  await page.getByText('delegates', { exact: true }).click()
+  toggle = page.getByTestId('toggle-delegates')
   await expect(toggle).toBeVisible()
   await expect(toggle).toHaveAttribute('checked', 'false')
   await expect(page.getByTestId('delegate-card')).not.toBeVisible()


### PR DESCRIPTION
- use `localhost:7002` for delegate API
- update e2e test to match the current behavior