### PR TITLE
update arkd to 0.9.1 and fulmine to 0.3.16 in docker-compose file

### DIFF
--- a/test.docker-compose.yml
+++ b/test.docker-compose.yml
@@ -43,7 +43,7 @@ services:
         condition: service_healthy
   arkd-wallet:
     restart: unless-stopped
-    image: ghcr.io/arkade-os/arkd-wallet:v0.9.0
+    image: ghcr.io/arkade-os/arkd-wallet:v0.9.1
     container_name: arkd-wallet
     depends_on:
       - nbxplorer
@@ -59,7 +59,7 @@ services:
       - type: tmpfs
         target: /app/data
   arkd:
-    image: ghcr.io/arkade-os/arkd:v0.9.0
+    image: ghcr.io/arkade-os/arkd:v0.9.1
     container_name: arkd
     restart: unless-stopped
     depends_on:
@@ -233,7 +233,7 @@ services:
     volumes:
       - postgres_datadir:/var/lib/postgresql/data
   boltz-fulmine:
-    image: ghcr.io/arklabshq/fulmine:v0.3.15
+    image: ghcr.io/arklabshq/fulmine:v0.3.16
     container_name: boltz-fulmine
     environment:
       - FULMINE_LOG_LEVEL=5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test service container images to newer versions (arkd-wallet v0.9.1, arkd v0.9.1, boltz-fulmine v0.3.16)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->