### PR TITLE
feat(receive): redesign receive flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,6 +130,8 @@ export default function App() {
     // avoid redirect if the user is still setting up the wallet
     if (initInfo.password || initInfo.privateKey) return
     if (!walletLoaded) return navigate(Pages.Loading)
+    // dev auto-init: stay on loading screen while VITE_DEV_NSEC initializes the wallet
+    if (import.meta.env.DEV && import.meta.env.VITE_DEV_NSEC && !initialized) return
     if (!wallet.pubkey) return navigate(Pages.Init)
     if (!initialized) return navigate(Pages.Unlock)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- navigate is unstable (recreated every render), including it causes an infinite redirect loop

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -4,11 +4,12 @@ import Refresher from './Refresher'
 
 interface ContentProps {
   children: ReactNode
+  noFade?: boolean
 }
 
-export default function Content({ children }: ContentProps) {
+export default function Content({ children, noFade }: ContentProps) {
   return (
-    <IonContent>
+    <IonContent className={noFade ? 'no-content-fade' : undefined}>
       <Refresher />
       <div className='content-shell'>{children}</div>
     </IonContent>

--- a/src/components/QrCode.tsx
+++ b/src/components/QrCode.tsx
@@ -1,31 +1,220 @@
+import { useMemo, useRef } from 'react'
 import encodeQR from 'qr'
 import FlexCol from './FlexCol'
+import { useReducedMotion } from '../hooks/useReducedMotion'
 
 interface QrCodeProps {
   value: string
 }
 
+// Finder pattern locations (7x7 squares at three corners)
+function isFinderPattern(row: number, col: number, size: number): boolean {
+  if (row < 7 && col < 7) return true
+  if (row < 7 && col >= size - 7) return true
+  if (row >= size - 7 && col < 7) return true
+  return false
+}
+
+// Check if a module is in the logo zone (center area to clear for logo)
+function isLogoZone(row: number, col: number, size: number, logoModules: number): boolean {
+  const center = size / 2
+  const half = logoModules / 2
+  return row >= center - half && row < center + half && col >= center - half && col < center + half
+}
+
+// Render finder pattern with rounded corners
+function renderFinderPattern(
+  originX: number,
+  originY: number,
+  moduleSize: number,
+  fgColor: string,
+  bgColor: string,
+): JSX.Element[] {
+  const r = moduleSize * 0.6
+  const elements: JSX.Element[] = []
+  const key = `fp-${originX}-${originY}`
+
+  elements.push(
+    <rect
+      key={`${key}-outer`}
+      x={originX}
+      y={originY}
+      width={moduleSize * 7}
+      height={moduleSize * 7}
+      rx={r * 2.5}
+      ry={r * 2.5}
+      fill={fgColor}
+    />,
+  )
+
+  elements.push(
+    <rect
+      key={`${key}-inner`}
+      x={originX + moduleSize}
+      y={originY + moduleSize}
+      width={moduleSize * 5}
+      height={moduleSize * 5}
+      rx={r * 1.8}
+      ry={r * 1.8}
+      fill={bgColor}
+    />,
+  )
+
+  elements.push(
+    <rect
+      key={`${key}-center`}
+      x={originX + moduleSize * 2}
+      y={originY + moduleSize * 2}
+      width={moduleSize * 3}
+      height={moduleSize * 3}
+      rx={r * 1.2}
+      ry={r * 1.2}
+      fill={fgColor}
+    />,
+  )
+
+  return elements
+}
+
 export default function QrCode({ value }: QrCodeProps) {
-  // encode value to a gif
-  const qrGifDataUrl = (text: string) => {
-    const gifBytes = encodeQR(text, 'gif', { scale: 7 })
-    const blob = new Blob([new Uint8Array(gifBytes)], { type: 'image/gif' })
-    return URL.createObjectURL(blob)
-  }
+  const prefersReduced = useReducedMotion()
+  const prevMatrixRef = useRef<boolean[][] | null>(null)
+  const renderCountRef = useRef(0)
+
+  const svgContent = useMemo(() => {
+    if (!value) return null
+
+    const matrix = encodeQR(value, 'raw', { ecc: 'medium', border: 0 })
+    const size = matrix.length
+    const moduleSize = 10
+    const quietZone = moduleSize * 2
+    const svgSize = size * moduleSize + quietZone * 2
+
+    const fgColor = 'var(--black)'
+    const bgColor = 'var(--ion-background-color, #fff)'
+    const logoColor = 'var(--logo-color)'
+
+    const logoModules = Math.ceil(size * 0.2)
+    const logoZoneSize = logoModules % 2 === 0 ? logoModules + 1 : logoModules
+
+    const prevMatrix = prevMatrixRef.current
+    const isUpdate = prevMatrix !== null && prevMatrix.length === size
+    const shouldAnimate = isUpdate && !prefersReduced
+    renderCountRef.current++
+
+    const elements: JSX.Element[] = []
+
+    // Background
+    elements.push(<rect key='bg' x={0} y={0} width={svgSize} height={svgSize} rx={moduleSize * 2} fill={bgColor} />)
+
+    // Data modules
+    const dotRadius = moduleSize * 0.42
+    const centerRow = size / 2
+    const centerCol = size / 2
+
+    for (let row = 0; row < size; row++) {
+      for (let col = 0; col < size; col++) {
+        if (isFinderPattern(row, col, size)) continue
+        if (isLogoZone(row, col, size, logoZoneSize)) continue
+        if (!matrix[row][col]) continue
+
+        const cx = quietZone + col * moduleSize + moduleSize / 2
+        const cy = quietZone + row * moduleSize + moduleSize / 2
+
+        // Determine if this dot is new/changed (animate it)
+        const isNew = shouldAnimate && (!prevMatrix[row] || !prevMatrix[row][col])
+        if (isNew) {
+          const dist = Math.sqrt((row - centerRow) ** 2 + (col - centerCol) ** 2)
+          const delay = Math.round(dist * 6)
+          elements.push(
+            <circle
+              key={`d-${row}-${col}-${renderCountRef.current}`}
+              cx={cx}
+              cy={cy}
+              r={dotRadius}
+              fill={fgColor}
+              style={{
+                animation: `qr-dot-in 250ms cubic-bezier(0.23, 1, 0.32, 1) ${delay}ms both`,
+                transformOrigin: `${cx}px ${cy}px`,
+              }}
+            />,
+          )
+        } else {
+          elements.push(<circle key={`d-${row}-${col}`} cx={cx} cy={cy} r={dotRadius} fill={fgColor} />)
+        }
+      }
+    }
+
+    // Save matrix for next comparison
+    prevMatrixRef.current = matrix.map((row) => [...row])
+
+    // Finder patterns
+    const finderPositions = [
+      [0, 0],
+      [0, size - 7],
+      [size - 7, 0],
+    ]
+    for (const [row, col] of finderPositions) {
+      const x = quietZone + col * moduleSize
+      const y = quietZone + row * moduleSize
+      elements.push(...renderFinderPattern(x, y, moduleSize, fgColor, bgColor))
+    }
+
+    // Logo overlay
+    const centerX = quietZone + (size * moduleSize) / 2
+    const centerY = quietZone + (size * moduleSize) / 2
+    const logoCircleR = logoZoneSize * moduleSize * 0.52
+
+    elements.push(<circle key='logo-bg' cx={centerX} cy={centerY} r={logoCircleR} fill={bgColor} />)
+
+    const logoInnerSize = logoCircleR * 1.2
+    const logoOffsetX = centerX - logoInnerSize / 2
+    const logoOffsetY = centerY - logoInnerSize / 2
+    const scale = logoInnerSize / 35
+
+    elements.push(
+      <g key='logo' transform={`translate(${logoOffsetX}, ${logoOffsetY}) scale(${scale})`}>
+        <path d='M0 8.75L8.75 0H26.25L35 8.75V17.5H26.25V8.75H8.75V17.5H2.45431e-07L0 8.75Z' fill={logoColor} />
+        <path d='M8.75 26.25V17.5H26.25V26.25H8.75Z' fill={logoColor} />
+        <path d='M8.75 26.25H2.45431e-07V35H8.75V26.25Z' fill={logoColor} />
+        <path d='M26.25 26.25V35H35V26.25H26.25Z' fill={logoColor} />
+      </g>,
+    )
+
+    return (
+      <svg
+        viewBox={`0 0 ${svgSize} ${svgSize}`}
+        width='100%'
+        height='100%'
+        xmlns='http://www.w3.org/2000/svg'
+        style={{ display: 'block' }}
+      >
+        <style>{`
+          @keyframes qr-dot-in {
+            from { transform: scale(0); opacity: 0; }
+            to { transform: scale(1); opacity: 1; }
+          }
+          @media (prefers-reduced-motion: reduce) {
+            circle { animation: none !important; }
+          }
+        `}</style>
+        {elements}
+      </svg>
+    )
+  }, [value, prefersReduced])
 
   return (
     <FlexCol centered>
-      {value ? (
+      {svgContent ? (
         <div
           style={{
-            backgroundColor: 'white',
-            borderRadius: '0.5rem',
-            padding: '0.5rem',
-            maxWidth: '100%',
-            width: '300px',
+            borderRadius: '1rem',
+            maxWidth: '340px',
+            overflow: 'hidden',
+            width: '100%',
           }}
         >
-          <img src={qrGifDataUrl(value)} alt='QR Code' style={{ width: '100%' }} />
+          {svgContent}
         </div>
       ) : null}
     </FlexCol>

--- a/src/components/SheetModal.tsx
+++ b/src/components/SheetModal.tsx
@@ -1,5 +1,7 @@
 import { IonModal } from '@ionic/react'
+import { useContext } from 'react'
 import CloseIcon from '../icons/Close'
+import { NavigationContext, Tabs } from '../providers/navigation'
 
 interface SheetModalProps {
   children?: React.ReactNode
@@ -8,6 +10,9 @@ interface SheetModalProps {
 }
 
 export default function SheetModal({ children, isOpen, onClose }: SheetModalProps) {
+  const { tab } = useContext(NavigationContext)
+  const hasNavbar = [Tabs.Wallet, Tabs.Apps].includes(tab)
+
   const outerStyle: React.CSSProperties = {
     maxWidth: '640px',
     margin: '0 auto',
@@ -20,7 +25,7 @@ export default function SheetModal({ children, isOpen, onClose }: SheetModalProp
     borderRadius: '1rem',
     height: '100%',
     padding: '1rem',
-    paddingBottom: '2rem',
+    paddingBottom: hasNavbar ? 'var(--pill-navbar-spacer)' : '2rem',
     width: '100%',
     position: 'relative',
   }

--- a/src/components/SheetModal.tsx
+++ b/src/components/SheetModal.tsx
@@ -2,6 +2,7 @@ import { IonModal } from '@ionic/react'
 import { useContext } from 'react'
 import CloseIcon from '../icons/Close'
 import { NavigationContext, Tabs } from '../providers/navigation'
+import { hapticLight } from '../lib/haptics'
 
 interface SheetModalProps {
   children?: React.ReactNode
@@ -13,6 +14,11 @@ export default function SheetModal({ children, isOpen, onClose }: SheetModalProp
   const { tab } = useContext(NavigationContext)
   const hasNavbar = [Tabs.Wallet, Tabs.Apps].includes(tab)
 
+  const handleClose = () => {
+    hapticLight()
+    onClose()
+  }
+
   const outerStyle: React.CSSProperties = {
     maxWidth: '640px',
     margin: '0 auto',
@@ -21,31 +27,47 @@ export default function SheetModal({ children, isOpen, onClose }: SheetModalProp
 
   const innerStyle: React.CSSProperties = {
     backgroundColor: 'var(--ion-background-color)',
-    borderTop: '1px solid var(--dark50)',
-    borderRadius: '1rem',
+    borderRadius: '1.5rem 1.5rem 0 0',
+    boxShadow: '0 -8px 32px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.04)',
     height: '100%',
-    padding: '1rem',
+    padding: '1.25rem',
+    paddingTop: '0.75rem',
     paddingBottom: hasNavbar ? 'var(--pill-navbar-spacer)' : '2rem',
     width: '100%',
     position: 'relative',
   }
 
+  const handleStyle: React.CSSProperties = {
+    backgroundColor: 'var(--dark20)',
+    borderRadius: '2px',
+    height: '4px',
+    margin: '0 auto 1rem',
+    width: '36px',
+  }
+
   const closeButtonStyle: React.CSSProperties = {
-    background: 'none',
+    alignItems: 'center',
+    background: 'var(--dark05)',
     border: 'none',
+    borderRadius: '50%',
     color: 'var(--ion-text-color)',
     cursor: 'pointer',
+    display: 'flex',
+    height: '32px',
+    justifyContent: 'center',
     padding: 0,
     position: 'absolute',
     right: '1rem',
     top: '1rem',
+    width: '32px',
   }
 
   return (
-    <IonModal initialBreakpoint={1} isOpen={isOpen} onDidDismiss={onClose}>
+    <IonModal initialBreakpoint={1} backdropBreakpoint={0} isOpen={isOpen} onDidDismiss={handleClose}>
       <div style={outerStyle}>
         <div style={innerStyle}>
-          <button type='button' style={closeButtonStyle} onClick={onClose} aria-label='Close'>
+          <div style={handleStyle} />
+          <button type='button' style={closeButtonStyle} onClick={handleClose} aria-label='Close'>
             <CloseIcon />
           </button>
           {children}

--- a/src/ionic.css
+++ b/src/ionic.css
@@ -255,6 +255,11 @@ ion-app.has-pill-navbar ion-content::part(scroll) {
   mask-size: 100% 100%;
 }
 
+ion-app.has-pill-navbar ion-content.no-content-fade::part(scroll) {
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
 ion-checkbox {
   --border-color: var(--dark10);
   --border-color-checked: var(--ion-color-danger);

--- a/src/ionic.css
+++ b/src/ionic.css
@@ -293,14 +293,19 @@ ion-action-sheet.my-ion-action-sheet {
   --width: 100%;
 }
 
+ion-modal {
+  z-index: 200 !important;
+  --backdrop-opacity: 0.4;
+}
+
 ion-modal::part(content) {
   --background: transparent;
-  --border-radius: 1rem;
+  --border-radius: 1.5rem 1.5rem 0 0;
   --height: auto;
   --max-width: 100%;
   --width: 100%;
   position: absolute;
-  bottom: -1rem;
+  bottom: 0;
 }
 
 ion-select {

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -30,6 +30,7 @@ import { arkNoteInUrl } from '../lib/arknote'
 import { deepLinkInUrl } from '../lib/deepLink'
 import { consoleError } from '../lib/logs'
 import { Tx, Vtxo, Wallet } from '../lib/types'
+import { nsecToPrivateKey } from '../lib/privateKey'
 import { calcBatchLifetimeMs, calcNextRollover } from '../lib/wallet'
 import { hex } from '@scure/base'
 import * as secp from '@noble/secp256k1'
@@ -130,6 +131,25 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   }
 
   // wallet is read synchronously in useState initializer above
+
+  // dev-only: auto-initialize wallet from VITE_DEV_NSEC, bypassing onboarding and unlock
+  useEffect(() => {
+    if (!import.meta.env.DEV || !import.meta.env.VITE_DEV_NSEC) return
+    if (initialized) return
+    if (!aspInfo.url) return
+
+    const autoInit = async () => {
+      try {
+        const privateKey = nsecToPrivateKey(import.meta.env.VITE_DEV_NSEC)
+        await initWallet(privateKey)
+      } catch (err) {
+        consoleError(err, 'Dev auto-init failed')
+      }
+    }
+
+    autoInit()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [aspInfo.url, initialized])
 
   // reload wallet as soon as we have a service worker wallet available
   useEffect(() => {

--- a/src/screens/Wallet/Index.tsx
+++ b/src/screens/Wallet/Index.tsx
@@ -58,7 +58,7 @@ export default function Wallet() {
 
   const handleReceive = () => {
     setRecvInfo(emptyRecvInfo)
-    navigate(Pages.ReceiveAmount)
+    navigate(Pages.ReceiveQRCode)
   }
 
   const handleSend = () => {

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -289,20 +289,41 @@ export default function ReceiveQRCode() {
   }
 
   const handleAmountConfirm = () => {
-    setRecvInfo({ ...recvInfo, satoshis: amountInput })
-    setShowAmountSheet(false)
     setShowKeys(false)
+    setShowAmountSheet(false)
+    setRecvInfo({ ...recvInfo, satoshis: amountInput })
+  }
+
+  const handleAmountClear = () => {
+    setAmountInput(0)
+    setAmountTextValue('')
+    setShowKeys(false)
+    setShowAmountSheet(false)
+    setRecvInfo({ ...recvInfo, satoshis: 0 })
   }
 
   const data = { title: 'Receive', text: qrCodeValue }
   const shareDisabled = !canBrowserShareData(data) || sharing || hasError || noPaymentMethods
 
-  // Mobile keyboard for amount sheet
+  // Mobile keyboard — bypass sheet on save, go straight to QR
   if (showKeys) {
-    return <Keyboard back={() => setShowKeys(false)} hideBalance onSats={handleAmountChange} value={amountInput} />
+    return (
+      <Keyboard
+        back={() => {
+          setShowKeys(false)
+          setShowAmountSheet(false)
+        }}
+        hideBalance
+        onSats={(sats) => {
+          setAmountInput(sats)
+          setRecvInfo({ ...recvInfo, satoshis: sats })
+        }}
+        value={amountInput}
+      />
+    )
   }
 
-  const amountLabel = satoshis ? `${prettyNumber(satoshis)} sats` : 'Add amount'
+  const amountLabel = satoshis ? 'Edit amount' : 'Add amount'
 
   return (
     <>
@@ -317,13 +338,19 @@ export default function ReceiveQRCode() {
             <div>No valid payment methods available for this amount</div>
           ) : (
             <FlexCol centered>
-              <QrCode value={qrCodeValue} />
-
-              {satoshis > 0 ? (
-                <div style={{ fontSize: '13px', color: 'var(--dark50)', textAlign: 'center' }}>
-                  Requesting {prettyNumber(satoshis)} sats
-                </div>
-              ) : null}
+              <div>
+                <QrCode value={qrCodeValue} />
+                {satoshis > 0 ? (
+                  <div style={{ fontSize: '14px', color: 'var(--dark50)', textAlign: 'center', marginTop: '0.5rem' }}>
+                    Requesting {prettyNumber(satoshis)} sats
+                  </div>
+                ) : null}
+                {(!satoshis || satoshis < 500) && !isAssetReceive ? (
+                  <div style={{ fontSize: '13px', color: 'var(--dark50)', textAlign: 'center', marginTop: '0.25rem' }}>
+                    500 sats min for Lightning
+                  </div>
+                ) : null}
+              </div>
 
               {swapsTimedOut && !invoice && !isAssetReceive ? (
                 <WarningBox text='Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.' />
@@ -363,6 +390,7 @@ export default function ReceiveQRCode() {
             onEnter={handleAmountConfirm}
           />
           <Button label='Set amount' onClick={handleAmountConfirm} disabled={!amountInput} />
+          {satoshis > 0 ? <Button label='Clear amount' onClick={handleAmountClear} secondary /> : null}
         </FlexCol>
       </SheetModal>
 

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -2,7 +2,6 @@ import { useContext, useEffect, useState } from 'react'
 import Button from '../../../components/Button'
 import Padded from '../../../components/Padded'
 import QrCode from '../../../components/QrCode'
-import ButtonsOnBottom from '../../../components/ButtonsOnBottom'
 import { FlowContext } from '../../../providers/flow'
 import { NavigationContext, Pages } from '../../../providers/navigation'
 import { WalletContext } from '../../../providers/wallet'
@@ -11,8 +10,8 @@ import Header from '../../../components/Header'
 import Content from '../../../components/Content'
 import { consoleError } from '../../../lib/logs'
 import { canBrowserShareData, shareData } from '../../../lib/share'
-import ExpandAddresses from '../../../components/ExpandAddresses'
 import FlexCol from '../../../components/FlexCol'
+import FlexRow from '../../../components/FlexRow'
 import { LimitsContext } from '../../../providers/limits'
 import { Asset, Coin, ExtendedVirtualCoin } from '@arkade-os/sdk'
 import Loading from '../../../components/Loading'
@@ -23,8 +22,28 @@ import { enableChainSwapsReceive } from '../../../lib/constants'
 import { centsToUnits } from '../../../lib/assets'
 import WarningBox from '../../../components/Warning'
 import ErrorMessage from '../../../components/Error'
+import { getReceivingAddresses } from '../../../lib/asp'
+import { extractError } from '../../../lib/error'
+import InputAmount from '../../../components/InputAmount'
+import Keyboard from '../../../components/Keyboard'
+import SheetModal from '../../../components/SheetModal'
+import Shadow from '../../../components/Shadow'
+import Text, { TextSecondary } from '../../../components/Text'
+import { copyToClipboard } from '../../../lib/clipboard'
+import { useIonToast } from '@ionic/react'
+import { copiedToClipboard } from '../../../lib/toast'
+import { prettyLongText, prettyNumber } from '../../../lib/format'
+import CopyIcon from '../../../icons/Copy'
+import CheckMarkIcon from '../../../icons/CheckMark'
+import { hapticSubtle } from '../../../lib/haptics'
+import { isMobileBrowser } from '../../../lib/browser'
+import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import Focusable from '../../../components/Focusable'
 
 export default function ReceiveQRCode() {
+  const { useFiat } = useContext(ConfigContext)
+  const { toFiat } = useContext(FiatContext)
   const { navigate } = useContext(NavigationContext)
   const { recvInfo, setRecvInfo } = useContext(FlowContext)
   const { notifyPaymentReceived } = useContext(NotificationsContext)
@@ -33,9 +52,22 @@ export default function ReceiveQRCode() {
   const { validBtcToArk, validLnSwap, validUtxoTx, validVtxoTx, utxoTxsAllowed, vtxoTxsAllowed } =
     useContext(LimitsContext)
 
-  const [sharing, setSharing] = useState(false)
+  const [present] = useIonToast()
 
-  // manage all possible receive methods
+  const [sharing, setSharing] = useState(false)
+  const [addressesLoaded, setAddressesLoaded] = useState(false)
+
+  // Amount sheet state
+  const [showAmountSheet, setShowAmountSheet] = useState(false)
+  const [showKeys, setShowKeys] = useState(false)
+  const [amountInput, setAmountInput] = useState(0)
+  const [amountTextValue, setAmountTextValue] = useState('')
+
+  // Copy address sheet state
+  const [showCopySheet, setShowCopySheet] = useState(false)
+  const [copied, setCopied] = useState('')
+
+  // Receive methods
   const { boardingAddr, offchainAddr, satoshis, assetId, addressError } = recvInfo
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
   const isAssetReceive = assetId && assetId !== ''
@@ -50,6 +82,28 @@ export default function ReceiveQRCode() {
   const [qrCodeValue, setQrCodeValue] = useState('')
   const [bip21Uri, setBip21Uri] = useState('')
   const [invoice, setInvoice] = useState('')
+
+  // Fetch addresses on mount
+  useEffect(() => {
+    if (!svcWallet) return
+    if (boardingAddr && offchainAddr) {
+      setAddressesLoaded(true)
+      return
+    }
+    getReceivingAddresses(svcWallet)
+      .then(({ offchainAddr, boardingAddr }) => {
+        if (!offchainAddr) throw 'Unable to get offchain address'
+        if (!boardingAddr) throw 'Unable to get boarding address'
+        setRecvInfo({ ...recvInfo, boardingAddr, offchainAddr, satoshis: 0, addressError: undefined })
+        setAddressesLoaded(true)
+      })
+      .catch((err) => {
+        const error = extractError(err)
+        consoleError(error, 'error getting addresses')
+        setRecvInfo({ ...recvInfo, addressError: error })
+        setAddressesLoaded(true)
+      })
+  }, [svcWallet])
 
   const createBtcAddress = () => {
     return new Promise((resolve, reject) => {
@@ -69,7 +123,7 @@ export default function ReceiveQRCode() {
 
   const createLightningInvoice = () => {
     return new Promise((resolve, reject) => {
-      if (invoice) return reject() // invoice already exists, no need to create another
+      if (invoice) return reject()
       if (!validLnSwap(satoshis)) return reject()
       createReverseSwap(satoshis)
         .then((pendingSwap) => {
@@ -86,13 +140,12 @@ export default function ReceiveQRCode() {
   useEffect(() => {
     if (isAssetReceive) return setShowQrCode(true)
     if (!satoshis || !svcWallet) return
+    if (!addressesLoaded) return
 
-    // LN is only expected when Boltz is enabled and this isn't an asset receive
     const lnExpected = connected && !isAssetReceive
 
     if (!arkadeSwaps) {
       if (!lnExpected || swapsInitError) {
-        // LN not expected or already failed — show QR immediately
         if (lnExpected && swapsInitError) {
           consoleError(swapsInitError, 'Swaps unavailable, showing receive without swap options')
           setSwapsTimedOut(true)
@@ -100,7 +153,6 @@ export default function ReceiveQRCode() {
         setShowQrCode(true)
         return
       }
-      // LN expected but swaps still initializing — wait up to 5s
       const timeout = setTimeout(() => {
         setSwapsTimedOut(true)
         setShowQrCode(true)
@@ -108,7 +160,6 @@ export default function ReceiveQRCode() {
       return () => clearTimeout(timeout)
     }
 
-    // arkadeSwaps is ready, generate swaps before showing QR to avoid QR code changing
     setSwapsTimedOut(false)
 
     Promise.allSettled([createBtcAddress(), createLightningInvoice()]).then(([btc, lightning]) => {
@@ -128,8 +179,8 @@ export default function ReceiveQRCode() {
       }
       if (lightning.status === 'fulfilled') {
         const pendingSwap = lightning.value as PendingReverseSwap
-        const invoice = pendingSwap.response.invoice
-        setInvoice(invoice)
+        const inv = pendingSwap.response.invoice
+        setInvoice(inv)
         arkadeSwaps
           .waitAndClaim(pendingSwap)
           .then(() => {
@@ -142,37 +193,41 @@ export default function ReceiveQRCode() {
       }
       setShowQrCode(true)
     })
-  }, [satoshis, svcWallet, arkadeSwaps, swapsInitError])
+  }, [satoshis, svcWallet, arkadeSwaps, swapsInitError, addressesLoaded])
 
-  //
+  // Build BIP21 URI
   useEffect(() => {
-    if (!showQrCode) return
+    if (!addressesLoaded && !showQrCode) return
 
-    const arkAddress = validVtxoTx(satoshis) && vtxoTxsAllowed() ? offchainAddr : ''
-    const btcAddress = validUtxoTx(satoshis) && utxoTxsAllowed() ? swapAddress || boardingAddr : ''
+    const recvOffchain = recvInfo.offchainAddr
+    const recvBoarding = recvInfo.boardingAddr
+
+    const ark = validVtxoTx(satoshis) && vtxoTxsAllowed() ? recvOffchain : ''
+    const btc = validUtxoTx(satoshis) && utxoTxsAllowed() ? swapAddress || recvBoarding : ''
 
     const bip21uri = isAssetReceive
-      ? encodeBip21Asset(arkAddress, assetId, centsToUnits(satoshis, assetMeta?.metadata?.decimals))
-      : encodeBip21(btcAddress, arkAddress, invoice, satoshis)
+      ? encodeBip21Asset(ark, assetId, centsToUnits(satoshis, assetMeta?.metadata?.decimals))
+      : encodeBip21(btc, ark, invoice, satoshis)
 
-    setNoPaymentMethods(!arkAddress && !btcAddress && !invoice && !isAssetReceive)
-    setArkAddress(arkAddress)
-    setBtcAddress(btcAddress)
+    setNoPaymentMethods(!ark && !btc && !invoice && !isAssetReceive)
+    setArkAddress(ark)
+    setBtcAddress(btc)
     setQrCodeValue(bip21uri)
     setBip21Uri(bip21uri)
-  }, [showQrCode, swapAddress, invoice])
+  }, [showQrCode, swapAddress, invoice, addressesLoaded, recvInfo.offchainAddr, recvInfo.boardingAddr, satoshis])
 
+  // Payment listener
   useEffect(() => {
     if (!svcWallet) return
 
     const listenForPayments = (event: MessageEvent) => {
-      let satoshis = 0
+      let sats = 0
       let receivedAssets: Asset[] = []
 
       if (event.data && event.data.type === 'VTXO_UPDATE') {
         const newVtxos = event.data.payload?.newVtxos
         if (Array.isArray(newVtxos)) {
-          satoshis = (newVtxos as ExtendedVirtualCoin[]).reduce((acc, v) => acc + v.value, 0)
+          sats = (newVtxos as ExtendedVirtualCoin[]).reduce((acc, v) => acc + v.value, 0)
           for (const v of newVtxos as ExtendedVirtualCoin[]) {
             receivedAssets.push(...(v.assets ?? []))
           }
@@ -181,7 +236,6 @@ export default function ReceiveQRCode() {
         }
       }
 
-      // reduce received assets to unique asset ids (sum amounts if same asset id)
       receivedAssets = receivedAssets.reduce((acc, v) => {
         const existing = acc.find((a) => a.assetId === v.assetId)
         if (existing) {
@@ -195,26 +249,24 @@ export default function ReceiveQRCode() {
       if (event.data && event.data.type === 'UTXO_UPDATE') {
         const coins = event.data.payload?.coins
         if (Array.isArray(coins)) {
-          satoshis = (coins as Coin[]).reduce((acc, v) => acc + v.value, 0)
+          sats = (coins as Coin[]).reduce((acc, v) => acc + v.value, 0)
         } else {
           consoleError('UTXO_UPDATE message has unexpected payload shape:', event.data.payload)
         }
       }
 
-      if (satoshis || receivedAssets.length > 0) {
-        setRecvInfo({ ...recvInfo, satoshis, receivedAssets })
-        if (!isAssetReceive) notifyPaymentReceived(satoshis)
+      if (sats || receivedAssets.length > 0) {
+        setRecvInfo({ ...recvInfo, satoshis: sats, receivedAssets })
+        if (!isAssetReceive) notifyPaymentReceived(sats)
         navigate(Pages.ReceiveSuccess)
       }
     }
 
     navigator.serviceWorker.addEventListener('message', listenForPayments)
-
-    return () => {
-      navigator.serviceWorker.removeEventListener('message', listenForPayments)
-    }
+    return () => navigator.serviceWorker.removeEventListener('message', listenForPayments)
   }, [svcWallet])
 
+  // Handlers
   const handleShare = () => {
     setSharing(true)
     shareData(data)
@@ -222,40 +274,214 @@ export default function ReceiveQRCode() {
       .finally(() => setSharing(false))
   }
 
+  const handleCopy = async (value: string) => {
+    hapticSubtle()
+    await copyToClipboard(value)
+    present(copiedToClipboard)
+    setCopied(value)
+  }
+
+  const handleAmountChange = (sats: number) => {
+    setAmountInput(sats)
+    const value = useFiat ? toFiat(sats) : sats
+    const maxFrac = useFiat ? 2 : 0
+    setAmountTextValue(prettyNumber(value, maxFrac, false))
+  }
+
+  const handleAmountConfirm = () => {
+    setRecvInfo({ ...recvInfo, satoshis: amountInput })
+    setShowAmountSheet(false)
+    setShowKeys(false)
+  }
+
   const data = { title: 'Receive', text: qrCodeValue }
-  const disabled = !canBrowserShareData(data) || sharing || hasError || noPaymentMethods
+  const shareDisabled = !canBrowserShareData(data) || sharing || hasError || noPaymentMethods
+
+  // Mobile keyboard for amount sheet
+  if (showKeys) {
+    return <Keyboard back={() => setShowKeys(false)} hideBalance onSats={handleAmountChange} value={amountInput} />
+  }
+
+  const amountLabel = satoshis ? `${prettyNumber(satoshis)} sats` : 'Add amount'
 
   return (
     <>
-      <Header text='Receive' back />
-      <Content>
+      <Header text='Receive' back={() => navigate(Pages.Wallet)} />
+      <Content noFade>
         <Padded>
           {hasError ? (
             <ErrorMessage error text={`Failed to get address: ${addressError}`} />
+          ) : !addressesLoaded || (!qrCodeValue && !noPaymentMethods) ? (
+            <Loading text='Loading...' />
           ) : noPaymentMethods ? (
             <div>No valid payment methods available for this amount</div>
-          ) : qrCodeValue ? (
+          ) : (
             <FlexCol centered>
               <QrCode value={qrCodeValue} />
-              <ExpandAddresses
-                bip21uri={bip21Uri}
-                boardingAddr={btcAddress}
-                offchainAddr={arkAddress}
-                invoice={invoice || ''}
-                onClick={setQrCodeValue}
-              />
+
+              {satoshis > 0 ? (
+                <div style={{ fontSize: '13px', color: 'var(--dark50)', textAlign: 'center' }}>
+                  Requesting {prettyNumber(satoshis)} sats
+                </div>
+              ) : null}
+
               {swapsTimedOut && !invoice && !isAssetReceive ? (
                 <WarningBox text='Lightning is temporarily unavailable. This QR code only supports Arkade and on-chain payments.' />
               ) : null}
+
+              <FlexCol strech>
+                <FlexRow centered gap='0.5rem'>
+                  <div style={{ flex: 1 }}>
+                    <Button label={amountLabel} onClick={() => setShowAmountSheet(true)} secondary />
+                  </div>
+                  <div style={{ flex: 1 }}>
+                    <Button label='Copy' onClick={() => setShowCopySheet(true)} secondary />
+                  </div>
+                </FlexRow>
+                <Button label='Share' onClick={handleShare} disabled={shareDisabled} />
+              </FlexCol>
             </FlexCol>
-          ) : (
-            <Loading text='Generating QR code...' />
           )}
         </Padded>
       </Content>
-      <ButtonsOnBottom>
-        <Button onClick={handleShare} label='Share' disabled={disabled} />
-      </ButtonsOnBottom>
+
+      {/* Amount bottom sheet */}
+      <SheetModal isOpen={showAmountSheet} onClose={() => setShowAmountSheet(false)}>
+        <FlexCol gap='1rem' padding='1rem 0'>
+          <Text>Set amount</Text>
+          <InputAmount
+            name='receive-amount-sheet'
+            focus={!isMobileBrowser}
+            label='Amount'
+            onSats={handleAmountChange}
+            onFocus={() => {
+              if (isMobileBrowser) setShowKeys(true)
+            }}
+            readOnly={isMobileBrowser}
+            value={amountTextValue ? Number(amountTextValue) : undefined}
+            sats={amountInput}
+            onEnter={handleAmountConfirm}
+          />
+          <Button label='Set amount' onClick={handleAmountConfirm} disabled={!amountInput} />
+        </FlexCol>
+      </SheetModal>
+
+      {/* Copy address bottom sheet */}
+      <SheetModal isOpen={showCopySheet} onClose={() => setShowCopySheet(false)}>
+        <FlexCol gap='1rem' padding='1rem 0'>
+          <Text>Copy address</Text>
+          <AddressList
+            bip21Uri={bip21Uri}
+            btcAddress={btcAddress}
+            arkAddress={arkAddress}
+            invoice={invoice}
+            onCopy={handleCopy}
+            onSelect={(v) => {
+              setQrCodeValue(v)
+              setShowCopySheet(false)
+            }}
+            copied={copied}
+          />
+        </FlexCol>
+      </SheetModal>
     </>
+  )
+}
+
+function AddressList({
+  bip21Uri,
+  btcAddress,
+  arkAddress,
+  invoice,
+  onCopy,
+  onSelect,
+  copied,
+}: {
+  bip21Uri: string
+  btcAddress: string
+  arkAddress: string
+  invoice: string
+  onCopy: (value: string) => void
+  onSelect: (value: string) => void
+  copied: string
+}) {
+  return (
+    <FlexCol gap='0.5rem'>
+      {bip21Uri ? (
+        <AddressLine
+          testId='bip21'
+          title='BIP21'
+          value={bip21Uri}
+          onCopy={onCopy}
+          onSelect={onSelect}
+          copied={copied}
+        />
+      ) : null}
+      {btcAddress ? (
+        <AddressLine
+          testId='btc'
+          title='BTC address'
+          value={btcAddress}
+          onCopy={onCopy}
+          onSelect={onSelect}
+          copied={copied}
+        />
+      ) : null}
+      {arkAddress ? (
+        <AddressLine
+          testId='ark'
+          title='Arkade address'
+          value={arkAddress}
+          onCopy={onCopy}
+          onSelect={onSelect}
+          copied={copied}
+        />
+      ) : null}
+      {invoice ? (
+        <AddressLine
+          testId='invoice'
+          title='Lightning invoice'
+          value={invoice}
+          onCopy={onCopy}
+          onSelect={onSelect}
+          copied={copied}
+        />
+      ) : null}
+    </FlexCol>
+  )
+}
+
+function AddressLine({
+  testId,
+  title,
+  value,
+  onCopy,
+  onSelect,
+  copied,
+}: {
+  testId: string
+  title: string
+  value: string
+  onCopy: (value: string) => void
+  onSelect: (value: string) => void
+  copied: string
+}) {
+  return (
+    <Focusable
+      onEnter={() => {
+        onCopy(value)
+        onSelect(value)
+      }}
+    >
+      <FlexRow between onClick={() => onSelect(value)}>
+        <FlexCol gap='0'>
+          <TextSecondary>{title}</TextSecondary>
+          <Text>{prettyLongText(value, 12)}</Text>
+        </FlexCol>
+        <Shadow flex onClick={() => onCopy(value)} testId={testId + '-address-copy'}>
+          {copied === value ? <CheckMarkIcon /> : <CopyIcon />}
+        </Shadow>
+      </FlexRow>
+    </Focusable>
   )
 }


### PR DESCRIPTION
## Summary
- Skip amount screen — show QR immediately on receive
- Custom SVG QR with circular dots, rounded finder patterns, Arkade logo center
- Amount entry and copy address via bottom sheet modals (iOS-inspired design)
- Sheet modals: shadow, handle bar, haptics, backdrop dismiss, z-index above navbar
- Mobile keyboard flow bypasses sheet — goes straight to QR after setting amount
- Lightning minimum hint under QR
- Dev NSEC auto-bypass for faster testing (cherry-picked)

## Status
WIP — still iterating on layout and polish

## Test plan
- [ ] QR scans correctly on phone camera
- [ ] Amount updates QR in real-time
- [ ] Sheet modals float above navbar
- [ ] Tap outside sheet to dismiss
- [ ] Clear amount resets QR
- [ ] Light/dark theme looks correct