### PR TITLE
fix(ui): add safe-area bottom padding to footer buttons and sheet modal

### DIFF
--- a/src/components/SheetModal.tsx
+++ b/src/components/SheetModal.tsx
@@ -16,12 +16,7 @@ export default function SheetModal({ children, isOpen, onClose }: SheetModalProp
   return (
     <IonModal initialBreakpoint={1} backdropBreakpoint={0} isOpen={isOpen} onDidDismiss={handleClose}>
       <div style={outerStyle}>
-        <div
-          style={{
-            ...innerStyle,
-            paddingBottom: '2rem',
-          }}
-        >
+        <div style={innerStyleWithSafeArea}>
           <div style={handleAreaStyle} onClick={handleClose}>
             <div style={handleStyle} />
           </div>
@@ -41,6 +36,11 @@ const outerStyle: React.CSSProperties = {
 const innerStyle: React.CSSProperties = {
   padding: '0 1.25rem',
   width: '100%',
+}
+
+const innerStyleWithSafeArea: React.CSSProperties = {
+  ...innerStyle,
+  paddingBottom: 'calc(2rem + env(safe-area-inset-bottom, 0px))',
 }
 
 const handleAreaStyle: React.CSSProperties = {

--- a/src/ionic.css
+++ b/src/ionic.css
@@ -232,6 +232,10 @@ ion-tab-bar ion-tab-button {
   padding-top: 2rem;
 }
 
+ion-footer.buttons-on-bottom {
+  padding-bottom: calc(var(--ion-padding, 16px) + env(safe-area-inset-bottom, 0px));
+}
+
 ion-app.has-pill-navbar ion-content {
   --padding-bottom: var(--pill-navbar-clearance);
 }


### PR DESCRIPTION
## Summary

- Adds `env(safe-area-inset-bottom)` padding to `ion-footer.buttons-on-bottom` in `ionic.css`, fixing buttons overlapping the iPhone home indicator on all screens using `ButtonsOnBottom` (30+ screens)
- Adds safe-area bottom padding to `SheetModal` inner content so sheet modal content doesn't sit in the home indicator area
- Ionic's `IonFooter` only auto-applies safe-area padding when it contains an `ion-toolbar`, which `ButtonsOnBottom` does not use — this fills that gap

## Changes

- `src/ionic.css` — New CSS rule: `ion-footer.buttons-on-bottom { padding-bottom: calc(var(--ion-padding, 16px) + env(safe-area-inset-bottom, 0px)); }`
- `src/components/SheetModal.tsx` — Added safe-area bottom padding, hoisted merged style to module-level constant

## Test plan

- [ ] Verify on iPhone (Safari/PWA) that bottom buttons have clear separation from home indicator
- [ ] Check receive amount, send form, init/onboarding, scanner, and settings screens
- [ ] Verify sheet modals don't clip into the home indicator area
- [ ] Confirm no visual regression on Android or desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modal inner content now respects device safe areas so content spacing near notches/home indicators is correct.
  * Footer buttons receive safe-area-aware bottom padding for consistent presentation on modern mobile screens.

* **Chores**
  * Updated regtest submodule to a newer commit for test maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->