### PR TITLE
Remove balance label, adjust spacing, fix fiat decimals

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -20,7 +20,9 @@ export default function Balance({ amount }: BalanceProps) {
   const showFiat = config.currencyDisplay === CurrencyDisplay.Fiat
 
   const satsBalance = config.showBalance ? prettyNumber(amount) : prettyHide(amount, '')
-  const fiatBalance = config.showBalance ? prettyNumber(fiatAmount, fiatDecimals(), true, fiatDecimals()) : prettyHide(fiatAmount, '')
+  const fiatBalance = config.showBalance
+    ? prettyNumber(fiatAmount, fiatDecimals(), true, fiatDecimals())
+    : prettyHide(fiatAmount, '')
 
   const mainBalance = showFiat ? fiatBalance : satsBalance
   const otherBalance = showFiat ? satsBalance : fiatBalance

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -20,7 +20,7 @@ export default function Balance({ amount }: BalanceProps) {
   const showFiat = config.currencyDisplay === CurrencyDisplay.Fiat
 
   const satsBalance = config.showBalance ? prettyNumber(amount) : prettyHide(amount, '')
-  const fiatBalance = config.showBalance ? prettyNumber(fiatAmount, fiatDecimals()) : prettyHide(fiatAmount, '')
+  const fiatBalance = config.showBalance ? prettyNumber(fiatAmount, fiatDecimals(), true, fiatDecimals()) : prettyHide(fiatAmount, '')
 
   const mainBalance = showFiat ? fiatBalance : satsBalance
   const otherBalance = showFiat ? satsBalance : fiatBalance
@@ -32,10 +32,7 @@ export default function Balance({ amount }: BalanceProps) {
   const toggleShow = () => updateConfig({ ...config, showBalance: !config.showBalance })
 
   return (
-    <FlexCol gap='0' margin={showBoth ? '3rem 0 2rem 0' : '3rem 0 0.5rem 0'}>
-      <Text color='dark50' smaller>
-        My balance
-      </Text>
+    <FlexCol gap='0' margin='2.5rem 0 1rem 0'>
       <FlexRow alignItems='baseline'>
         <Text bigger heading medium>
           {mainBalance}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -91,7 +91,12 @@ export const prettyNumber = (
   minimumFractionDigits?: number,
 ): string => {
   if (!num) return '0'
-  return new Intl.NumberFormat('en', { style: 'decimal', maximumFractionDigits, minimumFractionDigits, useGrouping }).format(num)
+  return new Intl.NumberFormat('en', {
+    style: 'decimal',
+    maximumFractionDigits,
+    minimumFractionDigits,
+    useGrouping,
+  }).format(num)
 }
 
 export const formatAssetAmount = (amount: number, decimals: number): string => {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -90,7 +90,7 @@ export const prettyNumber = (
   useGrouping = true,
   minimumFractionDigits?: number,
 ): string => {
-  if (!num) return '0'
+  if (num === undefined || num === null || Number.isNaN(num)) return '0'
   return new Intl.NumberFormat('en', {
     style: 'decimal',
     maximumFractionDigits,

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -84,9 +84,14 @@ export const prettyLongText = (str?: string, showChars = 11): string => {
   return `${left}...${right}`
 }
 
-export const prettyNumber = (num?: number, maximumFractionDigits = 8, useGrouping = true): string => {
+export const prettyNumber = (
+  num?: number,
+  maximumFractionDigits = 8,
+  useGrouping = true,
+  minimumFractionDigits?: number,
+): string => {
   if (!num) return '0'
-  return new Intl.NumberFormat('en', { style: 'decimal', maximumFractionDigits, useGrouping }).format(num)
+  return new Intl.NumberFormat('en', { style: 'decimal', maximumFractionDigits, minimumFractionDigits, useGrouping }).format(num)
 }
 
 export const formatAssetAmount = (amount: number, decimals: number): string => {

--- a/src/test/e2e/init.test.ts
+++ b/src/test/e2e/init.test.ts
@@ -5,7 +5,7 @@ test('should create a new wallet', async ({ page }) => {
   await createWallet(page)
 
   // Verify wallet main page
-  await page.waitForSelector('text=My balance')
+  await page.waitForSelector('text=SATS')
   await expect(page.getByText('0SATS')).toBeVisible()
   await expect(page.getByText('0USD')).toBeVisible()
   await expect(page.getByRole('button', { name: 'Send' })).toBeVisible()

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -8,7 +8,7 @@ describe('Wallet screen', () => {
     expect(screen.getByText('USD')).toBeInTheDocument()
     expect(screen.getByText('Send')).toBeInTheDocument()
     expect(screen.getByText('Receive')).toBeInTheDocument()
-    expect(screen.getByText('My balance')).toBeInTheDocument()
+    expect(screen.getByText('SATS')).toBeInTheDocument()
     expect(screen.getByText('No transactions yet')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Remove the "My balance" label from the wallet homepage balance display — the label was redundant
- Adjust balance margin from `3rem 0 2rem 0` → `2.5rem 0 1rem 0` for a tighter layout (buttons closer to balance)
- Fix fiat display to always show two decimal places (e.g. "17.30 USD" instead of "17.3 USD") by adding `minimumFractionDigits` support to `prettyNumber`

## Changed files
- `src/components/Balance.tsx` — removed label, updated margin, pass `minimumFractionDigits` for fiat
- `src/lib/format.ts` — added optional `minimumFractionDigits` param to `prettyNumber`

## Test plan
- [x] Wallet homepage shows balance amount without "My balance" label
- [x] Spacing between logo, balance, and buttons looks correct
- [x] Fiat balance displays with two decimal places (e.g. "17.30" not "17.3")
- [ ] JPY displays with zero decimals (unchanged behavior)
- [ ] Sats display unaffected
- [ ] Balance hide/show toggle still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fiat balance formatting with enhanced decimal precision control
  * Fixed numeric zero validation in number formatting utility
  * Removed redundant balance header label from display
  * Adjusted balance section spacing for better visual hierarchy

* **Tests**
  * Updated test assertions to reflect UI changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->