### PR TITLE
Fix service worker update

### DIFF
--- a/public/wallet-service-worker.mjs
+++ b/public/wallet-service-worker.mjs
@@ -55817,7 +55817,7 @@ var gN = (c) => {
     }));
   }
 };
-const xN = "4cb4802d-dirty", TN = new Kd(), bN = new Hd(), BN = new tw();
+const xN = "d5cd1d99-dirty", TN = new Kd(), bN = new Hd(), BN = new tw();
 self.addEventListener("message", (c) => {
   c.data?.type === "SKIP_WAITING" && c.waitUntil(self.skipWaiting());
 });
@@ -55828,15 +55828,17 @@ const IN = new oP(TN, bN, {
 IN.start().catch(console.error);
 const fw = "arkade-cache-v1";
 self.addEventListener("install", (c) => {
-  self.skipWaiting(), c.waitUntil(caches.open(fw)), console.log(`Service worker installed ${xN}`);
+  c.waitUntil(
+    caches.open(fw).then(() => (console.log(`Activating service worker ${xN}`), self.skipWaiting()))
+  );
 });
 self.addEventListener("activate", (c) => {
-  c.waitUntil(
+  c.waitUntil(self.clients.claim()), c.waitUntil(
     caches.keys().then((a) => Promise.all(
       a.map((l) => {
         if (l !== fw)
           return caches.delete(l);
       })
     ))
-  ), self.clients.claim();
+  );
 });

--- a/public/wallet-service-worker.mjs
+++ b/public/wallet-service-worker.mjs
@@ -55817,7 +55817,7 @@ var gN = (c) => {
     }));
   }
 };
-const xN = "5cd4082c", TN = new Kd(), bN = new Hd(), BN = new tw();
+const xN = "4cb4802d-dirty", TN = new Kd(), bN = new Hd(), BN = new tw();
 self.addEventListener("message", (c) => {
   c.data?.type === "SKIP_WAITING" && c.waitUntil(self.skipWaiting());
 });
@@ -55828,7 +55828,7 @@ const IN = new oP(TN, bN, {
 IN.start().catch(console.error);
 const fw = "arkade-cache-v1";
 self.addEventListener("install", (c) => {
-  c.waitUntil(caches.open(fw)), self.skipWaiting(), console.log(`Service worker installed ${xN}`);
+  self.skipWaiting(), c.waitUntil(caches.open(fw)), console.log(`Service worker installed ${xN}`);
 });
 self.addEventListener("activate", (c) => {
   c.waitUntil(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,17 @@ if (shouldInitializeSentry(sentryDsn)) {
   })
 }
 
+// check if there's a service worker controlling the page
+const previousSW = navigator.serviceWorker.controller
+
+// This fires when the service worker controlling this page changes,
+// eg a new worker has skipped waiting and become the new active worker.
+// We reload the page to have the new service worker properly initialized.
+navigator.serviceWorker.addEventListener('controllerchange', () => {
+  // don't reload on fresh install, only when the service worker changes (eg update)
+  if (previousSW) window.location.reload()
+})
+
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 
 root.render(

--- a/src/wallet-service-worker.ts
+++ b/src/wallet-service-worker.ts
@@ -32,18 +32,23 @@ declare const self: ServiceWorkerGlobalScope
 // only called once per service worker. If you alter your
 // service worker script the browser considers it a
 // different service worker, and it'll get its own install event.
-//
-// skipWaiting() must be called before or during waiting
-//
-// install event: activate service worker immediately
 self.addEventListener('install', (event: ExtendableEvent) => {
-  self.skipWaiting() // activate service worker immediately
-  event.waitUntil(caches.open(CACHE_NAME))
-  console.log(`Service worker installed ${gitCommit}`)
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(() => {
+      // activate service worker immediately
+      console.log(`Activating service worker ${gitCommit}`)
+      return self.skipWaiting()
+    }),
+  )
 })
 
 // activate event: clean up old caches
 self.addEventListener('activate', (event: ExtendableEvent) => {
+  // claim clients immediately so that the new
+  // service worker starts controlling the page
+  event.waitUntil(self.clients.claim())
+
+  // delete old caches
   event.waitUntil(
     caches.keys().then((cacheNames) => {
       return Promise.all(
@@ -54,7 +59,6 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
       )
     }),
   )
-  self.clients.claim() // take control of clients immediately
 })
 
 // we can adopt two different strategies for caching:

--- a/src/wallet-service-worker.ts
+++ b/src/wallet-service-worker.ts
@@ -33,10 +33,12 @@ declare const self: ServiceWorkerGlobalScope
 // service worker script the browser considers it a
 // different service worker, and it'll get its own install event.
 //
+// skipWaiting() must be called before or during waiting
+//
 // install event: activate service worker immediately
 self.addEventListener('install', (event: ExtendableEvent) => {
-  event.waitUntil(caches.open(CACHE_NAME))
   self.skipWaiting() // activate service worker immediately
+  event.waitUntil(caches.open(CACHE_NAME))
   console.log(`Service worker installed ${gitCommit}`)
 })
 


### PR DESCRIPTION
- Fixes a bug where we were calling skipWaiting() after waiting ([TIL](https://web.dev/articles/service-worker-lifecycle#:~:text=It%20doesn%27t%20really%20matter%20when%20you%20call%20skipWaiting()%2C%20as%20long%20as%20it%27s%20during%20or%20before%20waiting))
- Fixes bug where the app was not initialising the service worker after it's update

@louisinger @pietro909 please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic page reload when a new service worker takes control to ensure users run the latest code.

* **Bug Fixes**
  * Improved service worker install/activation sequencing for more reliable updates and immediate control of open pages.
  * Cache cleanup preserved alongside the new activation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->