### PR TITLE
fix(ui): remove double loading animation on app startup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,7 @@ export default function App() {
     if (jsCapabilitiesChecked && !isCapable) return navigate(Pages.Unavailable)
     // avoid redirect if the user is still setting up the wallet
     if (initInfo.password || initInfo.privateKey) return
-    if (!walletLoaded) return navigate(Pages.Loading)
+    if (!walletLoaded) return
     if (!wallet.pubkey) return navigate(pwaIsInstalled() ? Pages.Init : Pages.Onboard)
     if (!initialized) return navigate(Pages.Unlock)
   }, [walletLoaded, initialized, initInfo, aspInfo.unreachable, jsCapabilitiesChecked, isCapable])


### PR DESCRIPTION
## Summary

- Fixes the loading SVG appearing twice on startup (slides left, new one enters from right)
- Root cause: two independent mechanisms both showing the Loading page — an inline render guard (line 172) and a `navigate(Pages.Loading)` call in a useEffect (line 112). The navigate call redundantly set `direction: 'forward'`, triggering AnimatePresence to re-animate the already-visible Loading page.
- Replaced `navigate(Pages.Loading)` with a plain early `return`. The inline guard already renders Loading; the useEffect only needs to prevent premature navigation before wallet data loads.

## Changes

- `src/App.tsx` — one line: `if (!walletLoaded) return navigate(Pages.Loading)` → `if (!walletLoaded) return`

## Test plan

- [ ] Clear site data, reload on desktop — loading SVG should appear once, no slide animation
- [ ] Same test on mobile via HTTPS tunnel
- [ ] Returning user (has wallet, locked) — loading → unlock transition should work normally
- [ ] New user (no wallet) — loading → onboard transition should work normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet initialization flow during app startup to prevent unnecessary redirect interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->