### PR TITLE
fix: query indexer directly for swap double-funding check

### DIFF
--- a/src/providers/swaps.tsx
+++ b/src/providers/swaps.tsx
@@ -20,10 +20,8 @@ import {
 import { ConfigContext } from './config'
 import { consoleError, consoleLog } from '../lib/logs'
 import { sendOffChain } from '../lib/asp'
-import { ArkAddress, ServiceWorkerWallet } from '@arkade-os/sdk'
+import { ArkAddress, RestIndexerProvider } from '@arkade-os/sdk'
 import { hex } from '@scure/base'
-
-const FUNDING_LOOKBACK_MS = 60_000
 
 const BASE_URLS: Record<Network, string | null> = {
   bitcoin: import.meta.env.VITE_BOLTZ_URL ?? 'https://api.ark.boltz.exchange',
@@ -241,7 +239,7 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
     const swapAddress = pendingSwap.response.lockupDetails.lockupAddress
 
     // Prevent double-funding: check that the swap address has no existing VTXOs
-    await assertSwapAddressUnfunded(svcWallet, swapAddress)
+    await assertSwapAddressUnfunded(aspInfo.url, swapAddress)
 
     const txid = await sendOffChain(svcWallet, satoshis, swapAddress)
     if (!txid) throw new Error('Failed to send offchain payment')
@@ -285,7 +283,7 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
     const swapAddress = pendingSwap.response.address
 
     // Prevent double-funding: check that the swap address has no existing VTXOs before paying
-    await assertSwapAddressUnfunded(svcWallet, swapAddress)
+    await assertSwapAddressUnfunded(aspInfo.url, swapAddress)
 
     const txid = await sendOffChain(svcWallet, satoshis, swapAddress)
     if (!txid) throw new Error('Failed to send offchain payment')
@@ -404,13 +402,12 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
   )
 }
 
-const assertSwapAddressUnfunded = async (svcWallet: ServiceWorkerWallet, swapAddress: string): Promise<void> => {
+const assertSwapAddressUnfunded = async (aspUrl: string, swapAddress: string): Promise<void> => {
   const decoded = ArkAddress.decode(swapAddress)
   const script = hex.encode(decoded.pkScript)
-  const manager = await svcWallet.getContractManager()
-  await manager.refreshVtxos({ scripts: [script], after: Date.now() - FUNDING_LOOKBACK_MS })
-  const contracts = await manager.getContractsWithVtxos({ script })
-  if (contracts.some((c) => c.vtxos.length > 0)) {
+  const indexer = new RestIndexerProvider(aspUrl)
+  const { vtxos } = await indexer.getVtxos({ scripts: [script], spendableOnly: true })
+  if (vtxos.length > 0) {
     throw new Error('Swap address already funded')
   }
 }


### PR DESCRIPTION
## Summary

- `assertSwapAddressUnfunded` was a no-op: `ContractManager.refreshVtxos()` filters by locally registered contracts, and swap addresses are never registered (they're short-lived, managed by SwapManager)
- The function made **no network call** for the swap script and always returned empty
- Now queries `RestIndexerProvider.getVtxos()` directly with `spendableOnly: true`

## Test plan

- [x] Create a submarine swap, fund it, then retry funding the same swap — should get "Swap address already funded" error
- [x] Normal swap flow (first funding) should proceed without issues