### PR TITLE
feat(dev): add agentation design feedback toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@scure/bip39": "2.0.0",
     "@scure/btc-signer": "2.0.1",
     "@sentry/react": "^9.15.0",
+    "agentation": "^2.3.0",
     "decimal.js": "^10.5.0",
     "dompurify": "^3.2.6",
     "framer-motion": "^12.34.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@sentry/react':
         specifier: ^9.15.0
         version: 9.46.0(react@18.3.1)
+      agentation:
+        specifier: ^2.3.0
+        version: 2.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       decimal.js:
         specifier: ^10.5.0
         version: 10.6.0
@@ -1005,6 +1008,17 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentation@2.3.0:
+    resolution: {integrity: sha512-uGcDel78I5UAVSiWnsNv0pHj+ieuHyZ4GCsL6kqEralKeIW32869JlwfsKoy5S71jseyrI6O5duU+AacJs+CmQ==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -3409,6 +3423,11 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
+
+  agentation@2.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   ajv@6.12.6:
     dependencies:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,7 +47,7 @@ root.render(
                         <NudgeProvider>
                           <AnnouncementProvider>
                             <App />
-                            {import.meta.env.DEV ? <Agentation endpoint="http://localhost:4747" /> : null}
+                            {import.meta.env.DEV ? <Agentation endpoint='http://localhost:4747' /> : null}
                           </AnnouncementProvider>
                         </NudgeProvider>
                       </OptionsProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import { LightningProvider } from './providers/lightning'
 import { shouldInitializeSentry } from './lib/sentry'
 import { FeesProvider } from './providers/fees'
 import { AnnouncementProvider } from './providers/announcements'
+import { Agentation } from 'agentation'
 
 // Initialize Sentry only in production and when DSN is provided
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN
@@ -46,6 +47,7 @@ root.render(
                         <NudgeProvider>
                           <AnnouncementProvider>
                             <App />
+                            {import.meta.env.DEV ? <Agentation endpoint="http://localhost:4747" /> : null}
                           </AnnouncementProvider>
                         </NudgeProvider>
                       </OptionsProvider>


### PR DESCRIPTION
## Summary
- Adds `agentation` package for dev-only design annotation and visual feedback
- Toolbar renders only in development mode (`import.meta.env.DEV`) — completely tree-shaken from production builds
- Zero bytes of agentation code in the deployed app

## What is agentation?
A design feedback toolbar that lets you click any element in the app, annotate it with design critiques, and sync those annotations to Claude Code via MCP. Enables both manual annotation workflows and autonomous design review.

## Changes
- `src/index.tsx` — import and render `<Agentation />` component (dev-only)
- `package.json` — add `agentation` dependency

## Test plan
- [ ] `bun run dev` — toolbar appears on localhost
- [ ] Click an element — annotation dialog opens
- [ ] `bun run build` — builds successfully, no agentation in output
- [ ] Production deploy — no toolbar visible to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated a new development utility to enhance the local development experience. This tool is only active during development mode and does not affect production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->