### PR TITLE
Align VTXO lookback time window for Swaps to the SW timeout

### DIFF
--- a/src/providers/swaps.tsx
+++ b/src/providers/swaps.tsx
@@ -23,6 +23,8 @@ import { sendOffChain } from '../lib/asp'
 import { ArkAddress, ServiceWorkerWallet } from '@arkade-os/sdk'
 import { hex } from '@scure/base'
 
+const FUNDING_LOOKBACK_SECONDS = 60000
+
 const BASE_URLS: Record<Network, string | null> = {
   bitcoin: import.meta.env.VITE_BOLTZ_URL ?? 'https://api.ark.boltz.exchange',
   mutinynet: 'https://api.boltz.mutinynet.arkade.sh',
@@ -406,7 +408,7 @@ const assertSwapAddressUnfunded = async (svcWallet: ServiceWorkerWallet, swapAdd
   const decoded = ArkAddress.decode(swapAddress)
   const script = hex.encode(decoded.pkScript)
   const manager = await svcWallet.getContractManager()
-  await manager.refreshVtxos({ scripts: [script], after: Date.now() - 5000 })
+  await manager.refreshVtxos({ scripts: [script], after: Date.now() - FUNDING_LOOKBACK_SECONDS })
   const contracts = await manager.getContractsWithVtxos({ script })
   if (contracts.some((c) => c.vtxos.length > 0)) {
     throw new Error('Swap address already funded')

--- a/src/providers/swaps.tsx
+++ b/src/providers/swaps.tsx
@@ -23,7 +23,7 @@ import { sendOffChain } from '../lib/asp'
 import { ArkAddress, ServiceWorkerWallet } from '@arkade-os/sdk'
 import { hex } from '@scure/base'
 
-const FUNDING_LOOKBACK_SECONDS = 60000
+const FUNDING_LOOKBACK_MS = 60_000
 
 const BASE_URLS: Record<Network, string | null> = {
   bitcoin: import.meta.env.VITE_BOLTZ_URL ?? 'https://api.ark.boltz.exchange',
@@ -408,7 +408,7 @@ const assertSwapAddressUnfunded = async (svcWallet: ServiceWorkerWallet, swapAdd
   const decoded = ArkAddress.decode(swapAddress)
   const script = hex.encode(decoded.pkScript)
   const manager = await svcWallet.getContractManager()
-  await manager.refreshVtxos({ scripts: [script], after: Date.now() - FUNDING_LOOKBACK_SECONDS })
+  await manager.refreshVtxos({ scripts: [script], after: Date.now() - FUNDING_LOOKBACK_MS })
   const contracts = await manager.getContractsWithVtxos({ script })
   if (contracts.some((c) => c.vtxos.length > 0)) {
     throw new Error('Swap address already funded')


### PR DESCRIPTION
Fetch existing VTXOs for a swap script up to 60s ago, to avoid race conditions with Service Worker (example: swap fails after 10s, vtxo exists but out of the 5s window).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the lookback window for detecting previously funded swap addresses to improve reliability of swap funding checks when starting new swaps, reducing false negatives that could block swap initiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->