### PR TITLE
fix: hide global settings button on settings sub-pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,7 +219,11 @@ export default function App() {
               onClick={tab === Tabs.Settings && option === SettingsOptions.Menu ? handleCloseSettings : handleSettings}
               aria-label={tab === Tabs.Settings && option === SettingsOptions.Menu ? 'Close settings' : 'Settings'}
               style={
-                page !== Pages.Wallet && page !== Pages.Apps && tab !== Tabs.Settings ? { display: 'none' } : undefined
+                page !== Pages.Wallet &&
+                page !== Pages.Apps &&
+                (tab !== Tabs.Settings || option !== SettingsOptions.Menu)
+                  ? { display: 'none' }
+                  : undefined
               }
             >
               <span className={`header-icon-morph ${tab === Tabs.Settings ? 'header-icon-morph--close' : ''}`}>

--- a/src/test/e2e/delegate.test.ts
+++ b/src/test/e2e/delegate.test.ts
@@ -24,8 +24,7 @@ test('should toggle delegates', async ({ page }) => {
     await maybeLater.waitFor({ state: 'hidden' }).catch(() => {})
   }
 
-  await page.getByTestId('tab-settings').click()
-  await page.getByText('advanced', { exact: true }).click()
+  await page.getByLabel('Go back').click()
   await page.getByText('delegates', { exact: true }).click()
   toggle = page.getByTestId('toggle-delegates')
 

--- a/src/test/e2e/delegate.test.ts
+++ b/src/test/e2e/delegate.test.ts
@@ -24,7 +24,10 @@ test('should toggle delegates', async ({ page }) => {
     await maybeLater.waitFor({ state: 'hidden' }).catch(() => {})
   }
 
-  await page.getByLabel('Go back').click()
+  // toggle triggers window.location.reload(), wait for wallet to load
+  await page.waitForSelector('text=Send', { state: 'visible', timeout: 30000 })
+  await page.getByTestId('tab-settings').click()
+  await page.getByText('advanced', { exact: true }).click()
   await page.getByText('delegates', { exact: true }).click()
   toggle = page.getByTestId('toggle-delegates')
 

--- a/src/test/e2e/nostr.test.ts
+++ b/src/test/e2e/nostr.test.ts
@@ -34,7 +34,7 @@ test('should save config to nostr', async ({ page }) => {
   await page.getByText('Enable Nostr backups').click()
 
   // change fiat currency to euro
-  await page.getByTestId('tab-settings').click()
+  await page.getByLabel('Go back').click()
   await page.getByText('general', { exact: true }).click()
   await expect(page.getByText('USD')).toBeVisible()
   await page.getByText('Fiat currency').click()
@@ -42,24 +42,22 @@ test('should save config to nostr', async ({ page }) => {
   await page.waitForTimeout(500)
 
   // verify fiat currency is euro
-  await page.getByTestId('tab-settings').click()
-  await page.getByText('general', { exact: true }).click()
+  await page.getByLabel('Go back').click()
   await expect(page.getByText('EUR')).toBeVisible({ timeout: 2000 })
 
   // disable nostr backups
-  await page.getByTestId('tab-settings').click()
+  await page.getByLabel('Go back').click()
   await page.getByText('backup', { exact: true }).click()
   await page.getByText('Enable Nostr backups').click()
 
   // change fiat currency to usd
-  await page.getByTestId('tab-settings').click()
+  await page.getByLabel('Go back').click()
   await page.getByText('general', { exact: true }).click()
   await page.getByText('Fiat currency').click()
   await page.getByText('USD').click()
 
   // verify fiat currency is usd
-  await page.getByTestId('tab-settings').click()
-  await page.getByText('general', { exact: true }).click()
+  await page.getByLabel('Go back').click()
   await expect(page.getByText('USD')).toBeVisible()
 
   // restore wallet

--- a/src/test/e2e/utils.ts
+++ b/src/test/e2e/utils.ts
@@ -154,11 +154,18 @@ async function navigateToSettings(page: Page): Promise<void> {
     await backBtn.click()
     await page.waitForTimeout(200)
   }
-  // If on wallet/apps, open settings; if already on settings menu, this is a no-op
+  // If on wallet/apps sub-page, go to wallet root first (settings btn may be hidden)
+  const walletTab = page.getByTestId('tab-wallet')
+  if (await walletTab.isVisible().catch(() => false)) {
+    await walletTab.click()
+  }
+  // Open settings if visible and not already on settings menu
   const settingsBtn = page.getByTestId('tab-settings')
-  const label = await settingsBtn.getAttribute('aria-label').catch(() => '')
-  if (label === 'Settings') {
-    await settingsBtn.click()
+  if (await settingsBtn.isVisible().catch(() => false)) {
+    const label = await settingsBtn.getAttribute('aria-label').catch(() => '')
+    if (label === 'Settings') {
+      await settingsBtn.click()
+    }
   }
 }
 

--- a/src/test/e2e/utils.ts
+++ b/src/test/e2e/utils.ts
@@ -81,8 +81,9 @@ export async function createWalletWithPassword(page: Page, password: string): Pr
   await page.locator('div[data-testid="new-password"] input').fill(password)
   await page.locator('div[data-testid="confirm-password"] input').fill(password)
   await page.getByText('Save password').click()
-  // go to settings main, then close settings to return to wallet
-  await page.getByTestId('tab-settings').click()
+  // go back from Password → Advanced → Menu, then close settings
+  await page.getByLabel('Go back').click()
+  await page.getByLabel('Go back').click()
   await page.getByTestId('tab-settings').click()
 }
 
@@ -147,11 +148,18 @@ export async function receiveLightning(page: Page, isMobile: boolean, sats: numb
 }
 
 async function navigateToSettings(page: Page): Promise<void> {
-  const walletTab = page.getByTestId('tab-wallet')
-  if (await walletTab.isVisible().catch(() => false)) {
-    await walletTab.click()
+  // If on a settings sub-page, go back until we reach the settings menu
+  const backBtn = page.getByLabel('Go back')
+  while (await backBtn.isVisible({ timeout: 300 }).catch(() => false)) {
+    await backBtn.click()
+    await page.waitForTimeout(200)
   }
-  await page.getByTestId('tab-settings').click()
+  // If on wallet/apps, open settings; if already on settings menu, this is a no-op
+  const settingsBtn = page.getByTestId('tab-settings')
+  const label = await settingsBtn.getAttribute('aria-label').catch(() => '')
+  if (label === 'Settings') {
+    await settingsBtn.click()
+  }
 }
 
 async function getNsec(page: Page): Promise<string> {


### PR DESCRIPTION
## Summary
- Hide the global settings gear/X button on settings sub-pages (Vtxos, Backup, General, etc.) where it overlapped the page-specific Header aux button (e.g. "Coins" toggle)
- The button now only shows on root pages (Wallet, Apps, Settings Menu)
- Update e2e tests to use back navigation (`Go back` aria-label) instead of `tab-settings` click on settings sub-pages
- Update `navigateToSettings` utility to handle being called from a settings sub-page

## Test plan
- [ ] Verify "Coins" button is accessible on the Vtxos/Next Renewal page
- [ ] Verify settings gear still works from Wallet and Apps pages
- [ ] Verify settings X (close) still works from Settings Menu
- [ ] Verify all e2e tests pass with back navigation changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Clarified header settings button display logic for improved readability.

* **Tests**
  * Made end-to-end tests more robust: added explicit waits for wallet readiness, replaced direct tab clicks with back-navigation where appropriate, and strengthened test utilities to reliably reach settings before assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->