### PR TITLE
fix: use 'arkd' container name to match existing branches

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -48,8 +48,8 @@ jobs:
         docker ps --format "table {{.Names}}\t{{.Status}}" || true
         echo "=== boltz logs (last 50) ==="
         docker logs boltz 2>&1 | tail -50 || true
-        echo "=== ark logs (last 50) ==="
-        docker logs ark 2>&1 | tail -50 || true
+        echo "=== arkd logs (last 50) ==="
+        docker logs arkd 2>&1 | tail -50 || true
     - name: Cleanup
       if: always()
       run: |

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './src/test/e2e',
+  timeout: 60000,
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 5 : 0,

--- a/src/test/e2e/fundedWallet.ts
+++ b/src/test/e2e/fundedWallet.ts
@@ -33,7 +33,7 @@ const waitForBalance = async (
 }
 
 const createNote = async (amount: number): Promise<string> => {
-  const { stdout } = await execAsync(`docker exec -t ark arkd note --amount ${amount}`)
+  const { stdout } = await execAsync(`docker exec -t arkd arkd note --amount ${amount}`)
   return stdout.trim()
 }
 

--- a/src/test/e2e/send.test.ts
+++ b/src/test/e2e/send.test.ts
@@ -16,7 +16,6 @@ import { faucetOffchain } from './fundedWallet'
 import { prettyNumber } from '../../lib/format'
 
 test('should send to ark address', async ({ page, isMobile }) => {
-  test.setTimeout(60000)
   // create wallet
   await createWallet(page)
   await fundWallet(page, 5000)
@@ -50,7 +49,6 @@ test('should send to ark address', async ({ page, isMobile }) => {
 })
 
 test('should send MAX to ark address', async ({ page }) => {
-  test.setTimeout(60000)
   // create wallet
   await createWallet(page)
   await fundWallet(page, 5000)
@@ -91,7 +89,6 @@ test('should send MAX to ark address', async ({ page }) => {
 })
 
 test('should send assets to ark address', async ({ page, isMobile }) => {
-  test.setTimeout(60000)
   // create wallet
   await createWallet(page)
   await fundWallet(page, 5000)
@@ -153,7 +150,6 @@ test('should send assets to ark address', async ({ page, isMobile }) => {
 })
 
 test('should send MAX assets to ark address', async ({ page }) => {
-  test.setTimeout(60000)
   // create wallet
   await createWallet(page)
   await fundWallet(page, 5000)

--- a/src/test/e2e/send.test.ts
+++ b/src/test/e2e/send.test.ts
@@ -16,6 +16,7 @@ import { faucetOffchain } from './fundedWallet'
 import { prettyNumber } from '../../lib/format'
 
 test('should send to ark address', async ({ page, isMobile }) => {
+  test.setTimeout(60000)
   // create wallet
   await createWallet(page)
   await fundWallet(page, 5000)
@@ -49,6 +50,7 @@ test('should send to ark address', async ({ page, isMobile }) => {
 })
 
 test('should send MAX to ark address', async ({ page }) => {
+  test.setTimeout(60000)
   // create wallet
   await createWallet(page)
   await fundWallet(page, 5000)
@@ -89,6 +91,7 @@ test('should send MAX to ark address', async ({ page }) => {
 })
 
 test('should send assets to ark address', async ({ page, isMobile }) => {
+  test.setTimeout(60000)
   // create wallet
   await createWallet(page)
   await fundWallet(page, 5000)
@@ -150,6 +153,7 @@ test('should send assets to ark address', async ({ page, isMobile }) => {
 })
 
 test('should send MAX assets to ark address', async ({ page }) => {
+  test.setTimeout(60000)
   // create wallet
   await createWallet(page)
   await fundWallet(page, 5000)

--- a/src/test/e2e/send.test.ts
+++ b/src/test/e2e/send.test.ts
@@ -330,7 +330,7 @@ test('should send to onchain address with collaborative exit', async ({ page, is
 // since 1000 sats is below the minimum for chain swap, wallet will use collaborative exit to send onchain
 test('should send MAX to onchain address with collaborative exit', async ({ page }) => {
   // set fees
-  execSync('docker exec -t ark arkd fees intent --onchain-output "200.0"')
+  execSync('docker exec -t arkd arkd fees intent --onchain-output "200.0"')
 
   // create wallet
   await createWallet(page)
@@ -379,5 +379,5 @@ test('should send MAX to onchain address with collaborative exit', async ({ page
   await expect(page.getByText('Sent')).toBeVisible()
 
   // clear fees
-  execSync('docker exec -t ark arkd fees clear')
+  execSync('docker exec -t arkd arkd fees clear')
 })

--- a/src/test/e2e/swap.test.ts
+++ b/src/test/e2e/swap.test.ts
@@ -172,7 +172,7 @@ test('should receive bitcoin funds from swap', async ({ page, isMobile }) => {
 test('should send funds to onchain address via swap', async ({ page, isMobile }) => {
   test.setTimeout(120000)
   // set fees
-  execSync('docker exec -t ark arkd fees intent --onchain-output "200.0"')
+  execSync('docker exec -t arkd arkd fees intent --onchain-output "200.0"')
 
   // create wallet
   await createWallet(page)
@@ -202,5 +202,5 @@ test('should send funds to onchain address via swap', async ({ page, isMobile })
   await expect(page.getByText('Sent')).toBeVisible()
 
   // clear fees
-  execSync('docker exec -t ark arkd fees clear')
+  execSync('docker exec -t arkd arkd fees clear')
 })


### PR DESCRIPTION
## Summary
Fixes all open PRs broken by #492 (arkade-regtest submodule merge).

### Root causes
1. **Container name mismatch**: arkade-regtest used `container_name: ark`, but all existing branches use `docker exec -t arkd` (the original nigiri name)
2. **arkd init failure**: The `arkd` v0.9.1 binary has no `init` subcommand — wallet setup is already handled via the admin REST API
3. **Test timeouts**: The regtest environment runs more containers, making tests ~2x slower than the old `test.docker-compose.yml`

### Changes
- Update regtest submodule: container renamed to `arkd`, remove broken init step, use direct docker exec
- Revert test files to use `docker exec -t arkd` (matching all existing branches)
- Update CI workflow log capture to use `arkd`
- Increase global Playwright test timeout from 30s to 60s

## Test plan
- [x] Regtest environment starts successfully
- [x] 70+ tests pass (Mobile Chrome + Google Chrome)
- [ ] CI fully green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI failure log capture to target the correct runtime container.
  * Updated test commands to target the correct runtime container.
  * Updated a test submodule pointer to align test dependencies.

* **Tests**
  * Set a global test timeout (60s) to reduce end-to-end flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->