### PR TITLE
ci: add multi-arch Docker build (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Container Registry
         uses: docker/login-action@v3
         with:
@@ -38,6 +44,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
## Summary
- Add `docker/setup-qemu-action` and `docker/setup-buildx-action` to enable cross-platform builds
- Add `platforms: linux/amd64,linux/arm64` to the build step

The `ghcr.io/arkade-os/wallet:latest` image currently only ships amd64. This adds arm64 support so the image can run natively on ARM hosts (e.g. Apple Silicon, Raspberry Pi, AWS Graviton).

No Dockerfile changes needed — base images (`node:22-alpine`, `nginx:alpine`) already support both architectures.

## Test plan
- [ ] Verify CI builds successfully for both platforms
- [ ] Pull the resulting image on an ARM host and confirm it runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images are now built for multiple processor architectures (AMD64 and ARM64), enabling support for a wider range of systems including ARM-based devices and modern Apple Silicon machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->