### PR TITLE
Don't block app on swap init error

### DIFF
--- a/public/wallet-service-worker.mjs
+++ b/public/wallet-service-worker.mjs
@@ -55640,7 +55640,7 @@ var pN = (c) => {
     }));
   }
 };
-const vN = "35a39853-dirty", EN = new Wd(), SN = new Vd(), xN = new Yd();
+const vN = "89bcaec3-dirty", EN = new Wd(), SN = new Vd(), xN = new Yd();
 self.addEventListener("message", (c) => {
   c.data?.type === "SKIP_WAITING" && c.waitUntil(self.skipWaiting());
 });

--- a/src/providers/swaps.tsx
+++ b/src/providers/swaps.tsx
@@ -33,6 +33,7 @@ interface SwapsContextProps {
   connected: boolean
   arkadeSwaps: ServiceWorkerArkadeSwaps | null
   swapManager: SwapManagerClient | null
+  swapsInitError: string | null
   toggleConnection: () => void
   // Helper methods for chain swaps
   calcArkToBtcSwapFee: (satoshis: number) => number
@@ -61,6 +62,7 @@ export const SwapsContext = createContext<SwapsContextProps>({
   connected: false,
   arkadeSwaps: null,
   swapManager: null,
+  swapsInitError: null,
   toggleConnection: () => {},
   calcArkToBtcSwapFee: () => 0,
   calcBtcToArkSwapFee: () => 0,
@@ -94,6 +96,7 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
   const [arkToBtcFees, setArkToBtcFees] = useState<ChainFeesResponse | null>(null)
   const [btcToArkFees, setBtcToArkFees] = useState<ChainFeesResponse | null>(null)
   const [arkadeSwaps, setArkadeSwaps] = useState<ServiceWorkerArkadeSwaps | null>(null)
+  const [swapsInitError, setSwapsInitError] = useState<string | null>(null)
   const [fees, setFees] = useState<FeesResponse | null>(null)
   const [apiUrl, setApiUrl] = useState<string | null>(null)
 
@@ -127,10 +130,14 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
           instance.dispose().catch(consoleError)
         } else {
           disposeArkadeSwaps = () => instance.dispose().catch(consoleError)
+          setSwapsInitError(null)
           setArkadeSwaps(instance)
         }
       })
-      .catch(console.error)
+      .catch((err) => {
+        consoleError(err, 'Failed to initialize swaps')
+        if (!cancelled) setSwapsInitError(err instanceof Error ? err.message : String(err))
+      })
     setLogger({
       log: (...args: unknown[]) => consoleLog(...args),
       error: (...args: unknown[]) => consoleError(args[0], args.slice(1).join(' ')),
@@ -347,6 +354,7 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
         connected,
         arkadeSwaps,
         swapManager,
+        swapsInitError,
         toggleConnection,
         calcArkToBtcSwapFee,
         calcBtcToArkSwapFee,

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -27,8 +27,7 @@ export default function ReceiveQRCode() {
   const { navigate } = useContext(NavigationContext)
   const { recvInfo, setRecvInfo } = useContext(FlowContext)
   const { notifyPaymentReceived } = useContext(NotificationsContext)
-  const { arkadeSwaps, swapsInitError, connected, createBtcToArkSwap, createReverseSwap } =
-    useContext(SwapsContext)
+  const { arkadeSwaps, swapsInitError, connected, createBtcToArkSwap, createReverseSwap } = useContext(SwapsContext)
   const { assetMetadataCache, svcWallet } = useContext(WalletContext)
   const { validBtcToArk, validLnSwap, validUtxoTx, validVtxoTx, utxoTxsAllowed, vtxoTxsAllowed } =
     useContext(LimitsContext)

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -26,7 +26,7 @@ export default function ReceiveQRCode() {
   const { navigate } = useContext(NavigationContext)
   const { recvInfo, setRecvInfo } = useContext(FlowContext)
   const { notifyPaymentReceived } = useContext(NotificationsContext)
-  const { arkadeSwaps, createBtcToArkSwap, createReverseSwap } = useContext(SwapsContext)
+  const { arkadeSwaps, swapsInitError, createBtcToArkSwap, createReverseSwap } = useContext(SwapsContext)
   const { assetMetadataCache, svcWallet } = useContext(WalletContext)
   const { validBtcToArk, validLnSwap, validUtxoTx, validVtxoTx, utxoTxsAllowed, vtxoTxsAllowed } =
     useContext(LimitsContext)
@@ -80,7 +80,17 @@ export default function ReceiveQRCode() {
 
   useEffect(() => {
     if (isAssetReceive) return setShowQrCode(true)
-    if (!satoshis || !svcWallet || !arkadeSwaps) return
+    if (!satoshis || !svcWallet) return
+
+    // Show QR immediately with available addresses (ark + boarding),
+    // then progressively enhance with swap addresses if arkadeSwaps is ready
+    setShowQrCode(true)
+
+    if (!arkadeSwaps) {
+      if (swapsInitError) consoleError(swapsInitError, 'Swaps unavailable, showing receive without swap options')
+      return
+    }
+
     Promise.allSettled([createBtcAddress(), createLightningInvoice()]).then(([btc, lightning]) => {
       if (btc.status === 'fulfilled') {
         const pendingSwap = btc.value as PendingChainSwap
@@ -110,7 +120,6 @@ export default function ReceiveQRCode() {
             consoleError(error, 'Error claiming reverse swap:')
           })
       }
-      setShowQrCode(true)
     })
   }, [satoshis, svcWallet, arkadeSwaps])
 
@@ -130,7 +139,7 @@ export default function ReceiveQRCode() {
     setBtcAddress(btcAddress)
     setQrCodeValue(bip21uri)
     setBip21Uri(bip21uri)
-  }, [showQrCode])
+  }, [showQrCode, swapAddress, invoice])
 
   useEffect(() => {
     if (!svcWallet) return

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -21,12 +21,14 @@ import { encodeBip21, encodeBip21Asset } from '../../../lib/bip21'
 import { PendingChainSwap, PendingReverseSwap } from '@arkade-os/boltz-swap'
 import { enableChainSwapsReceive } from '../../../lib/constants'
 import { centsToUnits } from '../../../lib/assets'
+import WarningBox from '../../../components/Warning'
 
 export default function ReceiveQRCode() {
   const { navigate } = useContext(NavigationContext)
   const { recvInfo, setRecvInfo } = useContext(FlowContext)
   const { notifyPaymentReceived } = useContext(NotificationsContext)
-  const { arkadeSwaps, swapsInitError, createBtcToArkSwap, createReverseSwap } = useContext(SwapsContext)
+  const { arkadeSwaps, swapsInitError, connected, createBtcToArkSwap, createReverseSwap } =
+    useContext(SwapsContext)
   const { assetMetadataCache, svcWallet } = useContext(WalletContext)
   const { validBtcToArk, validLnSwap, validUtxoTx, validVtxoTx, utxoTxsAllowed, vtxoTxsAllowed } =
     useContext(LimitsContext)
@@ -42,6 +44,7 @@ export default function ReceiveQRCode() {
   const [arkAddress, setArkAddress] = useState(offchainAddr)
   const [btcAddress, setBtcAddress] = useState(boardingAddr)
   const [showQrCode, setShowQrCode] = useState(!satoshis)
+  const [swapsTimedOut, setSwapsTimedOut] = useState(false)
   const [swapAddress, setSwapAddress] = useState('')
   const [qrCodeValue, setQrCodeValue] = useState('')
   const [bip21Uri, setBip21Uri] = useState('')
@@ -82,14 +85,29 @@ export default function ReceiveQRCode() {
     if (isAssetReceive) return setShowQrCode(true)
     if (!satoshis || !svcWallet) return
 
-    // Show QR immediately with available addresses (ark + boarding),
-    // then progressively enhance with swap addresses if arkadeSwaps is ready
-    setShowQrCode(true)
+    // LN is only expected when Boltz is enabled and this isn't an asset receive
+    const lnExpected = connected && !isAssetReceive
 
     if (!arkadeSwaps) {
-      if (swapsInitError) consoleError(swapsInitError, 'Swaps unavailable, showing receive without swap options')
-      return
+      if (!lnExpected || swapsInitError) {
+        // LN not expected or already failed — show QR immediately
+        if (lnExpected && swapsInitError) {
+          consoleError(swapsInitError, 'Swaps unavailable, showing receive without swap options')
+          setSwapsTimedOut(true)
+        }
+        setShowQrCode(true)
+        return
+      }
+      // LN expected but swaps still initializing — wait up to 5s
+      const timeout = setTimeout(() => {
+        setSwapsTimedOut(true)
+        setShowQrCode(true)
+      }, 5_000)
+      return () => clearTimeout(timeout)
     }
+
+    // arkadeSwaps is ready, generate swaps before showing QR to avoid QR code changing
+    setSwapsTimedOut(false)
 
     Promise.allSettled([createBtcAddress(), createLightningInvoice()]).then(([btc, lightning]) => {
       if (btc.status === 'fulfilled') {
@@ -120,8 +138,9 @@ export default function ReceiveQRCode() {
             consoleError(error, 'Error claiming reverse swap:')
           })
       }
+      setShowQrCode(true)
     })
-  }, [satoshis, svcWallet, arkadeSwaps])
+  }, [satoshis, svcWallet, arkadeSwaps, swapsInitError])
 
   //
   useEffect(() => {
@@ -221,6 +240,9 @@ export default function ReceiveQRCode() {
                 invoice={invoice || ''}
                 onClick={setQrCodeValue}
               />
+              {swapsTimedOut && !invoice && !isAssetReceive ? (
+                <WarningBox text='Lightning is temporarily unavailable. This QR code only supports Ark and on-chain payments.' />
+              ) : null}
             </FlexCol>
           ) : (
             <Loading text='Generating QR code...' />

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -86,18 +86,30 @@ export const mockFiatContextValue = {
 export const mockSwapsContextValue = {
   arkadeSwaps: null,
   swapManager: null,
+  swapsInitError: null,
   connected: false,
+  calcArkToBtcSwapFee: () => 0,
+  calcBtcToArkSwapFee: () => 0,
   calcSubmarineSwapFee: () => 0,
   calcReverseSwapFee: () => 0,
+  createArkToBtcSwap: async () => null,
+  createBtcToArkSwap: async () => null,
   createSubmarineSwap: async () => null,
   createReverseSwap: async () => null,
+  claimArk: async () => {},
+  claimBtc: async () => {},
   claimVHTLC: async () => {},
+  refundArk: async () => {},
   refundVHTLC: async () => {},
+  payBtc: async () => {
+    throw new Error('Chain swap not initialized')
+  },
   payInvoice: async () => {
     throw new Error('Lightning not initialized')
   },
   getSwapHistory: async () => [],
   getApiUrl: () => null,
+  restoreSwaps: async () => 0,
   toggleConnection: () => {},
 }
 

--- a/src/test/screens/wallet/receive-qrcode.test.tsx
+++ b/src/test/screens/wallet/receive-qrcode.test.tsx
@@ -1,0 +1,221 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { FlowContext } from '../../../providers/flow'
+import { LimitsContext } from '../../../providers/limits'
+import {
+  mockAspContextValue,
+  mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockSwapsContextValue,
+  mockLimitsContextValue,
+  mockNavigationContextValue,
+  mockSvcWallet,
+  mockWalletContextValue,
+} from '../mocks'
+import { AspContext } from '../../../providers/asp'
+import { WalletContext } from '../../../providers/wallet'
+import { NavigationContext } from '../../../providers/navigation'
+import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import { SwapsContext } from '../../../providers/swaps'
+import { NotificationsContext } from '../../../providers/notifications'
+import ReceiveQRCode from '../../../screens/Wallet/Receive/QrCode'
+
+// Mock qr module used by QrCode component
+vi.mock('qr', () => ({
+  default: () => new Uint8Array([0]),
+}))
+
+// Mock URL.createObjectURL
+if (!globalThis.URL.createObjectURL) {
+  globalThis.URL.createObjectURL = () => 'blob:mock'
+}
+
+// Mock navigator.serviceWorker for jsdom
+beforeAll(() => {
+  if (!navigator.serviceWorker) {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        ready: Promise.resolve({}),
+      },
+      writable: true,
+    })
+  }
+})
+
+const mockNotificationsContextValue = {
+  notifyPaymentReceived: () => {},
+  notifyPaymentSent: () => {},
+  requestPermission: () => Promise.resolve(),
+}
+
+function renderReceiveQrCode(overrides?: {
+  swaps?: Partial<typeof mockSwapsContextValue>
+  flow?: Partial<typeof mockFlowContextValue>
+  wallet?: Partial<typeof mockWalletContextValue>
+  config?: Partial<typeof mockConfigContextValue>
+}) {
+  const swaps = { ...mockSwapsContextValue, ...overrides?.swaps }
+  const flow = { ...mockFlowContextValue, ...overrides?.flow }
+  const wallet = { ...mockWalletContextValue, ...overrides?.wallet }
+  const config = { ...mockConfigContextValue, ...overrides?.config }
+
+  return render(
+    <NavigationContext.Provider value={mockNavigationContextValue}>
+      <AspContext.Provider value={mockAspContextValue}>
+        <ConfigContext.Provider value={config as any}>
+          <FiatContext.Provider value={mockFiatContextValue as any}>
+            <NotificationsContext.Provider value={mockNotificationsContextValue as any}>
+              <SwapsContext.Provider value={swaps as any}>
+                <FlowContext.Provider value={flow as any}>
+                  <WalletContext.Provider value={wallet as any}>
+                    <LimitsContext.Provider value={mockLimitsContextValue}>
+                      <ReceiveQRCode />
+                    </LimitsContext.Provider>
+                  </WalletContext.Provider>
+                </FlowContext.Provider>
+              </SwapsContext.Provider>
+            </NotificationsContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </AspContext.Provider>
+    </NavigationContext.Provider>,
+  )
+}
+
+describe('Receive QR Code screen', () => {
+  // UX Constraint 1: When LN is not expected (disconnected), show QR immediately
+  // No waiting, no warning
+  it('shows QR immediately when Boltz is disconnected (LN not expected)', async () => {
+    renderReceiveQrCode({
+      swaps: { connected: false, arkadeSwaps: null },
+      flow: {
+        recvInfo: {
+          ...mockFlowContextValue.recvInfo,
+          satoshis: 50000,
+          offchainAddr: 'ark1testaddr',
+          boardingAddr: 'bc1testaddr',
+        },
+      },
+      wallet: { svcWallet: mockSvcWallet as any },
+    })
+
+    // Should show QR immediately, not the loader
+    expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
+    // Should NOT show the LN unavailable warning (constraint 1a)
+    expect(
+      screen.queryByText('Lightning is temporarily unavailable. This QR code only supports Ark and on-chain payments.'),
+    ).not.toBeInTheDocument()
+  })
+
+  // UX Constraint 2c: When LN init already failed, don't wait — show QR + warning immediately
+  it('shows QR immediately with warning when swapsInitError is set (no 5s wait)', async () => {
+    renderReceiveQrCode({
+      swaps: {
+        connected: true,
+        arkadeSwaps: null,
+        swapsInitError: 'SwapManager not supported',
+      },
+      flow: {
+        recvInfo: {
+          ...mockFlowContextValue.recvInfo,
+          satoshis: 50000,
+          offchainAddr: 'ark1testaddr',
+          boardingAddr: 'bc1testaddr',
+        },
+      },
+      wallet: { svcWallet: mockSvcWallet as any },
+    })
+
+    // Should show QR immediately (not loader), because error is already known
+    expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
+    // Should show the warning (constraint 2a)
+    expect(
+      screen.getByText('Lightning is temporarily unavailable. This QR code only supports Ark and on-chain payments.'),
+    ).toBeInTheDocument()
+  })
+
+  // UX Constraint 2b: When LN expected but still initializing, show loader (waiting up to 5s)
+  it('shows loader while waiting for arkadeSwaps to initialize', () => {
+    renderReceiveQrCode({
+      swaps: {
+        connected: true,
+        arkadeSwaps: null,
+        swapsInitError: null,
+      },
+      flow: {
+        recvInfo: {
+          ...mockFlowContextValue.recvInfo,
+          satoshis: 50000,
+          offchainAddr: 'ark1testaddr',
+          boardingAddr: 'bc1testaddr',
+        },
+      },
+      wallet: { svcWallet: mockSvcWallet as any },
+    })
+
+    // Should show the loader while waiting for swaps to initialize
+    expect(screen.getByText('Generating QR code...')).toBeInTheDocument()
+  })
+
+  // UX Constraint 2b: After timeout, show QR with warning
+  it('shows QR with warning after 5s timeout when arkadeSwaps never initializes', async () => {
+    vi.useFakeTimers()
+
+    renderReceiveQrCode({
+      swaps: {
+        connected: true,
+        arkadeSwaps: null,
+        swapsInitError: null,
+      },
+      flow: {
+        recvInfo: {
+          ...mockFlowContextValue.recvInfo,
+          satoshis: 50000,
+          offchainAddr: 'ark1testaddr',
+          boardingAddr: 'bc1testaddr',
+        },
+      },
+      wallet: { svcWallet: mockSvcWallet as any },
+    })
+
+    // Initially should show loader
+    expect(screen.getByText('Generating QR code...')).toBeInTheDocument()
+
+    // Advance past the 5s timeout
+    await act(async () => {
+      vi.advanceTimersByTime(5_000)
+    })
+
+    // Now should show QR, not the loader
+    expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
+    // Should show the warning
+    expect(
+      screen.getByText('Lightning is temporarily unavailable. This QR code only supports Ark and on-chain payments.'),
+    ).toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+
+  // No amount → show QR immediately (no swaps needed)
+  it('shows QR immediately when no amount is set', () => {
+    renderReceiveQrCode({
+      swaps: { connected: true, arkadeSwaps: null },
+      flow: {
+        recvInfo: {
+          ...mockFlowContextValue.recvInfo,
+          satoshis: 0,
+          offchainAddr: 'ark1testaddr',
+          boardingAddr: 'bc1testaddr',
+        },
+      },
+      wallet: { svcWallet: mockSvcWallet as any },
+    })
+
+    // No amount means no swaps needed, QR should show immediately
+    expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
When `!arkadeSwaps` → effect returns early → `showQrCode` stays false → infinite "Generating QR code..." spinner.
                                                 
The fix:
1. As soon as `svcWallet` is available, `showQrCode = true` → QR renders immediately with the ARK address and boarding address
2. If `arkadeSwaps` is null (deadlocked SW, timeout, etc.), the user still sees a working receive screen
3. If `arkadeSwaps` loads later (effect re-runs due to dependency change), swap addresses and lightning invoice are created in the background
4. The second `useEffect` now depends on `[showQrCode, swapAddress, invoice]`, so the QR code and address list update progressively as swap results arrive
5. Log errors to improve visibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap initialization error handling and logging to provide better error visibility.
  * Enhanced QR code generation to display immediately and work reliably even when swap services aren't ready yet.

* **Chores**
  * Updated internal constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->