### PR TITLE
adds support to GBP, JPY and CNY

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -14,12 +14,12 @@ interface BalanceProps {
 
 export default function Balance({ amount }: BalanceProps) {
   const { config, updateConfig } = useContext(ConfigContext)
-  const { toFiat } = useContext(FiatContext)
+  const { toFiat, fiatDecimals } = useContext(FiatContext)
 
   const fiatAmount = toFiat(amount)
 
   const satsBalance = config.showBalance ? prettyNumber(amount) : prettyHide(amount, '')
-  const fiatBalance = config.showBalance ? prettyNumber(fiatAmount, 2) : prettyHide(fiatAmount, '')
+  const fiatBalance = config.showBalance ? prettyNumber(fiatAmount, fiatDecimals()) : prettyHide(fiatAmount, '')
 
   const otherBalance = config.currencyDisplay === CurrencyDisplay.Fiat ? satsBalance : fiatBalance
   const mainBalance = config.currencyDisplay === CurrencyDisplay.Fiat ? fiatBalance : satsBalance

--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -45,7 +45,7 @@ export default function InputAmount({
   sats,
 }: InputAmountProps) {
   const { config, useFiat } = useContext(ConfigContext)
-  const { fromFiat, toFiat } = useContext(FiatContext)
+  const { fromFiat, toFiat, fiatDecimals } = useContext(FiatContext)
   const { minSwapAllowed, maxSwapAllowed } = useContext(LimitsContext)
 
   const [error, setError] = useState('')
@@ -60,7 +60,7 @@ export default function InputAmount({
 
   useEffect(() => {
     if (asset) return
-    setOtherValue(useFiat ? prettyNumber(sats) : prettyNumber(toFiat(sats), 2))
+    setOtherValue(useFiat ? prettyNumber(sats) : prettyNumber(toFiat(sats), fiatDecimals()))
     setError(sats ? (sats < 0 ? 'Invalid amount' : '') : '')
   }, [sats])
 

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -63,7 +63,7 @@ export default function Keyboard({ asset, back, hideBalance, onSats, value }: Ke
       case 'asset':
         return asset?.decimals ?? 0
       case 'fiat':
-        return 2
+        return fiatDecimals()
       case 'sats':
       default:
         return 0

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -26,7 +26,7 @@ interface KeyboardProps {
 
 export default function Keyboard({ asset, back, hideBalance, onSats, value }: KeyboardProps) {
   const { config, useFiat } = useContext(ConfigContext)
-  const { fromFiat, toFiat } = useContext(FiatContext)
+  const { fromFiat, toFiat, fiatDecimals } = useContext(FiatContext)
   const { balance, svcWallet } = useContext(WalletContext)
 
   const [amountInSats, setAmountInSats] = useState(0)
@@ -107,7 +107,7 @@ export default function Keyboard({ asset, back, hideBalance, onSats, value }: Ke
   const handleToggleCurrency = () => {
     if (inputMode === 'sats') {
       // Convert from sats to fiat and round to 2 decimal places
-      setTextValue(amountInSats ? prettyNumber(toFiat(amountInSats), 2, false) : '')
+      setTextValue(amountInSats ? prettyNumber(toFiat(amountInSats), fiatDecimals(), false) : '')
       setInputMode('fiat')
     } else {
       setTextValue(amountInSats ? prettyNumber(amountInSats, 0, false) : '')
@@ -128,12 +128,12 @@ export default function Keyboard({ asset, back, hideBalance, onSats, value }: Ke
         ? prettyAmount(amountInSats)
         : inputMode === 'asset'
           ? prettyAmount(amountInSats, asset?.ticker)
-          : prettyAmount(toFiat(amountInSats), config.fiat),
+          : prettyAmount(toFiat(amountInSats), config.fiat, fiatDecimals()),
     balance:
       inputMode === 'asset'
         ? `${formatAssetAmount(asset?.balance ?? 0, asset?.decimals ?? 0)} ${asset?.ticker}`
         : inputMode === 'fiat'
-          ? prettyAmount(toFiat(available), config.fiat)
+          ? prettyAmount(toFiat(available), config.fiat, fiatDecimals())
           : prettyAmount(available),
   }
 
@@ -168,7 +168,7 @@ export default function Keyboard({ asset, back, hideBalance, onSats, value }: Ke
         text='Amount'
       />
       <Content>
-        <FlexCol centered gap='0.5rem'>
+        <FlexCol centered gap='0.5rem' className='no-fade'>
           <ErrorMessage error={Boolean(error)} text={error} />
           <Text big centered heading>
             {amount.primary}

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -20,7 +20,7 @@ const border = '1px solid var(--dark20)'
 
 const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
   const { config } = useContext(ConfigContext)
-  const { toFiat } = useContext(FiatContext)
+  const { toFiat, fiatDecimals } = useContext(FiatContext)
   const { assetMetadataCache } = useContext(WalletContext)
 
   const prefix = tx.type === 'sent' ? '-' : '+'
@@ -41,7 +41,7 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
             : ''
     const value = toFiat(tx.amount)
     const small = config.currencyDisplay === CurrencyDisplay.Both
-    const world = config.showBalance ? prettyAmount(value, config.fiat) : prettyHide(value, config.fiat)
+    const world = config.showBalance ? prettyAmount(value, config.fiat, fiatDecimals()) : prettyHide(value, config.fiat)
     return (
       <Text color={color} small={small}>
         {world}

--- a/src/lib/fiat.ts
+++ b/src/lib/fiat.ts
@@ -4,6 +4,9 @@ export interface FiatPrices {
   eur: number
   usd: number
   chf: number
+  jpy: number
+  gbp: number
+  cny: number
 }
 
 export const getPriceFeed = async (): Promise<FiatPrices | undefined> => {
@@ -14,6 +17,9 @@ export const getPriceFeed = async (): Promise<FiatPrices | undefined> => {
       eur: json.EUR?.last,
       usd: json.USD?.last,
       chf: json.CHF?.last,
+      jpy: json.JPY?.last,
+      gbp: json.GBP?.last,
+      cny: json.CNY?.last,
     }
   } catch (err) {
     consoleError(err, 'error fetching fiat prices')

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -26,9 +26,9 @@ export const prettyAgo = (timestamp: number | string, long = false): string => {
   return ''
 }
 
-export const prettyAmount = (amount: string | number, suffix?: string): string => {
+export const prettyAmount = (amount: string | number, suffix?: string, decimals = 2): string => {
   const sats = typeof amount === 'string' ? Number(amount) : amount
-  if (suffix) return `${prettyNumber(sats, 2)} ${suffix}`
+  if (suffix) return `${prettyNumber(sats, decimals)} ${suffix}`
   if (sats >= 100_000_000_000) return `${prettyNumber(fromSatoshis(sats), 0)} BTC`
   if (sats >= 100_000_000) return `${prettyNumber(fromSatoshis(sats), 3)} BTC`
   if (sats >= 1_000_000) return `${prettyNumber(sats / 1_000_000, 3)}M SATS`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,9 @@ export enum Fiats {
   EUR = 'EUR',
   USD = 'USD',
   CHF = 'CHF',
+  JPY = 'JPY',
+  GBP = 'GBP',
+  CNY = 'CNY',
 }
 
 export type Satoshis = number

--- a/src/providers/fiat.tsx
+++ b/src/providers/fiat.tsx
@@ -59,7 +59,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
   }
 
   const fiatDecimals = () => {
-    return [Fiats.JPY, Fiats.CNY].includes(config.fiat) ? 0 : 2
+    return config.fiat === Fiats.JPY ? 0 : 2
   }
 
   const updateFiatPrices = async () => {

--- a/src/providers/fiat.tsx
+++ b/src/providers/fiat.tsx
@@ -26,20 +26,20 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
 
   const [loading, setLoading] = useState(false)
 
-  const fiatPrices = useRef<FiatPrices>(emptyFiatPrices)
+  const prices = useRef<FiatPrices>(emptyFiatPrices)
 
-  const fromEUR = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.eur).toNumber())
-  const fromUSD = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.usd).toNumber())
-  const fromCHF = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.chf).toNumber())
-  const fromJPY = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.jpy).toNumber())
-  const fromGBP = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.gbp).toNumber())
-  const fromCNY = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.cny).toNumber())
-  const toEUR = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.eur).toNumber()
-  const toUSD = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.usd).toNumber()
-  const toCHF = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.chf).toNumber()
-  const toJPY = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.jpy).toNumber()
-  const toGBP = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.gbp).toNumber()
-  const toCNY = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.cny).toNumber()
+  const fromEUR = (fiat = 0) => (prices.current.eur ? toSatoshis(Decimal.div(fiat, prices.current.eur).toNumber()) : 0)
+  const fromUSD = (fiat = 0) => (prices.current.usd ? toSatoshis(Decimal.div(fiat, prices.current.usd).toNumber()) : 0)
+  const fromCHF = (fiat = 0) => (prices.current.chf ? toSatoshis(Decimal.div(fiat, prices.current.chf).toNumber()) : 0)
+  const fromJPY = (fiat = 0) => (prices.current.jpy ? toSatoshis(Decimal.div(fiat, prices.current.jpy).toNumber()) : 0)
+  const fromGBP = (fiat = 0) => (prices.current.gbp ? toSatoshis(Decimal.div(fiat, prices.current.gbp).toNumber()) : 0)
+  const fromCNY = (fiat = 0) => (prices.current.cny ? toSatoshis(Decimal.div(fiat, prices.current.cny).toNumber()) : 0)
+  const toEUR = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.eur).toNumber()
+  const toUSD = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.usd).toNumber()
+  const toCHF = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.chf).toNumber()
+  const toJPY = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.jpy).toNumber()
+  const toGBP = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.gbp).toNumber()
+  const toCNY = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.cny).toNumber()
 
   const fromFiat = (fiat = 0) => {
     if (config.fiat === Fiats.EUR) return fromEUR(fiat)
@@ -66,7 +66,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
     if (loading) return
     setLoading(true)
     const pf = await getPriceFeed()
-    if (pf) fiatPrices.current = pf
+    if (pf) prices.current = pf
     else setConfig({ ...config, currencyDisplay: CurrencyDisplay.Sats }) // hide fiat if fetch fails
     setLoading(false)
   }

--- a/src/providers/fiat.tsx
+++ b/src/providers/fiat.tsx
@@ -6,16 +6,18 @@ import { CurrencyDisplay, Fiats, Satoshis } from '../lib/types'
 import { ConfigContext } from './config'
 
 type FiatContextProps = {
+  toFiat: (satoshis?: Satoshis) => number
   fromFiat: (fiat?: number) => Satoshis
-  toFiat: (sats?: Satoshis) => number
+  fiatDecimals: () => number
   updateFiatPrices: () => void
 }
 
-const emptyFiatPrices: FiatPrices = { eur: 0, usd: 0, chf: 0 }
+const emptyFiatPrices: FiatPrices = { eur: 0, usd: 0, chf: 0, jpy: 0, gbp: 0, cny: 0 }
 
 export const FiatContext = createContext<FiatContextProps>({
-  fromFiat: () => 0,
   toFiat: () => 0,
+  fromFiat: () => 0,
+  fiatDecimals: () => 2,
   updateFiatPrices: () => {},
 })
 
@@ -29,19 +31,35 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
   const fromEUR = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.eur).toNumber())
   const fromUSD = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.usd).toNumber())
   const fromCHF = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.chf).toNumber())
+  const fromJPY = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.jpy).toNumber())
+  const fromGBP = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.gbp).toNumber())
+  const fromCNY = (fiat = 0) => toSatoshis(Decimal.div(fiat, fiatPrices.current.cny).toNumber())
   const toEUR = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.eur).toNumber()
   const toUSD = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.usd).toNumber()
   const toCHF = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.chf).toNumber()
+  const toJPY = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.jpy).toNumber()
+  const toGBP = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.gbp).toNumber()
+  const toCNY = (sats = 0) => Decimal.mul(fromSatoshis(sats), fiatPrices.current.cny).toNumber()
 
   const fromFiat = (fiat = 0) => {
     if (config.fiat === Fiats.EUR) return fromEUR(fiat)
     if (config.fiat === Fiats.CHF) return fromCHF(fiat)
+    if (config.fiat === Fiats.JPY) return fromJPY(fiat)
+    if (config.fiat === Fiats.GBP) return fromGBP(fiat)
+    if (config.fiat === Fiats.CNY) return fromCNY(fiat)
     return fromUSD(fiat)
   }
   const toFiat = (sats = 0) => {
     if (config.fiat === Fiats.EUR) return toEUR(sats)
     if (config.fiat === Fiats.CHF) return toCHF(sats)
+    if (config.fiat === Fiats.JPY) return toJPY(sats)
+    if (config.fiat === Fiats.GBP) return toGBP(sats)
+    if (config.fiat === Fiats.CNY) return toCNY(sats)
     return toUSD(sats)
+  }
+
+  const fiatDecimals = () => {
+    return [Fiats.JPY, Fiats.CNY].includes(config.fiat) ? 0 : 2
   }
 
   const updateFiatPrices = async () => {
@@ -57,5 +75,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
     updateFiatPrices()
   }, [])
 
-  return <FiatContext.Provider value={{ fromFiat, toFiat, updateFiatPrices }}>{children}</FiatContext.Provider>
+  return (
+    <FiatContext.Provider value={{ fromFiat, toFiat, fiatDecimals, updateFiatPrices }}>{children}</FiatContext.Provider>
+  )
 }

--- a/src/screens/Apps/Assets/Detail.tsx
+++ b/src/screens/Apps/Assets/Detail.tsx
@@ -108,7 +108,7 @@ export default function AppAssetDetail() {
       <Header text={name} back={() => navigate(Pages.AppAssets)} />
       <Content>
         <Padded>
-          <FlexCol gap='1rem' centered>
+          <FlexCol gap='1rem' centered className='no-fade'>
             <AssetAvatar icon={meta?.icon} ticker={ticker} name={name} size={64} />
 
             <FlexCol gap='0.25rem' centered>

--- a/src/screens/Apps/Assets/MintSuccess.tsx
+++ b/src/screens/Apps/Assets/MintSuccess.tsx
@@ -33,7 +33,7 @@ export default function AppAssetMintSuccess() {
       <Header text='Asset Created' />
       <Content>
         <Padded>
-          <FlexCol gap='1.5rem' centered padding='1rem 0 0 0'>
+          <FlexCol gap='1.5rem' centered padding='1rem 0 0 0' className='no-fade'>
             <SuccessIcon small />
             <Text centered big bold>
               Asset minted!

--- a/src/screens/Settings/Fiat.tsx
+++ b/src/screens/Settings/Fiat.tsx
@@ -20,7 +20,11 @@ export default function Fiat() {
       <Header text='Fiat' back />
       <Content>
         <Padded>
-          <Select onChange={handleChange} options={[Fiats.EUR, Fiats.USD, Fiats.CHF]} selected={config.fiat} />
+          <Select
+            onChange={handleChange}
+            options={[Fiats.EUR, Fiats.USD, Fiats.CHF, Fiats.GBP, Fiats.JPY, Fiats.CNY]}
+            selected={config.fiat}
+          />
         </Padded>
       </Content>
     </>

--- a/src/screens/Wallet/Notes/Success.tsx
+++ b/src/screens/Wallet/Notes/Success.tsx
@@ -10,7 +10,7 @@ import { FiatContext } from '../../../providers/fiat'
 
 export default function NotesSuccess() {
   const { config, useFiat } = useContext(ConfigContext)
-  const { toFiat } = useContext(FiatContext)
+  const { toFiat, fiatDecimals } = useContext(FiatContext)
   const { noteInfo } = useContext(FlowContext)
   const { notifyPaymentReceived } = useContext(NotificationsContext)
 
@@ -18,7 +18,9 @@ export default function NotesSuccess() {
     notifyPaymentReceived(noteInfo.satoshis)
   }, [])
 
-  const displayAmount = useFiat ? prettyAmount(toFiat(noteInfo.satoshis), config.fiat) : prettyAmount(noteInfo.satoshis)
+  const displayAmount = useFiat
+    ? prettyAmount(toFiat(noteInfo.satoshis), config.fiat, fiatDecimals())
+    : prettyAmount(noteInfo.satoshis)
 
   return (
     <>

--- a/src/screens/Wallet/Receive/Amount.tsx
+++ b/src/screens/Wallet/Receive/Amount.tsx
@@ -33,7 +33,7 @@ import { AssetOption } from '../../../lib/types'
 export default function ReceiveAmount() {
   const { aspInfo } = useContext(AspContext)
   const { config, useFiat } = useContext(ConfigContext)
-  const { toFiat } = useContext(FiatContext)
+  const { toFiat, fiatDecimals } = useContext(FiatContext)
   const { recvInfo, setRecvInfo } = useContext(FlowContext)
   const { calcBtcToArkSwapFee, calcReverseSwapFee } = useContext(SwapsContext)
   const { amountIsAboveMaxLimit, amountIsBelowMinLimit, validBtcToArk, validLnSwap } = useContext(LimitsContext)
@@ -100,7 +100,11 @@ export default function ReceiveAmount() {
   const handleChange = (sats: number) => {
     setSatoshis(sats)
     const value = assetMeta ? centsToUnits(sats, assetMeta.metadata?.decimals) : useFiat ? toFiat(sats) : sats
-    const maximumFractionDigits = useFiat ? 2 : assetMeta?.metadata?.decimals ? assetMeta?.metadata?.decimals : 0
+    const maximumFractionDigits = useFiat
+      ? fiatDecimals()
+      : assetMeta?.metadata?.decimals
+        ? assetMeta?.metadata?.decimals
+        : 0
     setTextValue(prettyNumber(value, maximumFractionDigits, false))
     setButtonLabel(sats ? 'Continue' : defaultButtonLabel)
   }
@@ -167,7 +171,9 @@ export default function ReceiveAmount() {
   }
 
   if (faucetSuccess) {
-    const displayAmount = useFiat ? prettyAmount(toFiat(satoshis), config.fiat) : prettyAmount(satoshis ?? 0)
+    const displayAmount = useFiat
+      ? prettyAmount(toFiat(satoshis), config.fiat, fiatDecimals())
+      : prettyAmount(satoshis ?? 0)
     return (
       <>
         <Header text='Success' />

--- a/src/screens/Wallet/Receive/Success.tsx
+++ b/src/screens/Wallet/Receive/Success.tsx
@@ -20,7 +20,7 @@ import type { AssetDetails } from '@arkade-os/sdk'
 
 export default function ReceiveSuccess() {
   const { config, useFiat } = useContext(ConfigContext)
-  const { toFiat } = useContext(FiatContext)
+  const { toFiat, fiatDecimals } = useContext(FiatContext)
   const { recvInfo } = useContext(FlowContext)
   const { notifyPaymentReceived } = useContext(NotificationsContext)
   const { assetMetadataCache, setCacheEntry, svcWallet } = useContext(WalletContext)
@@ -71,7 +71,9 @@ export default function ReceiveSuccess() {
     }
   }, [assetDetails])
 
-  const displayAmount = useFiat ? prettyAmount(toFiat(recvInfo.satoshis), config.fiat) : prettyAmount(recvInfo.satoshis)
+  const displayAmount = useFiat
+    ? prettyAmount(toFiat(recvInfo.satoshis), config.fiat, fiatDecimals())
+    : prettyAmount(recvInfo.satoshis)
 
   if (isAssetReceive) {
     return (

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -49,7 +49,7 @@ export default function SendForm() {
   const { aspInfo } = useContext(AspContext)
   const { config, useFiat } = useContext(ConfigContext)
   const { calcOnchainOutputFee } = useContext(FeesContext)
-  const { fromFiat, toFiat } = useContext(FiatContext)
+  const { fromFiat, toFiat, fiatDecimals } = useContext(FiatContext)
   const { sendInfo, setNoteInfo, setSendInfo } = useContext(FlowContext)
   const { calcSubmarineSwapFee, createArkToBtcSwap, createSubmarineSwap, connected, getApiUrl } =
     useContext(SwapsContext)
@@ -529,7 +529,7 @@ export default function SendForm() {
     }
 
     const amount = useFiat ? toFiat(liquidBalance) : liquidBalance
-    const pretty = useFiat ? prettyAmount(amount, config.fiat) : prettyAmount(amount)
+    const pretty = useFiat ? prettyAmount(amount, config.fiat, fiatDecimals()) : prettyAmount(amount)
 
     return (
       <div onClick={handleSendAll} style={{ cursor: 'pointer' }}>

--- a/src/screens/Wallet/Send/Success.tsx
+++ b/src/screens/Wallet/Send/Success.tsx
@@ -18,7 +18,7 @@ import { WalletContext } from '../../../providers/wallet'
 
 export default function SendSuccess() {
   const { config, useFiat } = useContext(ConfigContext)
-  const { toFiat } = useContext(FiatContext)
+  const { toFiat, fiatDecimals } = useContext(FiatContext)
   const { sendInfo } = useContext(FlowContext)
   const { notifyPaymentSent } = useContext(NotificationsContext)
   const { assetMetadataCache } = useContext(WalletContext)
@@ -41,7 +41,7 @@ export default function SendSuccess() {
   const displayAmount = isAssetSend
     ? `${formatAssetAmount(assetAmountValue, assetDecimals)} ${assetTicker}`
     : useFiat
-      ? prettyAmount(toFiat(totalSats), config.fiat)
+      ? prettyAmount(toFiat(totalSats), config.fiat, fiatDecimals())
       : prettyAmount(totalSats)
 
   if (isAssetSend) {


### PR DESCRIPTION
@tiero please review
closes #451

Big change because JPY and CNY are non decimal currencies, and all our code assumed 2 decimal places for all fiat currencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JPY, GBP, and CNY as selectable fiat currencies
  * Introduced a configurable fiat-decimal provider (e.g., 0 decimals for JPY)

* **UX / Formatting**
  * Fiat displays now use dynamic decimal precision across the app so converted amounts respect the selected currency

* **Style**
  * Minor visual tweaks (no-fade styling applied to some screens/components)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->