### PR TITLE
fix: hide settings button on settings sub-pages to unblock coin list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,7 +219,10 @@ export default function App() {
               onClick={tab === Tabs.Settings && option === SettingsOptions.Menu ? handleCloseSettings : handleSettings}
               aria-label={tab === Tabs.Settings && option === SettingsOptions.Menu ? 'Close settings' : 'Settings'}
               style={
-                page !== Pages.Wallet && page !== Pages.Apps && tab !== Tabs.Settings ? { display: 'none' } : undefined
+                (page !== Pages.Wallet && page !== Pages.Apps && tab !== Tabs.Settings) ||
+                (tab === Tabs.Settings && option !== SettingsOptions.Menu)
+                  ? { display: 'none' }
+                  : undefined
               }
             >
               <span className={`header-icon-morph ${tab === Tabs.Settings ? 'header-icon-morph--close' : ''}`}>


### PR DESCRIPTION
## Summary
- The global settings/close button (`position: absolute; z-index: 9`) was overlapping the Header aux buttons (e.g. "Coins") on Settings sub-pages like Virtual Coins (Vtxos)
- This made it impossible to toggle between "Next Renewal" and "Virtual Coins" views
- Fix: extend the `display: none` condition to also hide the button when `tab === Settings && option !== Menu`

## Test plan
- [ ] Navigate to Settings → Virtual Coins
- [ ] Verify "Coins" / "Date" toggle button in header is tappable
- [ ] Verify settings gear button still works on main Wallet, Apps, and Settings menu pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted header settings button display behavior based on current navigation state to prevent unintended visibility in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->