### PR TITLE
fix bug where was not possible to navigate to password in lock wallet

### DIFF
--- a/public/wallet-service-worker.mjs
+++ b/public/wallet-service-worker.mjs
@@ -55817,7 +55817,7 @@ var gN = (c) => {
     }));
   }
 };
-const xN = "fda01a1c-dirty", TN = new Kd(), bN = new Hd(), BN = new tw();
+const xN = "513f822a-dirty", TN = new Kd(), bN = new Hd(), BN = new tw();
 self.addEventListener("message", (c) => {
   c.data?.type === "SKIP_WAITING" && c.waitUntil(self.skipWaiting());
 });

--- a/src/screens/Settings/Lock.tsx
+++ b/src/screens/Settings/Lock.tsx
@@ -30,7 +30,6 @@ export default function Lock() {
 
   const handleSetPassword = () => {
     setOption(SettingsOptions.Password)
-    navigate(Pages.Settings)
   }
 
   const handleLock = async () => {


### PR DESCRIPTION
@pietro909 please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic navigation after setting a password in the Lock settings screen, allowing users to remain on the configuration page.

* **Chores**
  * Updated internal version identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->