### PR TITLE
fix: dynamic row height for virtualised transaction list

### DIFF
--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -155,9 +155,9 @@ export default function TransactionsList() {
   const virtualizer = useVirtualizer({
     count: txs.length,
     getScrollElement: () => parentRef.current,
-    // Estimated height of one TransactionLine row (icon 24px + 2×line-height + 2×8px padding)
     estimateSize: () => 61,
     overscan: 5,
+    measureElement: (el) => el.getBoundingClientRect().height,
   })
 
   const key = (tx: Tx, index: number) => tx.roundTxid || tx.redeemTxid || tx.boardingTxid || `tx-${index}`
@@ -228,6 +228,8 @@ export default function TransactionsList() {
               return (
                 <div
                   key={k}
+                  ref={virtualizer.measureElement}
+                  data-index={virtualItem.index}
                   data-testid='tx-row'
                   onFocus={() => {
                     if (focusedIndex !== virtualItem.index) setFocusedIndex(virtualItem.index)


### PR DESCRIPTION
## Summary
- Transaction rows with asset info (e.g. "-14.7 BB") are taller than the 61px estimate, causing rows to overlap visually
- Enables `measureElement` on `@tanstack/react-virtual` so each row's actual DOM height is measured instead of relying on the fixed estimate
- Adds `ref={virtualizer.measureElement}` and `data-index` to each virtual row element

## Test plan
- [ ] Send a transaction that includes assets — verify the row doesn't overlap with adjacent rows
- [ ] Verify normal (no-asset) transactions still render correctly with proper spacing