### PR TITLE
fix(receive): add spacing between button row and share button

### DIFF
--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -423,7 +423,7 @@ export default function ReceiveQRCode() {
       </Content>
 
       <ButtonsOnBottom>
-        <FlexCol gap='0'>
+        <FlexCol gap='0.75rem'>
           <FlexRow gap='0.5rem'>
             <Button label={amountLabel} onClick={() => setShowAmountSheet(true)} secondary />
             <Button label='Copy' onClick={() => setShowCopySheet(true)} secondary />


### PR DESCRIPTION
## Summary
- Increased vertical spacing between the "Add amount / Copy" button row and the "Share" button on the receive page
- Changed `FlexCol gap` from `0` to `0.75rem` (12px)

## Test plan
- [ ] Open receive page
- [ ] Verify spacing between button row and Share button looks correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing between action buttons and controls on the Wallet Receive QR Code screen. Enhanced layout with better vertical spacing between amount/copy options and sharing functionality provides improved visual organization, clearer hierarchy, and a more polished user interface presentation. The adjustments result in a cleaner, more intuitive layout for wallet receive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->