### PR TITLE
Fix boot animation overlay blocking the Unlock page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,8 +263,8 @@ export default function App() {
         ? Pages.Unlock
         : screen
 
-  // Boot animation: persists from Loading through Unlock until Wallet is reached,
-  // then flies to the LogoIcon position. For new users (→ Init), exits with fly-up.
+  // Boot animation: persists on Loading, then flies to the LogoIcon position when
+  // Wallet is reached. For any other destination (Unlock, Init, etc.), exits with fly-up.
   useEffect(() => {
     // Start boot animation when we first see the Loading page
     if (page === Pages.Loading && !bootAnimActive) {
@@ -283,8 +283,11 @@ export default function App() {
       return
     }
 
-    // If we land on Init (new user) or any non-boot page, fly up and exit
-    if (page !== Pages.Loading && page !== Pages.Unlock) {
+    // If we land on any non-Loading page (Unlock, Init, etc.), fly up and exit.
+    // For passwordless wallets page goes Loading → Wallet (never Unlock), so this
+    // only fires for locked wallets or when passwordless auto-boot fails — in both
+    // cases the overlay must dismiss to reveal the Unlock/Init page underneath.
+    if (page !== Pages.Loading) {
       setBootExitMode('fly-up')
       setBootAnimDone(true)
     }

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -18,6 +18,7 @@ import {
 } from './screens/mocks'
 import { defaultPassword } from '../lib/constants'
 import { detectJSCapabilities } from '../lib/jsCapabilities'
+import { gitCommit } from '../_gitCommit'
 
 const PASSWORDLESS_AUTO_RELOAD_KEY = 'passwordless-auto-reload-attempted'
 
@@ -120,7 +121,7 @@ describe('App startup routing', () => {
   it('keeps passwordless wallets on loading and boots them in the background', async () => {
     const { navigate, unlockWallet } = renderApp({ authState: 'passwordless', initialized: false })
 
-    expect(await screen.findByText('Loading...')).toBeInTheDocument()
+    expect(await screen.findByText(gitCommit)).toBeInTheDocument()
     await waitFor(() => expect(unlockWallet).toHaveBeenCalledWith(defaultPassword))
     expect(navigate).not.toHaveBeenCalledWith(Pages.Unlock)
   })
@@ -142,7 +143,7 @@ describe('App startup routing', () => {
   it('keeps authenticated but uninitialized wallets on loading', async () => {
     const { navigate, unlockWallet } = renderApp({ authState: 'authenticated', initialized: false })
 
-    expect(await screen.findByText('Loading...')).toBeInTheDocument()
+    expect(await screen.findByText(gitCommit)).toBeInTheDocument()
     expect(unlockWallet).not.toHaveBeenCalled()
     expect(navigate).not.toHaveBeenCalledWith(Pages.Unlock)
   })


### PR DESCRIPTION
## Summary
- The boot animation overlay (opaque white background at z-index 9) was kept alive when `page` transitioned to `Pages.Unlock`, making the password input completely invisible and the app appear permanently stuck
- For passwordless wallets `page` goes `Loading → Wallet` (never `Unlock`), so the exclusion was dead code — except when the passwordless auto-boot fails (e.g. Vivaldi service worker timeout sets `authState` to `'locked'`), where it caused a deadlock
- Dismiss the overlay for any non-Loading page, including Unlock
- Fix two pre-existing broken unit tests (from #489) that looked for removed `'Loading...'` text

## Test plan
- [x] All unit tests pass (`pnpm test:unit` — 164 passed, 2 skipped)
- [x] Lint clean (`pnpm lint`)
- [x] Manual test: locked wallet boots to visible Unlock page
- [x] Manual test: passwordless wallet still gets fly-to-target animation (Loading → Wallet)
- [x] Manual test in Vivaldi: app no longer stuck on loading screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated boot animation exit behavior to correctly dismiss the overlay when navigating through certain app states during startup.

* **Tests**
  * Updated initial render assertions to verify correct startup state content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->