### PR TITLE
fix lendasat back navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,6 +28,7 @@ export default function Header({ auxAriaLabel, auxFunc, auxText, back, text, aux
         else goBack()
       }
     : undefined
+
   const SideButton = (text: string) => (
     <Shadow>
       <Text color='dark80' centered tiny wrap>

--- a/src/screens/Apps/Lendasat/Index.tsx
+++ b/src/screens/Apps/Lendasat/Index.tsx
@@ -13,6 +13,7 @@ import { hmac } from '@noble/hashes/hmac.js'
 import { collaborativeExit, getReceivingAddresses } from '../../../lib/asp'
 import { Transaction } from '@arkade-os/sdk'
 import { isArkAddress, isBTCAddress } from '../../../lib/address'
+import { NavigationContext, Pages } from '../../../providers/navigation'
 
 const { bytesToHex, hexToBytes } = utils
 
@@ -21,7 +22,9 @@ secp.hashes.sha256 = sha256
 secp.hashes.hmacSha256 = (key, msg) => hmac(sha256, key, msg)
 
 export default function AppLendasat() {
+  const { navigate } = useContext(NavigationContext)
   const { wallet, svcWallet } = useContext(WalletContext)
+
   const [arkAddress, setArkAddress] = useState<string | null>(null)
   const [boardingAddress, setBoardingAddress] = useState<string | null>(null)
 
@@ -176,7 +179,7 @@ export default function AppLendasat() {
 
   return (
     <>
-      <Header text='Lendasat' back />
+      <Header text='Lendasat' back={() => navigate(Pages.Apps)} />
       <Content>
         <Padded>
           <FlexCol gap='2rem' between>


### PR DESCRIPTION
Issue:
- Going to Apps / Lendasat required a double tap on the back button to exit.

Diagnostic:
- We recently add a [navigation based on history](https://github.com/arkade-os/wallet/blob/master/src/providers/navigation.tsx)
- All works fine unless the iframe app also plays with the history (it's my guess)

Solution:
- The back button on Lendasat does a hard navigate to Apps, thus going back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Back button navigation now properly returns users to the Apps page.

* **Style**
  * Minor formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->