### PR TITLE
reverse logs in csv export

### DIFF
--- a/src/screens/Settings/Logs.tsx
+++ b/src/screens/Settings/Logs.tsx
@@ -109,6 +109,7 @@ export default function Logs() {
       .map((row) =>
         Object.values(row)
           .map((k) => `"${k}"`)
+          .reverse()
           .join(','),
       )
       .join('\n')

--- a/src/screens/Settings/Logs.tsx
+++ b/src/screens/Settings/Logs.tsx
@@ -106,10 +106,10 @@ export default function Logs() {
         .map((k) => `"${k}"`)
         .join(',') + '\n'
     const csvBody = logs
+      .reverse()
       .map((row) =>
         Object.values(row)
           .map((k) => `"${k}"`)
-          .reverse()
           .join(','),
       )
       .join('\n')

--- a/src/screens/Settings/Logs.tsx
+++ b/src/screens/Settings/Logs.tsx
@@ -105,7 +105,7 @@ export default function Logs() {
       Object.keys(logs[0])
         .map((k) => `"${k}"`)
         .join(',') + '\n'
-    const csvBody = logs
+    const csvBody = [...logs]
       .reverse()
       .map((row) =>
         Object.values(row)


### PR DESCRIPTION
NIT: reverse logs in CSV export so newer logs appear on top.

Useful for when Slack shows a preview of the CSV file in support channel.

@tiero wdyt?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV log export now produces rows in reverse chronological order so exported files list recent entries first (header and column values unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->