### PR TITLE
Fix localStorage quota error in asset metadata cache

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -42,11 +42,16 @@ export const readWalletFromStorage = (): Wallet | undefined => {
 }
 
 // local storage caches the asset details for 24 hours
+export const ASSET_METADATA_TTL_MS = 24 * 60 * 60 * 1000
+
 export type CachedAssetDetails = AssetDetails & { cachedAt: number; hasIcon?: boolean }
 
 export const saveAssetMetadataToStorage = (cache: Map<string, CachedAssetDetails>): void => {
+  const now = Date.now()
   const obj: Record<string, CachedAssetDetails> = {}
   cache.forEach((v, k) => {
+    // evict expired entries to prevent unbounded localStorage growth
+    if (now - v.cachedAt >= ASSET_METADATA_TTL_MS) return
     // strip icon from persisted data — it can be large (base64) and is re-fetched on demand
     const { metadata, ...rest } = v
     const { icon: _, ...metaWithoutIcon } = metadata ?? {}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -47,7 +47,10 @@ export type CachedAssetDetails = AssetDetails & { cachedAt: number; hasIcon?: bo
 export const saveAssetMetadataToStorage = (cache: Map<string, CachedAssetDetails>): void => {
   const obj: Record<string, CachedAssetDetails> = {}
   cache.forEach((v, k) => {
-    obj[k] = v
+    // strip icon from persisted data — it can be large (base64) and is re-fetched on demand
+    const { metadata, ...rest } = v
+    const { icon: _, ...metaWithoutIcon } = metadata ?? {}
+    obj[k] = { ...rest, metadata: metaWithoutIcon }
   })
   setStorageItem('assetMetadataCache', JSON.stringify(obj))
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -52,10 +52,7 @@ export const saveAssetMetadataToStorage = (cache: Map<string, CachedAssetDetails
   cache.forEach((v, k) => {
     // evict expired entries to prevent unbounded localStorage growth
     if (now - v.cachedAt >= ASSET_METADATA_TTL_MS) return
-    // strip icon from persisted data — it can be large (base64) and is re-fetched on demand
-    const { metadata, ...rest } = v
-    const { icon: _, ...metaWithoutIcon } = metadata ?? {}
-    obj[k] = { ...rest, metadata: metaWithoutIcon }
+    obj[k] = v
   })
   setStorageItem('assetMetadataCache', JSON.stringify(obj))
 }

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -19,6 +19,7 @@ import {
   saveAssetMetadataToStorage,
   readAssetMetadataFromStorage,
   CachedAssetDetails,
+  ASSET_METADATA_TTL_MS,
 } from '../lib/storage'
 import { NavigationContext, Pages } from './navigation'
 import { getRestApiExplorerURL } from '../lib/explorers'
@@ -41,7 +42,6 @@ import { IndexedDBStorageAdapter } from '@arkade-os/sdk/adapters/indexedDB'
 import { Indexer } from '../lib/indexer'
 import { IndexedDbSwapRepository, migrateToSwapRepository, Network } from '@arkade-os/boltz-swap'
 
-const ASSET_METADATA_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
 const SERVICE_WORKER_SETUP_TIMEOUT_MS = 5_000
 
 const defaultWallet: Wallet = {

--- a/src/test/lib/storage.test.ts
+++ b/src/test/lib/storage.test.ts
@@ -45,23 +45,6 @@ describe('asset metadata storage', () => {
     expect(loaded).toBeUndefined()
   })
 
-  it('should strip icon field when persisting', () => {
-    const cache = new Map<string, CachedAssetDetails>()
-    cache.set('asset1', {
-      assetId: 'asset1',
-      supply: 100,
-      metadata: { name: 'Token', ticker: 'TKN', decimals: 8, icon: 'data:image/png;base64,huge-string' },
-      cachedAt: Date.now(),
-      hasIcon: true,
-    })
-    saveAssetMetadataToStorage(cache)
-    const loaded = readAssetMetadataFromStorage()
-
-    expect(loaded!.get('asset1')?.metadata?.name).toBe('Token')
-    expect(loaded!.get('asset1')?.metadata?.icon).toBeUndefined()
-    expect(loaded!.get('asset1')?.hasIcon).toBe(true)
-  })
-
   it('should evict expired entries when saving', () => {
     const cache = new Map<string, CachedAssetDetails>()
     cache.set('fresh', makeCached('fresh', 'Fresh Token'))

--- a/src/test/lib/storage.test.ts
+++ b/src/test/lib/storage.test.ts
@@ -3,6 +3,7 @@ import {
   saveAssetMetadataToStorage,
   readAssetMetadataFromStorage,
   CachedAssetDetails,
+  ASSET_METADATA_TTL_MS,
   clearStorage,
 } from '../../lib/storage'
 
@@ -59,6 +60,19 @@ describe('asset metadata storage', () => {
     expect(loaded!.get('asset1')?.metadata?.name).toBe('Token')
     expect(loaded!.get('asset1')?.metadata?.icon).toBeUndefined()
     expect(loaded!.get('asset1')?.hasIcon).toBe(true)
+  })
+
+  it('should evict expired entries when saving', () => {
+    const cache = new Map<string, CachedAssetDetails>()
+    cache.set('fresh', makeCached('fresh', 'Fresh Token'))
+    cache.set('stale', makeCached('stale', 'Stale Token', Date.now() - ASSET_METADATA_TTL_MS - 1))
+
+    saveAssetMetadataToStorage(cache)
+    const loaded = readAssetMetadataFromStorage()
+
+    expect(loaded!.size).toBe(1)
+    expect(loaded!.has('fresh')).toBe(true)
+    expect(loaded!.has('stale')).toBe(false)
   })
 
   it('should overwrite on re-save', () => {

--- a/src/test/lib/storage.test.ts
+++ b/src/test/lib/storage.test.ts
@@ -44,6 +44,23 @@ describe('asset metadata storage', () => {
     expect(loaded).toBeUndefined()
   })
 
+  it('should strip icon field when persisting', () => {
+    const cache = new Map<string, CachedAssetDetails>()
+    cache.set('asset1', {
+      assetId: 'asset1',
+      supply: 100,
+      metadata: { name: 'Token', ticker: 'TKN', decimals: 8, icon: 'data:image/png;base64,huge-string' },
+      cachedAt: Date.now(),
+      hasIcon: true,
+    })
+    saveAssetMetadataToStorage(cache)
+    const loaded = readAssetMetadataFromStorage()
+
+    expect(loaded!.get('asset1')?.metadata?.name).toBe('Token')
+    expect(loaded!.get('asset1')?.metadata?.icon).toBeUndefined()
+    expect(loaded!.get('asset1')?.hasIcon).toBe(true)
+  })
+
   it('should overwrite on re-save', () => {
     const cache1 = new Map<string, CachedAssetDetails>()
     cache1.set('a', makeCached('a', 'First'))


### PR DESCRIPTION
## Summary
- Evict expired entries (older than 24h TTL) from the cache on save, preventing unbounded growth
- Extract `ASSET_METADATA_TTL_MS` into a shared constant in `storage.ts`

Fixes: `Failed to execute 'setItem' on 'Storage': Setting the value of 'config' exceeded the quota.`

The `config` key itself is small, but `assetMetadataCache` was filling up the ~5MB localStorage quota with large icon strings and never-evicted entries, causing subsequent writes (including `config`) to fail.

## Test plan
- [x] Unit tests added for expired entry eviction
- [ ] Manually verify asset icons still display correctly after page reload (re-fetched from server)
- [ ] Verify that after 24h, stale asset metadata is refreshed rather than served from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Asset metadata cache now properly expires outdated entries, preventing stale data from consuming storage space.
  * Optimized data storage by removing unnecessary icon information from asset metadata records while preserving other asset details.

* **Tests**
  * Added comprehensive test coverage for asset metadata storage persistence and cache expiration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->