### PR TITLE
Rename instances of "ark" to "arkade" for clarity

### DIFF
--- a/src/components/ExpandAddresses.tsx
+++ b/src/components/ExpandAddresses.tsx
@@ -97,7 +97,7 @@ export default function ExpandAddresses({
           <FlexCol gap='0.21rem'>
             {bip21uri ? <ExpandLine testId='bip21' title='BIP21' value={bip21uri} /> : null}
             {boardingAddr ? <ExpandLine testId='btc' title='BTC address' value={boardingAddr} /> : null}
-            {offchainAddr ? <ExpandLine testId='ark' title='Ark address' value={offchainAddr} /> : null}
+            {offchainAddr ? <ExpandLine testId='ark' title='Arkade address' value={offchainAddr} /> : null}
             {invoice ? <ExpandLine testId='invoice' title='Lightning invoice' value={invoice} /> : null}
           </FlexCol>
         </div>

--- a/src/screens/Apps/Lendasat/Index.tsx
+++ b/src/screens/Apps/Lendasat/Index.tsx
@@ -117,7 +117,7 @@ export default function AppLendasat() {
 
           switch (addressType) {
             case AddressType.ARK:
-              if (!arkAddress) throw new Error('Ark address not yet loaded')
+              if (!arkAddress) throw new Error('Arkade address not yet loaded')
               return arkAddress
 
             case AddressType.BITCOIN:

--- a/src/screens/Apps/Lendaswap/Index.tsx
+++ b/src/screens/Apps/Lendaswap/Index.tsx
@@ -23,7 +23,7 @@ export default function AppLendaswap() {
           const addresses = await getReceivingAddresses(svcWallet)
           setArkAddress(addresses.offchainAddr)
         } catch (error) {
-          console.error('Failed to load Ark address:', error)
+          console.error('Failed to load Arkade address:', error)
         }
       }
     }
@@ -61,7 +61,7 @@ export default function AppLendaswap() {
             case AddressType.LOAN_ASSET:
               throw Error('Address type not supported')
             case AddressType.ARK:
-              if (!arkAddress) throw new Error('Ark address not yet loaded')
+              if (!arkAddress) throw new Error('Arkade address not yet loaded')
               return arkAddress
           }
         },

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -245,7 +245,7 @@ export default function ReceiveQRCode() {
                 onClick={setQrCodeValue}
               />
               {swapsTimedOut && !invoice && !isAssetReceive ? (
-                <WarningBox text='Lightning is temporarily unavailable. This QR code only supports Ark and on-chain payments.' />
+                <WarningBox text='Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.' />
               ) : null}
             </FlexCol>
           ) : (

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -126,7 +126,7 @@ export default function SendDetails() {
     if (!details || !svcWallet) return
     if (!isAssetSend && (!details.total || !details.satoshis)) return
     if (isAssetSend && !arkAddress) {
-      setError('Assets can only be sent to Ark addresses')
+      setError('Assets can only be sent to Arkade addresses')
       return
     }
     setSending(true)

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -53,7 +53,7 @@ export default function SendDetails() {
       const feeInSats = defaultFee
       setDetails({
         destination,
-        direction: 'Paying inside the Ark',
+        direction: 'Paying inside Arkade',
         fees: feeInSats,
         satoshis: 0,
         total: feeInSats,
@@ -72,7 +72,7 @@ export default function SendDetails() {
             : ''
     const direction =
       destination === arkAddress
-        ? 'Paying inside the Ark'
+        ? 'Paying inside Arkade'
         : destination === invoice
           ? 'Swapping to Lightning'
           : pendingSwap?.type === 'chain'
@@ -164,7 +164,7 @@ export default function SendDetails() {
           details?.destination === invoice ? (
             <Loading text='Paying to Lightning' />
           ) : details?.destination === arkAddress ? (
-            <Loading text='Paying inside the Ark' />
+            <Loading text='Paying inside Arkade' />
           ) : (
             <WaitingForRound />
           )

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -217,7 +217,7 @@ export default function SendForm() {
       }
       if (isLightningInvoice(lowerCaseData)) {
         if (isAssetSend) {
-          return setError('Assets can only be sent to Ark addresses')
+          return setError('Assets can only be sent to Arkade addresses')
         }
         if (!connected) {
           setError('Lightning swaps not enabled')
@@ -232,7 +232,7 @@ export default function SendForm() {
       }
       if (isBTCAddress(recipient)) {
         if (isAssetSend) {
-          return setError('Assets can only be sent to Ark addresses')
+          return setError('Assets can only be sent to Arkade addresses')
         }
         return setState({ ...sendInfo, address: recipient, arkAddress: '' })
       }
@@ -435,7 +435,7 @@ export default function SendForm() {
     setSelectedAsset(asset)
     if (asset) {
       if (isBTCAddress(recipient)) {
-        return setError('Assets can only be sent to Ark addresses')
+        return setError('Assets can only be sent to Arkade addresses')
       }
       setState({ ...sendInfo, address: '', assets: [{ assetId: asset.assetId, amount: 0 }], satoshis: 0 })
       setAmount(undefined)
@@ -462,7 +462,7 @@ export default function SendForm() {
           // Fetch Ark address instead of Lightning invoice
           const arkResponse = await fetchArkAddress(sendInfo.lnUrl)
           if (!isArkAddress(arkResponse.address)) {
-            handleError('Invalid Ark address received from LNURL')
+            handleError('Invalid Arkade address received from LNURL')
             return
           }
           setState({ ...sendInfo, arkAddress: arkResponse.address, invoice: undefined })

--- a/src/test/screens/wallet/receive-qrcode.test.tsx
+++ b/src/test/screens/wallet/receive-qrcode.test.tsx
@@ -107,7 +107,9 @@ describe('Receive QR Code screen', () => {
     expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
     // Should NOT show the LN unavailable warning (constraint 1a)
     expect(
-      screen.queryByText('Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.'),
+      screen.queryByText(
+        'Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.',
+      ),
     ).not.toBeInTheDocument()
   })
 
@@ -134,7 +136,9 @@ describe('Receive QR Code screen', () => {
     expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
     // Should show the warning (constraint 2a)
     expect(
-      screen.getByText('Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.'),
+      screen.getByText(
+        'Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.',
+      ),
     ).toBeInTheDocument()
   })
 
@@ -194,7 +198,9 @@ describe('Receive QR Code screen', () => {
     expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
     // Should show the warning
     expect(
-      screen.getByText('Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.'),
+      screen.getByText(
+        'Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.',
+      ),
     ).toBeInTheDocument()
 
     vi.useRealTimers()

--- a/src/test/screens/wallet/receive-qrcode.test.tsx
+++ b/src/test/screens/wallet/receive-qrcode.test.tsx
@@ -107,7 +107,7 @@ describe('Receive QR Code screen', () => {
     expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
     // Should NOT show the LN unavailable warning (constraint 1a)
     expect(
-      screen.queryByText('Lightning is temporarily unavailable. This QR code only supports Ark and on-chain payments.'),
+      screen.queryByText('Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.'),
     ).not.toBeInTheDocument()
   })
 
@@ -134,7 +134,7 @@ describe('Receive QR Code screen', () => {
     expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
     // Should show the warning (constraint 2a)
     expect(
-      screen.getByText('Lightning is temporarily unavailable. This QR code only supports Ark and on-chain payments.'),
+      screen.getByText('Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.'),
     ).toBeInTheDocument()
   })
 
@@ -194,7 +194,7 @@ describe('Receive QR Code screen', () => {
     expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
     // Should show the warning
     expect(
-      screen.getByText('Lightning is temporarily unavailable. This QR code only supports Ark and on-chain payments.'),
+      screen.getByText('Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.'),
     ).toBeInTheDocument()
 
     vi.useRealTimers()


### PR DESCRIPTION
Changes various strings and error messages to refer to "Arkade address", "Paying inside Arkade", etc.

Does not change "Ark notes" terminology or test comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated product naming from "Ark" to "Arkade" across the app: UI labels, error messages, warnings (including QR/receive flow), send/receive screens, and tests to ensure consistent user-facing branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->