### PR TITLE
Prevent swap after receival

### DIFF
--- a/src/providers/flow.tsx
+++ b/src/providers/flow.tsx
@@ -30,6 +30,7 @@ export interface RecvInfo {
   assetId?: string
   assetAmount?: number
   receivedAssets?: Asset[]
+  received: boolean
 }
 
 export type SendInfo = {
@@ -83,6 +84,7 @@ export const emptyNoteInfo: NoteInfo = {
 export const emptyRecvInfo: RecvInfo = {
   boardingAddr: '',
   offchainAddr: '',
+  received: false,
   satoshis: 0,
 }
 

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -114,6 +114,7 @@ export default function ReceiveQRCode() {
   // LNURL session for amountless Lightning receives
   const isAmountlessLnurl =
     !satoshis && !isAssetReceive && !!lnurlServerUrl && connected && !!arkadeSwaps && !swapsInitError
+
   const handleInvoiceRequest = useCallback(
     async (req: { amountMsat: number }) => {
       const sats = Math.floor(req.amountMsat / 1000)
@@ -124,7 +125,7 @@ export default function ReceiveQRCode() {
         arkadeSwaps
           .waitAndClaim(pendingSwap)
           .then(() => {
-            setRecvInfo({ ...recvInfo, satoshis: pendingSwap.response.onchainAmount ?? 0 })
+            setRecvInfo({ ...recvInfo, received: true, satoshis: pendingSwap.response.onchainAmount ?? 0 })
             notifyPaymentReceived(pendingSwap.response.onchainAmount ?? 0)
             navigate(Pages.ReceiveSuccess)
           })
@@ -212,7 +213,7 @@ export default function ReceiveQRCode() {
         arkadeSwaps
           .waitAndClaimArk(pendingSwap)
           .then(() => {
-            setRecvInfo({ ...recvInfo, satoshis: pendingSwap.response.claimDetails.amount })
+            setRecvInfo({ ...recvInfo, received: true, satoshis: pendingSwap.response.claimDetails.amount })
             navigate(Pages.ReceiveSuccess)
           })
           .catch((error) => {
@@ -226,7 +227,7 @@ export default function ReceiveQRCode() {
         arkadeSwaps
           .waitAndClaim(pendingSwap)
           .then(() => {
-            setRecvInfo({ ...recvInfo, satoshis: pendingSwap.response.onchainAmount ?? 0 })
+            setRecvInfo({ ...recvInfo, received: true, satoshis: pendingSwap.response.onchainAmount ?? 0 })
             navigate(Pages.ReceiveSuccess)
           })
           .catch((error) => {

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -74,7 +74,7 @@ export default function ReceiveQRCode() {
   const prefersReducedMotion = useReducedMotion()
 
   // Receive methods
-  const { boardingAddr, offchainAddr, satoshis, assetId, addressError } = recvInfo
+  const { boardingAddr, offchainAddr, satoshis, assetId, addressError, received } = recvInfo
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
   const isAssetReceive = assetId && assetId !== ''
   const hasError = Boolean(addressError)
@@ -182,6 +182,7 @@ export default function ReceiveQRCode() {
     if (isAssetReceive) return setShowQrCode(true)
     if (!satoshis || !svcWallet) return
     if (!addressesLoaded) return
+    if (received) return
 
     const lnExpected = connected && !isAssetReceive
 
@@ -301,7 +302,7 @@ export default function ReceiveQRCode() {
       }
 
       if (sats || receivedAssets.length > 0) {
-        setRecvInfo({ ...recvInfo, satoshis: sats, receivedAssets })
+        setRecvInfo({ ...recvInfo, received: true, satoshis: sats, receivedAssets })
         if (!isAssetReceive) notifyPaymentReceived(sats)
         navigate(Pages.ReceiveSuccess)
       }


### PR DESCRIPTION
When the wallet receives some funds, it sets `recvInfo.satoshis` to the value received and jumps to the success page.
But there was an effect that would run with the `satoshi` update and create a reverse swap for the same value.
This PR adds a `received` field o recvInfo to prevent the bug. 