### PR TITLE
use app components in reload page

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,13 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 import * as Sentry from '@sentry/react'
 import Button from './Button'
+import { IonApp, IonPage } from '@ionic/react'
+import Padded from './Padded'
+import Content from './Content'
+import Header from './Header'
+import ButtonsOnBottom from './ButtonsOnBottom'
+import Text, { TextSecondary } from './Text'
+import CenterScreen from './CenterScreen'
 
 interface Props {
   children: ReactNode
@@ -32,15 +39,23 @@ export default class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{ padding: '2rem', textAlign: 'center', color: 'white' }}>
-          <h2>Something went wrong</h2>
-          <p style={{ opacity: 0.7, fontSize: '0.875rem', marginBottom: '0.5rem' }}>
-            The app ran into an unexpected error. This has been automatically reported to our team. Please reload to
-            continue.
-          </p>
-          <p style={{ opacity: 0.5, fontSize: '0.75rem', marginBottom: '1.5rem' }}>{this.state.error?.message}</p>
-          <Button label='Reload' onClick={this.handleReload} />
-        </div>
+        <IonApp>
+          <IonPage>
+            <Header text='Something went wrong' />
+            <Content>
+              <Padded>
+                <CenterScreen>
+                  <Text>The app ran into an unexpected error</Text>
+                  <Text>Please reload to continue</Text>
+                  <TextSecondary centered>{this.state.error?.message}</TextSecondary>
+                </CenterScreen>
+              </Padded>
+            </Content>
+            <ButtonsOnBottom>
+              <Button label='Reload' onClick={this.handleReload} />
+            </ButtonsOnBottom>
+          </IonPage>
+        </IonApp>
       )
     }
 


### PR DESCRIPTION
Uses app components to render reload page.

From

<img width="1747" height="968" alt="Screenshot 2026-03-31 at 17 14 27" src="https://github.com/user-attachments/assets/8f4ed85d-a7a8-47e3-bcf7-60a501b67a05" />


To

<img width="1747" height="968" alt="Screenshot 2026-03-31 at 17 27 59" src="https://github.com/user-attachments/assets/ec0725a1-bd0a-497b-8721-f5a7f446450e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the error page layout with improved visual presentation of error messages and user guidance when unexpected errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->