### PR TITLE
fix: add bottom padding to footer to clear pill navbar

### DIFF
--- a/src/components/ButtonsOnBottom.tsx
+++ b/src/components/ButtonsOnBottom.tsx
@@ -16,7 +16,7 @@ export default function ButtonsOnBottom({ bordered, children }: ButtonsOnBottomP
   return (
     <>
       {bordered ? <hr style={borderStyle} /> : null}
-      <IonFooter className='ion-padding ion-no-border'>
+      <IonFooter className='ion-padding ion-no-border' style={{ paddingBottom: '80px' }}>
         <FlexCol gap='0' strech>
           {children}
         </FlexCol>


### PR DESCRIPTION
## Summary
- The floating pill navbar overlaps `ButtonsOnBottom` content (e.g. Share button on Receive page)
- Adds 80px `padding-bottom` to `IonFooter` so buttons remain visible above the navbar

## Test plan
- [ ] Open Receive page, verify Share button is fully visible above the pill navbar
- [ ] Check other pages with bottom buttons (Send, etc.) don't overlap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted footer spacing to improve visual layout and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->