### PR TITLE
fix(qr): hardcode dark-on-white colors for scanner reliability

### DIFF
--- a/src/components/QrCode.tsx
+++ b/src/components/QrCode.tsx
@@ -87,12 +87,13 @@ export default function QrCode({ value }: QrCodeProps) {
     const matrix = encodeQR(value, 'raw', { ecc: 'medium', border: 0 })
     const size = matrix.length
     const moduleSize = 10
-    const quietZone = moduleSize * 2
+    const quietZone = moduleSize * 4
     const svgSize = size * moduleSize + quietZone * 2
 
-    const fgColor = 'var(--black)'
-    const bgColor = 'var(--ion-background-color, #fff)'
-    const logoColor = 'var(--logo-color)'
+    // Hardcoded for scanner reliability — QR must always be dark-on-white regardless of theme
+    const fgColor = '#040404'
+    const bgColor = '#ffffff'
+    const logoColor = '#391998'
 
     const logoModules = Math.ceil(size * 0.2)
     const logoZoneSize = logoModules % 2 === 0 ? logoModules + 1 : logoModules


### PR DESCRIPTION
## Summary

- QR codes were using theme-coupled CSS variables (`--black`, `--ion-background-color`, `--logo-color`) which flip in dark mode, producing light-on-dark QR codes that cameras struggle to scan
- Hardcoded QR colors to always render dark modules on white background regardless of app theme
- Increased quiet zone from 2 to 4 modules (QR spec minimum) for better scanner margin

Reported by a bitdevs attendee via James — QR codes hard to scan on dark screens.

## Changes

**`src/components/QrCode.tsx`** (only file changed):
- `fgColor`: `var(--black)` → `#040404`
- `bgColor`: `var(--ion-background-color, #fff)` → `#ffffff`
- `logoColor`: `var(--logo-color)` → `#391998`
- `quietZone`: `moduleSize * 2` → `moduleSize * 4`

## Before / after

| Before (dark mode) | After (dark mode) |
|---|---|
| QR blends into dark background, no visible quiet zone | White QR card pops against dark page, proper quiet zone |

## Test plan

- [x] Light mode: dark QR on white background with purple Arkade logo
- [x] Dark mode: same dark QR on white background — white card visible against dark page
- [x] Quiet zone visually wider than before
- [x] Playwright screenshots captured for both modes
- [ ] Phone camera scan test in dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced QR code appearance by increasing the white space padding around the code and updating the color scheme for improved visual clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->