### PR TITLE
fix(ui): top-align tx history rows when assets are present

### DIFF
--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -35,6 +35,7 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
   const prefix = tx.type === 'sent' ? '-' : '+'
   const amount = `${prefix} ${config.showBalance ? prettyAmount(tx.amount) : prettyHide(tx.amount)}`
   const date = tx.createdAt ? prettyDate(tx.createdAt) : tx.boardingTxid ? 'Unconfirmed' : 'Unknown'
+  const asAssets = Boolean(tx.assets?.length)
   const issuance = isIssuance(tx)
   const burn = isBurn(tx)
 
@@ -49,7 +50,7 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
             ? 'orange'
             : ''
     const value = toFiat(tx.amount)
-    const small = config.currencyDisplay === CurrencyDisplay.Both
+    const small = asAssets || config.currencyDisplay === CurrencyDisplay.Both
     const world = config.showBalance ? prettyFiatAmount(value, config.fiat) : prettyFiatHide(value, config.fiat)
     return (
       <Text color={color} small={small}>
@@ -79,7 +80,11 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
 
   const Sats = () =>
     issuance || burn ? null : (
-      <Text color={tx.type === 'received' ? (tx.preconfirmed && tx.boardingTxid ? 'orange' : 'green') : ''} thin>
+      <Text
+        color={tx.type === 'received' ? (tx.preconfirmed && tx.boardingTxid ? 'orange' : 'green') : ''}
+        smaller={asAssets}
+        thin
+      >
         {amount}
       </Text>
     )
@@ -96,7 +101,7 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
           const decimals = meta?.decimals ?? 8
           return (
             <FlexRow key={a.assetId} gap='0.25rem' end>
-              <Text color={color} smaller>
+              <Text color={color}>
                 {config.showBalance
                   ? `${formatAssetAmount(a.amount, decimals)} ${ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`}`
                   : prettyHide(a.amount, ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`)}
@@ -127,7 +132,12 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
 
   const Right = () => (
     <div style={{ textAlign: 'right' }}>
-      {config.currencyDisplay === CurrencyDisplay.Fiat ? (
+      {tx.assets?.length ? (
+        <>
+          <AssetInfo />
+          {config.currencyDisplay === CurrencyDisplay.Fiat ? <Fiat /> : <Sats />}
+        </>
+      ) : config.currencyDisplay === CurrencyDisplay.Fiat ? (
         <Fiat />
       ) : config.currencyDisplay === CurrencyDisplay.Sats ? (
         <Sats />
@@ -137,7 +147,6 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
           <Fiat />
         </>
       )}
-      <AssetInfo />
     </div>
   )
 

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -110,7 +110,6 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
   }
 
   const rowStyle = {
-    alignItems: 'center',
     borderTop: border,
     cursor: 'pointer',
     padding: '0.5rem 0',
@@ -144,7 +143,7 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
 
   return (
     <div style={rowStyle} onClick={onClick}>
-      <FlexRow>
+      <FlexRow between alignItems='start'>
         <Left />
         <Right />
       </FlexRow>


### PR DESCRIPTION
## Summary
- Fixes vertical alignment in transaction history rows when assets (e.g. "4 SCAM") are displayed alongside the BTC amount and fiat value
- The right column (sats + fiat + asset info) was taller than the left column, and `alignItems: 'center'` pushed the sats amount above the "Received" label
- Switches to `alignItems: 'start'` so both columns begin at the same top position
- Adds explicit `between` prop to the outer `FlexRow` (replacing implicit width-based spacing)
- Removes dead `alignItems: 'center'` on the non-flex wrapper div

## Test plan
- [ ] Open a wallet that has received asset transfers (e.g. SCAM token)
- [ ] Verify "Received" label and "+ X SATS" are top-aligned in the transaction row
- [ ] Verify rows without assets still look correct
- [ ] Verify the asset avatar icon and ticker remain visible and right-aligned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted transaction list row layout to refine content alignment. Right-side elements now align to the top of each row for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->