### PR TITLE
fix swap page

### DIFF
--- a/src/screens/Apps/Boltz/Swap.tsx
+++ b/src/screens/Apps/Boltz/Swap.tsx
@@ -110,7 +110,7 @@ export default function AppBoltzSwap() {
       ['Total', formatAmount(sentSats)],
     ]
   } else if (swapInfo.type === 'reverse') {
-    const sentSats = swapInfo.request.invoiceAmount ?? 0
+    const sentSats = swapInfo.request.invoiceAmount
     const rcvdSats = swapInfo.response.onchainAmount ?? 0
 
     tableData = [
@@ -127,7 +127,7 @@ export default function AppBoltzSwap() {
       ['Total', formatAmount(sentSats)],
     ]
   } else if (swapInfo.type === 'submarine') {
-    const sentSats = swapInfo.response.expectedAmount ?? 0
+    const sentSats = swapInfo.response.expectedAmount
     const rcvdSats = isValidInvoice(swapInfo.request.invoice) ? decodeInvoice(swapInfo.request.invoice).amountSats : 0
 
     tableData = [

--- a/src/screens/Apps/Boltz/Swap.tsx
+++ b/src/screens/Apps/Boltz/Swap.tsx
@@ -110,12 +110,12 @@ export default function AppBoltzSwap() {
       ['Total', formatAmount(sentSats)],
     ]
   } else if (swapInfo.type === 'reverse') {
-    const sentSats = swapInfo.request.invoiceAmount
-    const rcvdSats = swapInfo.response.onchainAmount
+    const sentSats = swapInfo.request.invoiceAmount ?? 0
+    const rcvdSats = swapInfo.response.onchainAmount ?? 0
 
     tableData = [
       ['When', when],
-      ['Kind', 'Chain Swap'],
+      ['Kind', 'Reverse Swap'],
       ['Swap ID', swapId],
       ['Direction', 'Lightning to Arkade'],
       ['Date', date],
@@ -127,8 +127,8 @@ export default function AppBoltzSwap() {
       ['Total', formatAmount(sentSats)],
     ]
   } else if (swapInfo.type === 'submarine') {
-    const sentSats = isValidInvoice(swapInfo.request.invoice) ? decodeInvoice(swapInfo.request.invoice).amountSats : 0
-    const rcvdSats = swapInfo.response.expectedAmount ?? 0
+    const sentSats = swapInfo.response.expectedAmount ?? 0
+    const rcvdSats = isValidInvoice(swapInfo.request.invoice) ? decodeInvoice(swapInfo.request.invoice).amountSats : 0
 
     tableData = [
       ['When', when],

--- a/src/test/e2e/swap.test.ts
+++ b/src/test/e2e/swap.test.ts
@@ -18,7 +18,6 @@ test('should be connected to Boltz app', async ({ page }) => {
 })
 
 test('should receive funds from Lightning', async ({ page, isMobile }) => {
-  test.setTimeout(60000)
   await createWallet(page)
 
   // get invoice
@@ -47,6 +46,27 @@ test('should receive funds from Lightning', async ({ page, isMobile }) => {
   await expect(page.getByText('Successful')).toBeVisible()
   await expect(page.getByText('+ 1,992')).toBeVisible()
   await expect(page.getByText('Lightning to Arkade')).toBeVisible()
+
+  // swap page should show correct details
+  await page.getByText('Lightning to Arkade').click()
+  await expect(page.getByText('When')).toBeVisible()
+  await expect(page.getByText('Kind')).toBeVisible()
+  await expect(page.getByText('Swap ID')).toBeVisible()
+  await expect(page.getByText('Direction')).toBeVisible()
+  await expect(page.getByText('Date')).toBeVisible()
+  await expect(page.getByText('Preimage')).toBeVisible()
+  await expect(page.getByText('Invoice', { exact: true })).toBeVisible()
+  await expect(page.getByText('Status')).toBeVisible()
+  await expect(page.getByText('Amount')).toBeVisible()
+  await expect(page.getByText('Fees')).toBeVisible()
+  await expect(page.getByText('Total')).toBeVisible()
+
+  expect(await page.getByTestId('Kind').textContent()).toBe('Reverse Swap')
+  expect(await page.getByTestId('Direction').textContent()).toBe('Lightning to Arkade')
+  expect(await page.getByTestId('Status').textContent()).toBe('invoice.settled')
+  expect(await page.getByTestId('Amount').textContent()).toBe('1,992 SATS')
+  expect(await page.getByTestId('Fees').textContent()).toBe('8 SATS')
+  expect(await page.getByTestId('Total').textContent()).toBe('2,000 SATS')
 })
 
 test('should send funds to Lightning', async ({ page }) => {
@@ -75,6 +95,64 @@ test('should send funds to Lightning', async ({ page }) => {
   await expect(page.getByText('Successful')).toBeVisible()
   await page.waitForSelector('text=- 1,001', { timeout: 10000 })
   await expect(page.getByText('Arkade to Lightning')).toBeVisible()
+
+  // swap page should show correct details
+  await page.getByText('Arkade to Lightning').click()
+  await expect(page.getByText('When')).toBeVisible()
+  await expect(page.getByText('Kind')).toBeVisible()
+  await expect(page.getByText('Swap ID')).toBeVisible()
+  await expect(page.getByText('Direction')).toBeVisible()
+  await expect(page.getByText('Date')).toBeVisible()
+  await expect(page.getByText('Preimage')).toBeVisible()
+  await expect(page.getByText('Invoice')).toBeVisible()
+  await expect(page.getByText('Status')).toBeVisible()
+  await expect(page.getByText('Amount')).toBeVisible()
+  await expect(page.getByText('Fees')).toBeVisible()
+  await expect(page.getByText('Total')).toBeVisible()
+
+  expect(await page.getByTestId('Kind').textContent()).toBe('Submarine Swap')
+  expect(await page.getByTestId('Direction').textContent()).toBe('Arkade to Lightning')
+  expect(await page.getByTestId('Status').textContent()).toBe('transaction.claimed')
+  expect(await page.getByTestId('Amount').textContent()).toBe('1,000 SATS')
+  expect(await page.getByTestId('Fees').textContent()).toBe('1 SAT')
+  expect(await page.getByTestId('Total').textContent()).toBe('1,001 SATS')
+})
+
+test('should send funds to Bitcoin', async ({ page, isMobile }) => {
+  await createWallet(page)
+  await fundWallet(page, 5000)
+
+  const someOnchainAddress = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+
+  // pay invoice
+  await pay(page, someOnchainAddress, isMobile, 2000)
+
+  // should be visible in Boltz app
+  await page.getByTestId('tab-apps').click()
+  await expect(page.getByText('Boltz', { exact: true })).toBeVisible()
+  await page.getByTestId('app-boltz').click()
+  await expect(page.getByText('Boltz')).toBeVisible()
+  await expect(page.getByText('Successful')).toBeVisible()
+  await expect(page.getByText('Arkade to Bitcoin')).toBeVisible()
+
+  // swap page should show correct details
+  await page.getByText('Arkade to Bitcoin').click()
+  await expect(page.getByText('When')).toBeVisible()
+  await expect(page.getByText('Kind')).toBeVisible()
+  await expect(page.getByText('Swap ID')).toBeVisible()
+  await expect(page.getByText('Direction')).toBeVisible()
+  await expect(page.getByText('Date')).toBeVisible()
+  await expect(page.getByText('Status')).toBeVisible()
+  await expect(page.getByText('Amount')).toBeVisible()
+  await expect(page.getByText('Fees')).toBeVisible()
+  await expect(page.getByText('Total')).toBeVisible()
+
+  expect(await page.getByTestId('Kind').textContent()).toBe('Chain Swap')
+  expect(await page.getByTestId('Direction').textContent()).toBe('Arkade to BTC')
+  expect(await page.getByTestId('Status').textContent()).toBe('transaction.claimed')
+  expect(await page.getByTestId('Amount').textContent()).toBe('2,111 SATS')
+  expect(await page.getByTestId('Fees').textContent()).toBe('164 SATS')
+  expect(await page.getByTestId('Total').textContent()).toBe('2,275 SATS')
 })
 
 test('should refund failing swap', async ({ page }) => {


### PR DESCRIPTION
Fixes values in submarine swap page and direction in reverse swap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reverse-swap label to "Reverse Swap" and improved handling of missing swap amounts so displayed values default to 0.
  * Fixed displayed amount/fee/total calculations for submarine and reverse swaps.

* **Tests**
  * Expanded end-to-end coverage: added detailed assertions for swap detail fields and values, and a new on-chain (Arkade to Bitcoin) swap test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->