### PR TITLE
feat(wallet): redesign home screen with portfolio hero and floating action bar

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "arkade",
       "dependencies": {
-        "@arkade-os/boltz-swap": "0.3.16",
-        "@arkade-os/sdk": "0.4.15",
+        "@arkade-os/boltz-swap": "0.3.17",
+        "@arkade-os/sdk": "0.4.16",
         "@branta-ops/branta": "0.0.9",
         "@lendasat/lendasat-wallet-bridge": "^0.0.90",
         "@noble/curves": "^2.0.1",
@@ -77,9 +77,9 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@arkade-os/boltz-swap": ["@arkade-os/boltz-swap@0.3.16", "", { "dependencies": { "@arkade-os/sdk": "0.4.15", "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0", "@scure/btc-signer": "2.0.1", "bip68": "1.0.4", "light-bolt11-decoder": "3.2.0" } }, "sha512-lGCI9AE292IFbQdpChxiVeiaQjs0emTCi2SUPNG38y3IqJ98gBxTkyyNmiONcsNKZvkyX4LE7WAfk+0lIeHyGQ=="],
+    "@arkade-os/boltz-swap": ["@arkade-os/boltz-swap@0.3.17", "", { "dependencies": { "@arkade-os/sdk": "0.4.16", "@noble/curves": "^2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0", "@scure/btc-signer": "2.0.1", "bip68": "^1.0.4", "light-bolt11-decoder": "3.2.0" } }, "sha512-OgddsRgYPBd876vyUw09S1x93vhdwi378ZLku4k4ZUD9xOoEkeGEuS9qVOh4MYhdE0IXGnWeHfE9A+HNfDytkQ=="],
 
-    "@arkade-os/sdk": ["@arkade-os/sdk@0.4.15", "", { "dependencies": { "@bitcoinerlab/descriptors-scure": "3.1.7", "@marcbachmann/cel-js": "7.3.1", "@noble/curves": "2.0.1", "@noble/secp256k1": "3.0.0", "@scure/base": "2.0.0", "@scure/bip39": "2.0.1", "@scure/btc-signer": "2.0.1", "bip68": "1.0.4" } }, "sha512-zUA1Cw/NYj9PG6afpIuEser50wDRuUBcXkkU2YPcvDKJPwlGmmk6/NbBCevsqk0HAiQHuIDEryO3nHccwW08bA=="],
+    "@arkade-os/sdk": ["@arkade-os/sdk@0.4.16", "", { "dependencies": { "@bitcoinerlab/descriptors-scure": "3.1.7", "@marcbachmann/cel-js": "7.3.1", "@noble/curves": "2.0.1", "@noble/secp256k1": "3.0.0", "@scure/base": "2.0.0", "@scure/bip39": "2.0.1", "@scure/btc-signer": "2.0.1", "bip68": "1.0.4" }, "peerDependencies": { "@react-native-async-storage/async-storage": ">=1.0.0", "expo": ">=54.0.0", "expo-background-task": "~1.0.10", "expo-sqlite": "~16.0.10", "expo-task-manager": "~14.0.9" }, "optionalPeers": ["@react-native-async-storage/async-storage", "expo", "expo-background-task", "expo-sqlite", "expo-task-manager"] }, "sha512-7eKFZLEuZ9gHLWJPwaC30bnBCYNU6a+qhCyAx4JOHS9nIV+rChSl4aqjDhQBqzE/xpCf01eLLH84CLTf/WBfsQ=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "2.1.4", "@csstools/css-color-parser": "3.1.0", "@csstools/css-parser-algorithms": "3.0.5", "@csstools/css-tokenizer": "3.0.4", "lru-cache": "10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,7 +241,8 @@ export default function App() {
 
   const comp = page === Pages.Loading ? null : pageComponent(page)
   const isSettingsRoot = screen === Pages.Settings && option === SettingsOptions.Menu
-  const showNavbar = page === screen && (screen === Pages.Wallet || screen === Pages.Apps || isSettingsRoot)
+  // Wallet home uses floating action bar + header icons instead of pill navbar
+  const showNavbar = page === screen && (screen === Pages.Apps || isSettingsRoot)
 
   const appStyle: React.CSSProperties = {
     display: 'flex',

--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -1,37 +1,111 @@
-import Text from './Text'
-import Shadow from './Shadow'
-import FlexCol from './FlexCol'
-import FlexRow from './FlexRow'
+import { ReactNode } from 'react'
 import AssetAvatar from './AssetAvatar'
 import { centsToUnits, truncatedAssetId } from '../lib/assets'
 import { prettyNumber } from '../lib/format'
+import { hapticLight } from '../lib/haptics'
 
 interface AssetCardProps {
   assetId: string
   balance: number
   decimals?: number
   icon?: string
+  /** Fully rendered avatar (e.g. a real Bitcoin SVG). Takes precedence over `icon`. */
+  avatar?: ReactNode
+  /** Background color for the avatar circle. */
+  avatarBg?: string
+  /** Foreground color for the avatar content. */
+  avatarColor?: string
+  /** Asset name (e.g. "Bitcoin"). */
   name?: string
+  /** Asset ticker (e.g. "BTC"). */
   ticker?: string
+  /** Fiat-value text shown on the right (e.g. "$7.29 USD"). */
+  fiatText?: string
   onClick?: () => void
 }
-export default function AssetCard({ assetId, balance, decimals, icon, name, ticker, onClick }: AssetCardProps) {
-  const assetName = name || truncatedAssetId(assetId) || 'Asset name'
-  const tokenTick = ticker ? ticker : 'TKN'
+
+/**
+ * Home-screen asset row. Clean card with subtle border and shadow.
+ * Left column: avatar + name + balance. Right column: fiat value.
+ */
+export default function AssetCard({
+  assetId,
+  balance,
+  decimals,
+  icon,
+  avatar,
+  avatarBg,
+  avatarColor,
+  name,
+  ticker,
+  fiatText,
+  onClick,
+}: AssetCardProps) {
+  const assetName = name || truncatedAssetId(assetId) || 'Asset'
+  const tokenTick = ticker ?? 'TKN'
+  const prettyBalance = prettyNumber(centsToUnits(balance, decimals ?? 8))
+  const leftSecondary = `${prettyBalance} ${tokenTick}`
+
+  const handleClick = onClick
+    ? () => {
+        hapticLight()
+        onClick()
+      }
+    : undefined
+
+  const renderedAvatar = avatar ? (
+    <div
+      className="flex size-9 min-h-9 min-w-9 items-center justify-center rounded-full font-semibold"
+      style={{
+        background: avatarBg ?? 'var(--neutral-100)',
+        color: avatarColor ?? 'var(--orange)',
+      }}
+    >
+      {avatar}
+    </div>
+  ) : (
+    <AssetAvatar icon={icon} name={name} ticker={ticker} size={36} assetId={assetId} />
+  )
+
+  const content = (
+    <>
+      <div className="flex items-center gap-3">
+        {renderedAvatar}
+        <div className="flex flex-col items-start gap-0.5">
+          <span className="font-medium">{assetName}</span>
+          <span className="text-sm text-[var(--neutral-500)]">{leftSecondary}</span>
+        </div>
+      </div>
+      {fiatText ? (
+        <div className="text-right">
+          <span className="font-heading text-lg font-medium">{fiatText}</span>
+        </div>
+      ) : null}
+    </>
+  )
+
+  const baseClasses =
+    'flex w-full items-center justify-between rounded-xl border border-[var(--neutral-100)] bg-[var(--bg)] px-4 py-3.5 text-left text-inherit shadow-sm'
+
+  // Non-interactive row (e.g. BTC which has no detail screen)
+  if (!onClick) {
+    return (
+      <div data-testid={`asset-row-${assetId || 'btc'}`} className={baseClasses}>
+        {content}
+      </div>
+    )
+  }
+
+  // Interactive row with tap feedback
   return (
-    <Shadow key={assetId} border onClick={onClick} darkPurple>
-      <FlexRow between padding='0.75rem' testId={tokenTick}>
-        <FlexRow>
-          <AssetAvatar icon={icon} name={name} ticker={ticker} size={32} assetId={assetId} clickable />
-          <FlexCol gap='0'>
-            <Text bold>{assetName}</Text>
-            <Text color='white' smaller>
-              {tokenTick}
-            </Text>
-          </FlexCol>
-        </FlexRow>
-        <Text>{prettyNumber(centsToUnits(balance, decimals ?? 8))}</Text>
-      </FlexRow>
-    </Shadow>
+    <button
+      type="button"
+      onClick={handleClick}
+      data-testid={`asset-row-${assetId || 'btc'}`}
+      className={`${baseClasses} cursor-pointer transition-transform active:scale-[0.98]`}
+      style={{ touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent' }}
+    >
+      {content}
+    </button>
   )
 }

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -3,6 +3,7 @@ import { usePullToRefresh } from '../hooks/usePullToRefresh'
 
 interface ContentProps {
   children: ReactNode
+  className?: string
   noFade?: boolean
   onPullToRefresh?: () => Promise<void>
 }
@@ -56,7 +57,7 @@ function PullArrow({ progress }: { progress: number }) {
   )
 }
 
-export default function Content({ children, noFade, onPullToRefresh }: ContentProps) {
+export default function Content({ children, className, noFade, onPullToRefresh }: ContentProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const { pullOffset, isRefreshing, progress } = usePullToRefresh({
@@ -85,7 +86,7 @@ export default function Content({ children, noFade, onPullToRefresh }: ContentPr
         position: 'relative',
         touchAction: onPullToRefresh ? 'pan-y' : undefined,
       }}
-      className={noFade ? 'no-content-fade' : undefined}
+      className={[noFade ? 'no-content-fade' : '', className].filter(Boolean).join(' ') || undefined}
     >
       {/* Indicator in the space above content */}
       {onPullToRefresh ? (

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -152,10 +152,20 @@ const TransactionLine = ({ tx, onClick }: { tx: Tx; onClick: () => void }) => {
   )
 }
 
-export default function TransactionsList() {
+interface TransactionsListProps {
+  /** Override the default "Transaction history" title. Pass '' to hide it. */
+  title?: string
+  /** 'virtual' (default) uses virtualization; 'static' renders a simple list. */
+  mode?: 'virtual' | 'static'
+  /** Max number of transactions to show (only applies when mode='static'). */
+  limit?: number
+}
+
+export default function TransactionsList({ title, mode = 'virtual', limit }: TransactionsListProps = {}) {
   const { setTxInfo } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
-  const { txs } = useContext(WalletContext)
+  const { txs: allTxs } = useContext(WalletContext)
+  const txs = mode === 'static' && limit ? allTxs.slice(0, limit) : allTxs
 
   const focusedRef = useRef(false)
   const focusedIndexRef = useRef(0)
@@ -215,9 +225,24 @@ export default function TransactionsList() {
     navigate(Pages.Transaction)
   }
 
+  // Static mode: simple list without virtualization
+  if (mode === 'static') {
+    return (
+      <div>
+        {title !== '' && <TextLabel>{title ?? 'Transaction history'}</TextLabel>}
+        <div style={{ borderBottom: border }}>
+          {txs.map((tx, index) => (
+            <TransactionLine key={key(tx, index)} onClick={() => handleClick(tx)} tx={tx} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  // Virtual mode: virtualized list for long transaction history
   return (
     <>
-      <TextLabel>Transaction history</TextLabel>
+      {title !== '' && <TextLabel>{title ?? 'Transaction history'}</TextLabel>}
       <Focusable id='outer' onEnter={focusOnFirstRow} ariaLabel={ariaLabel()}>
         <div
           ref={parentRef}
@@ -232,7 +257,7 @@ export default function TransactionsList() {
         >
           <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative', width: '100%' }}>
             {virtualizer.getVirtualItems().map((virtualItem) => {
-              const tx = txs[virtualItem.index]
+              const tx = allTxs[virtualItem.index]
               const k = key(tx, virtualItem.index)
               return (
                 <div

--- a/src/components/WalletActionBar.tsx
+++ b/src/components/WalletActionBar.tsx
@@ -1,0 +1,35 @@
+import Button from './Button'
+import SendIcon from '../icons/Send'
+import SwapIcon from '../icons/Swap'
+import ReceiveIcon from '../icons/Receive'
+
+interface WalletActionBarProps {
+  onSendClick: () => void
+  onSwapClick: () => void
+  onReceiveClick: () => void
+}
+
+/**
+ * Full-width purple primary action buttons (Send | Swap | Receive).
+ * Rendered inside WalletActionBarOverlay which supplies the fixed positioning
+ * and gradient haze behind the buttons.
+ */
+export default function WalletActionBar({ onSendClick, onSwapClick, onReceiveClick }: WalletActionBarProps) {
+  return (
+    <div
+      role="toolbar"
+      aria-label="Wallet actions"
+      className="flex w-full gap-2"
+    >
+      <div className="min-w-0 flex-1" data-testid="action-send">
+        <Button main icon={<SendIcon />} label="Send" onClick={onSendClick} />
+      </div>
+      <div className="min-w-0 flex-1" data-testid="action-swap">
+        <Button main icon={<SwapIcon />} label="Swap" onClick={onSwapClick} />
+      </div>
+      <div className="min-w-0 flex-1" data-testid="action-receive">
+        <Button main icon={<ReceiveIcon />} label="Receive" onClick={onReceiveClick} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/WalletActionBarOverlay.tsx
+++ b/src/components/WalletActionBarOverlay.tsx
@@ -1,0 +1,40 @@
+import { createPortal } from 'react-dom'
+import { motion, useReducedMotion } from 'framer-motion'
+import WalletActionBar from './WalletActionBar'
+
+interface WalletActionBarOverlayProps {
+  visible: boolean
+  onSendClick: () => void
+  onSwapClick: () => void
+  onReceiveClick: () => void
+}
+
+/**
+ * Fixed overlay pinned to the bottom of the viewport holding the wallet action
+ * bar. Renders a radial gradient haze behind the buttons for depth and to
+ * smoothly fade the scrolling content behind them.
+ */
+export default function WalletActionBarOverlay({
+  visible,
+  onSendClick,
+  onSwapClick,
+  onReceiveClick,
+}: WalletActionBarOverlayProps) {
+  const prefersReduced = useReducedMotion()
+
+  return createPortal(
+    <motion.div
+      className={`wallet-action-bar-layer ${!visible ? 'wallet-action-bar-layer--hidden' : ''}`}
+      animate={visible ? { opacity: 1, y: 0 } : { opacity: 0, y: 24 }}
+      initial={false}
+      transition={prefersReduced ? { duration: 0 } : { type: 'spring', duration: 0.5, bounce: 0.25 }}
+      {...(!visible && { inert: '' })}
+    >
+      <div className="wallet-action-bar-haze" aria-hidden="true" />
+      <div className="wallet-action-bar-dock">
+        <WalletActionBar onSendClick={onSendClick} onSwapClick={onSwapClick} onReceiveClick={onReceiveClick} />
+      </div>
+    </motion.div>,
+    document.body,
+  )
+}

--- a/src/hooks/usePortfolioFiat.ts
+++ b/src/hooks/usePortfolioFiat.ts
@@ -1,0 +1,79 @@
+import { useContext } from 'react'
+import { WalletContext } from '../providers/wallet'
+import { FiatContext } from '../providers/fiat'
+
+export interface PortfolioRow {
+  /** 'btc' for the native Bitcoin row, otherwise the asset's on-chain id. */
+  assetId: string
+  name: string
+  ticker: string
+  icon?: string
+  decimals: number
+  /** Raw balance in the asset's smallest unit (sats for BTC, minor units otherwise). */
+  balance: number
+  /** Fiat value in the user's selected currency (0 if no price feed). */
+  fiatAmount: number
+  /** Equivalent value in satoshis, computed via the live BTC→USD rate. */
+  satsEquivalent: number
+  /** True if this asset has a price feed and fiatAmount is meaningful. */
+  hasFiatPrice: boolean
+}
+
+export interface PortfolioFiat {
+  totalFiat: number
+  totalSats: number
+  rows: PortfolioRow[]
+}
+
+/**
+ * Aggregates BTC + all asset balances into a single fiat total using the
+ * user's configured currency. Non-BTC assets currently show balance only
+ * (no fiat conversion without a price feed).
+ */
+export function usePortfolioFiat(): PortfolioFiat {
+  const { balance, assetBalances, assetMetadataCache } = useContext(WalletContext)
+  const { toFiat } = useContext(FiatContext)
+
+  const rows: PortfolioRow[] = []
+  let totalSats = 0
+
+  // BTC row first — always present.
+  totalSats += balance
+  rows.push({
+    assetId: 'btc',
+    name: 'Bitcoin',
+    ticker: 'BTC',
+    decimals: 8,
+    balance,
+    fiatAmount: toFiat(balance),
+    satsEquivalent: balance,
+    hasFiatPrice: true,
+  })
+
+  // Non-BTC asset rows from real SDK data.
+  for (const ab of assetBalances) {
+    const meta = assetMetadataCache.get(ab.assetId)?.metadata
+    const decimals = meta?.decimals ?? 8
+    // No price feed yet for non-BTC assets — show balance only.
+    const satsEq = 0
+    totalSats += satsEq
+
+    rows.push({
+      assetId: ab.assetId,
+      name: meta?.name ?? `Asset ${ab.assetId.slice(0, 8)}…`,
+      ticker: meta?.ticker ?? 'TKN',
+      icon: meta?.icon,
+      decimals,
+      balance: ab.amount,
+      fiatAmount: toFiat(satsEq),
+      satsEquivalent: satsEq,
+      hasFiatPrice: false,
+    })
+  }
+
+  return {
+    totalFiat: toFiat(totalSats),
+    totalSats,
+    rows,
+  }
+}

--- a/src/icons/Bitcoin.tsx
+++ b/src/icons/Bitcoin.tsx
@@ -1,0 +1,42 @@
+interface BitcoinIconProps {
+  size?: number
+}
+
+export default function BitcoinIcon({ size = 24 }: BitcoinIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9.5 5.5V4M9.5 20v-1.5M14.5 5.5V4M14.5 20v-1.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M7 8.5h8.5c1.38 0 2.5 1.12 2.5 2.5s-1.12 2.5-2.5 2.5H7V8.5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7 13.5h9c1.38 0 2.5 1.12 2.5 2.5s-1.12 2.5-2.5 2.5H7v-5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7 8.5V5.5M7 18.5v-3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/src/icons/Coins.tsx
+++ b/src/icons/Coins.tsx
@@ -1,0 +1,31 @@
+export default function CoinsIcon({ size = 20 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        r="6"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M18.09 10.37A6 6 0 1 1 10.34 18"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+      <path
+        d="M7 6h2M8 8V6"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/src/icons/History.tsx
+++ b/src/icons/History.tsx
@@ -1,0 +1,30 @@
+interface HistoryIconProps {
+  size?: number
+}
+
+export default function HistoryIcon({ size = 24 }: HistoryIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 8v4l2.5 2.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3.05 11a9 9 0 1 1 .5 4m-.5-4H6m-2.95 0V7"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/src/icons/Landmark.tsx
+++ b/src/icons/Landmark.tsx
@@ -1,0 +1,19 @@
+export default function LandmarkIcon({ size = 20 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 21h18M3 10h18M5 6l7-3 7 3M4 10v11M20 10v11M8 14v3M12 14v3M16 14v3"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/src/icons/Plus.tsx
+++ b/src/icons/Plus.tsx
@@ -1,0 +1,18 @@
+export default function PlusIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 5v14M5 12h14"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -433,3 +433,63 @@ input:focus::placeholder {
   width: auto !important;
   white-space: nowrap !important;
 }
+
+/* ================================================
+   Wallet Action Bar
+   ================================================ */
+
+:root {
+  --wallet-action-bar-spacer: calc(112px + env(safe-area-inset-bottom, 0px));
+  --wallet-action-bar-clearance: calc(96px + env(safe-area-inset-bottom, 0px));
+}
+
+.wallet-action-bar-layer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.wallet-action-bar-layer--hidden .wallet-action-bar-dock {
+  pointer-events: none;
+}
+
+.wallet-action-bar-dock {
+  position: relative;
+  padding: 0 1rem calc(1rem + env(safe-area-inset-bottom, 0px));
+  pointer-events: auto;
+}
+
+.wallet-action-bar-haze {
+  position: absolute;
+  inset: 0;
+  top: auto;
+  height: 200px;
+  background: linear-gradient(
+    to top,
+    var(--bg) 0%,
+    var(--bg) 40%,
+    color-mix(in srgb, var(--bg) 92%, transparent) 60%,
+    color-mix(in srgb, var(--bg) 70%, transparent) 75%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+.dark .wallet-action-bar-haze {
+  background: linear-gradient(
+    to top,
+    var(--bg) 0%,
+    var(--bg) 45%,
+    color-mix(in srgb, var(--bg) 95%, transparent) 65%,
+    color-mix(in srgb, var(--bg) 80%, transparent) 80%,
+    transparent 100%
+  );
+}
+
+/* Content padding when action bar is visible */
+.has-wallet-action-bar .content-shell {
+  padding-bottom: var(--wallet-action-bar-spacer);
+}

--- a/src/providers/navigation.tsx
+++ b/src/providers/navigation.tsx
@@ -16,6 +16,7 @@ import Transaction from '../screens/Wallet/Transaction'
 import Unlock from '../screens/Wallet/Unlock'
 import Vtxos from '../screens/Settings/Vtxos'
 import Wallet from '../screens/Wallet/Index'
+import Activity from '../screens/Wallet/Activity'
 import Settings from '../screens/Settings/Index'
 
 import Apps from '../screens/Apps/Index'
@@ -41,6 +42,7 @@ import ComponentPreview from '../screens/ComponentPreview'
 export type NavigationDirection = 'forward' | 'back' | 'none'
 
 export enum Pages {
+  Activity,
   AppBoltz,
   AppBoltzSettings,
   AppBoltzSwap,
@@ -88,6 +90,7 @@ export enum Tabs {
 }
 
 const pageTab = {
+  [Pages.Activity]: Tabs.Wallet,
   [Pages.AppBoltz]: Tabs.Apps,
   [Pages.AppBoltzSettings]: Tabs.Apps,
   [Pages.AppBoltzSwap]: Tabs.Apps,
@@ -147,6 +150,8 @@ export const subNavHandler = {
 
 export const pageComponent = (page: Pages): JSX.Element => {
   switch (page) {
+    case Pages.Activity:
+      return <Activity />
     case Pages.AppBoltz:
       return <AppBoltz />
     case Pages.AppBoltzSettings:

--- a/src/screens/Wallet/Activity.tsx
+++ b/src/screens/Wallet/Activity.tsx
@@ -1,0 +1,43 @@
+import { useContext } from 'react'
+import Content from '../../components/Content'
+import Padded from '../../components/Padded'
+import TransactionsList from '../../components/TransactionsList'
+import { EmptyTxList } from '../../components/Empty'
+import { WalletContext } from '../../providers/wallet'
+import { NavigationContext, Pages } from '../../providers/navigation'
+import BackIcon from '../../icons/Back'
+import { hapticLight } from '../../lib/haptics'
+
+/**
+ * Full transaction history page. Accessed from the home screen header
+ * activity icon or the "View all" link in RecentActivitySection.
+ */
+export default function Activity() {
+  const { txs } = useContext(WalletContext)
+  const { navigate } = useContext(NavigationContext)
+
+  const handleBack = () => {
+    hapticLight()
+    navigate(Pages.Wallet)
+  }
+
+  return (
+    <Content>
+      <Padded>
+        <div className="flex items-center gap-3 pb-4 pt-2">
+          <button
+            type="button"
+            onClick={handleBack}
+            aria-label="Go back"
+            className="inline-flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 text-inherit active:scale-95"
+            style={{ touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent' }}
+          >
+            <BackIcon />
+          </button>
+          <span className="font-heading text-xl font-medium">Activity</span>
+        </div>
+        {!txs || txs.length === 0 ? <EmptyTxList /> : <TransactionsList title="" />}
+      </Padded>
+    </Content>
+  )
+}

--- a/src/screens/Wallet/AssetsSection.tsx
+++ b/src/screens/Wallet/AssetsSection.tsx
@@ -1,0 +1,122 @@
+import { useContext } from 'react'
+import AssetCard from '../../components/AssetCard'
+import PlusIcon from '../../icons/Plus'
+import ArrowIcon from '../../icons/Arrow'
+import BitcoinIcon from '../../icons/Bitcoin'
+import { usePortfolioFiat } from '../../hooks/usePortfolioFiat'
+import { NavigationContext, Pages } from '../../providers/navigation'
+import { ConfigContext } from '../../providers/config'
+import { FiatContext } from '../../providers/fiat'
+import { FlowContext } from '../../providers/flow'
+import { hapticLight } from '../../lib/haptics'
+import { prettyNumber } from '../../lib/format'
+
+interface AssetsSectionProps {
+  onCreateClick: () => void
+}
+
+export default function AssetsSection({ onCreateClick }: AssetsSectionProps) {
+  const { navigate } = useContext(NavigationContext)
+  const { config } = useContext(ConfigContext)
+  const { fiatDecimals } = useContext(FiatContext)
+  const { setAssetInfo } = useContext(FlowContext)
+  const { rows } = usePortfolioFiat()
+
+  const handleViewAll = () => {
+    hapticLight()
+    navigate(Pages.AppAssets)
+  }
+
+  const handleCreate = () => {
+    hapticLight()
+    onCreateClick()
+  }
+
+  const handleRowClick = (assetId: string) => () => {
+    // BTC row is non-interactive (no detail screen)
+    if (assetId === 'btc') return
+    // Haptic is fired by AssetCard, no need to duplicate here
+    setAssetInfo({ assetId, supply: 0 })
+    navigate(Pages.AppAssetDetail)
+  }
+
+  const fiatLabel = (amount: number) => `${prettyNumber(amount, fiatDecimals(), true, fiatDecimals())} ${config.fiat}`
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <div className="flex w-full items-center justify-between px-1">
+        <span className="text-sm text-[var(--neutral-500)]">Assets</span>
+        <div className="inline-flex items-center gap-4">
+          <LinkButton
+            onClick={handleCreate}
+            label="Create"
+            testId="assets-create"
+            ariaLabel="Create asset"
+            leadingIcon={<PlusIcon />}
+          />
+          <LinkButton
+            onClick={handleViewAll}
+            label="View all"
+            testId="assets-view-all"
+            ariaLabel="View all assets"
+            trailingIcon={<ArrowIcon small />}
+          />
+        </div>
+      </div>
+      <div className="flex w-full flex-col gap-2">
+        {rows.map((row) => {
+          const isBtc = row.assetId === 'btc'
+          return (
+            <AssetCard
+              key={row.assetId}
+              assetId={isBtc ? '' : row.assetId}
+              name={row.name}
+              ticker={row.ticker}
+              icon={row.icon}
+              avatar={isBtc ? <BitcoinIcon size={20} /> : undefined}
+              avatarBg={isBtc ? 'var(--orange-100)' : undefined}
+              avatarColor={isBtc ? 'var(--orange)' : undefined}
+              decimals={row.decimals}
+              balance={row.balance}
+              fiatText={row.hasFiatPrice ? fiatLabel(row.fiatAmount) : undefined}
+              onClick={isBtc ? undefined : handleRowClick(row.assetId)}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function LinkButton({
+  onClick,
+  label,
+  testId,
+  ariaLabel,
+  leadingIcon,
+  trailingIcon,
+}: {
+  onClick: () => void
+  label: string
+  testId: string
+  ariaLabel: string
+  leadingIcon?: React.ReactNode
+  trailingIcon?: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className="inline-flex cursor-pointer items-center border-none bg-transparent p-0 text-inherit"
+      style={{ touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent' }}
+    >
+      <span className="inline-flex items-center gap-1 text-sm font-medium leading-none text-[var(--purple)]">
+        {leadingIcon}
+        {label}
+        {trailingIcon}
+      </span>
+    </button>
+  )
+}

--- a/src/screens/Wallet/HomeHeader.tsx
+++ b/src/screens/Wallet/HomeHeader.tsx
@@ -1,0 +1,63 @@
+import { forwardRef, useContext } from 'react'
+import LogoIcon from '../../icons/Logo'
+import SettingsIcon from '../../icons/Settings'
+import HistoryIcon from '../../icons/History'
+import { NavigationContext, Pages } from '../../providers/navigation'
+import { OptionsContext } from '../../providers/options'
+import { SettingsOptions } from '../../lib/types'
+import { hapticLight } from '../../lib/haptics'
+
+interface HomeHeaderProps {
+  logoVisible?: boolean
+}
+
+/**
+ * Home header: logo left, top-right icon cluster (Activity, Settings).
+ */
+const HomeHeader = forwardRef<HTMLDivElement, HomeHeaderProps>(function HomeHeader({ logoVisible = true }, ref) {
+  const { navigate } = useContext(NavigationContext)
+  const { setOption } = useContext(OptionsContext)
+
+  const handleActivity = () => {
+    hapticLight()
+    navigate(Pages.Activity)
+  }
+
+  const handleSettings = () => {
+    hapticLight()
+    setOption(SettingsOptions.Menu)
+    navigate(Pages.Settings)
+  }
+
+  return (
+    <div className="flex w-full items-center justify-between pb-6 pt-2">
+      <div ref={ref} className="inline-flex" style={{ visibility: logoVisible ? 'visible' : 'hidden' }}>
+        <LogoIcon small />
+      </div>
+      <div className="inline-flex items-center gap-1">
+        <button
+          type="button"
+          onClick={handleActivity}
+          aria-label="View recent activity"
+          data-testid="top-right-activity"
+          className="inline-flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 text-inherit active:scale-95"
+          style={{ touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent' }}
+        >
+          <HistoryIcon size={22} />
+        </button>
+        <button
+          type="button"
+          onClick={handleSettings}
+          aria-label="Open settings"
+          data-testid="top-right-settings"
+          className="inline-flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 text-inherit active:scale-95"
+          style={{ touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent' }}
+        >
+          <SettingsIcon />
+        </button>
+      </div>
+    </div>
+  )
+})
+
+export default HomeHeader

--- a/src/screens/Wallet/Index.tsx
+++ b/src/screens/Wallet/Index.tsx
@@ -1,24 +1,17 @@
 import { useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from 'react'
-import Balance from '../../components/Balance'
 import DismissibleBanner from '../../components/DismissibleBanner'
 import ErrorMessage from '../../components/Error'
-import TransactionsList from '../../components/TransactionsList'
+import WalletActionBarOverlay from '../../components/WalletActionBarOverlay'
 import { WalletContext } from '../../providers/wallet'
 import { AspContext } from '../../providers/asp'
 import { ConfigContext } from '../../providers/config'
-import LogoIcon from '../../icons/Logo'
 import HomeIcon from '../../icons/Home'
 import Padded from '../../components/Padded'
 import Content from '../../components/Content'
 import FlexCol from '../../components/FlexCol'
-import Button from '../../components/Button'
-import SendIcon from '../../icons/Send'
-import ReceiveIcon from '../../icons/Receive'
-import FlexRow from '../../components/FlexRow'
 import { emptyRecvInfo, emptySendInfo, FlowContext } from '../../providers/flow'
 import { NavigationContext, Pages } from '../../providers/navigation'
 import { NudgeContext } from '../../providers/nudge'
-import { EmptyTxList } from '../../components/Empty'
 import { InfoBox } from '../../components/AlertBox'
 import { psaMessage } from '../../lib/constants'
 import { AnnouncementContext } from '../../providers/announcements'
@@ -26,14 +19,19 @@ import { WalletStaggerContainer, WalletStaggerChild } from '../../components/Wal
 import { pwaCanInstall, usePwaInstalled, canPromptInstall, promptPwaInstall } from '../../lib/pwa'
 import { isIOS, isAndroid } from '../../lib/browser'
 import { setLogoAnchor, getBootAnimActive, subscribeBootAnim } from '../../lib/logoAnchor'
+import HomeHeader from './HomeHeader'
+import PortfolioHero from './PortfolioHero'
+import AssetsSection from './AssetsSection'
+import UpsellsSection from './UpsellsSection'
+import RecentActivitySection from './RecentActivitySection'
 
 export default function Wallet() {
   const { aspInfo } = useContext(AspContext)
   const { announcement } = useContext(AnnouncementContext)
   const { config, updateConfig } = useContext(ConfigContext)
   const { setRecvInfo, setSendInfo } = useContext(FlowContext)
-  const { isInitialLoad, navigate } = useContext(NavigationContext)
-  const { balance, txs, reloadWallet, svcWallet } = useContext(WalletContext)
+  const { isInitialLoad, navigate, screen } = useContext(NavigationContext)
+  const { reloadWallet, svcWallet } = useContext(WalletContext)
   const { nudge, nudgeVisible, nudgeCheckComplete } = useContext(NudgeContext)
 
   const [error, setError] = useState(false)
@@ -75,74 +73,79 @@ export default function Wallet() {
     navigate(Pages.SendForm)
   }
 
+  const handleSwap = () => {
+    // Navigate to Boltz app (Ark↔BTC/Lightning swap flow)
+    navigate(Pages.AppBoltz)
+  }
+
+  const handleCreateAsset = () => {
+    navigate(Pages.AppAssetMint)
+  }
+
   const handleRefresh = useCallback(async () => {
     await svcWallet?.reload()
     await reloadWallet()
   }, [svcWallet, reloadWallet])
 
+  // Show action bar only on wallet home
+  const showActionBar = screen === Pages.Wallet
+
   return (
     <>
       {announcement}
-      <Content onPullToRefresh={handleRefresh}>
+      <Content onPullToRefresh={handleRefresh} className={showActionBar ? 'has-wallet-action-bar' : ''}>
         <Padded>
-          {/* Anchor lives outside the stagger tree so getBoundingClientRect returns the final position */}
-          <div ref={logoRef} style={{ display: 'inline-flex', visibility: bootAnimActive ? 'hidden' : 'visible' }}>
-            <LogoIcon small />
-          </div>
+          <HomeHeader ref={logoRef} logoVisible={!bootAnimActive} />
           <WalletStaggerContainer animate={shouldStagger} hold={bootAnimActive}>
-            <FlexCol>
-              <FlexCol gap='0'>
-                <WalletStaggerChild animate={shouldStagger}>
-                  <Balance amount={balance} />
-                </WalletStaggerChild>
-                <WalletStaggerChild animate={shouldStagger}>
-                  <ErrorMessage error={error} text='Ark server unreachable' />
-                </WalletStaggerChild>
-                <WalletStaggerChild animate={shouldStagger}>
-                  <FlexRow padding='0 0 0.5rem 0'>
-                    <Button main icon={<SendIcon />} label='Send' onClick={handleSend} />
-                    <Button main icon={<ReceiveIcon />} label='Receive' onClick={handleReceive} />
-                  </FlexRow>
-                </WalletStaggerChild>
-                <WalletStaggerChild animate={shouldStagger}>
-                  {nudge}
-                  {psaMessage ? <InfoBox html={psaMessage} /> : null}
-                  <DismissibleBanner
-                    id='pwa-install'
-                    icon={<HomeIcon />}
-                    title='Add Arkade to your home screen'
-                    description={pwaDescription}
-                    action={
-                      canPromptInstall()
-                        ? {
-                            label: 'Install',
-                            onClick: async () => {
-                              const outcome = await promptPwaInstall().catch(() => null)
-                              if (outcome) dismissPwaBanner()
-                            },
-                          }
-                        : undefined
-                    }
-                    onDismiss={dismissPwaBanner}
-                    visible={Boolean(nudgeCheckComplete && !nudgeVisible && showPwaBanner)}
-                  />
-                </WalletStaggerChild>
-              </FlexCol>
-              {txs?.length === 0 ? (
-                <WalletStaggerChild animate={shouldStagger}>
-                  <div style={{ marginTop: '5rem', width: '100%' }}>
-                    <EmptyTxList />
-                  </div>
-                </WalletStaggerChild>
-              ) : (
-                <WalletStaggerChild animate={shouldStagger}>
-                  <TransactionsList />
-                </WalletStaggerChild>
-              )}
+            <FlexCol gap="1.5rem">
+              <WalletStaggerChild animate={shouldStagger}>
+                <PortfolioHero />
+              </WalletStaggerChild>
+              <WalletStaggerChild animate={shouldStagger}>
+                <ErrorMessage error={error} text="Ark server unreachable" />
+              </WalletStaggerChild>
+              <WalletStaggerChild animate={shouldStagger}>
+                <AssetsSection onCreateClick={handleCreateAsset} />
+              </WalletStaggerChild>
+              <WalletStaggerChild animate={shouldStagger}>
+                <UpsellsSection />
+              </WalletStaggerChild>
+              <WalletStaggerChild animate={shouldStagger}>
+                <RecentActivitySection />
+              </WalletStaggerChild>
+              <WalletStaggerChild animate={shouldStagger}>
+                {nudge}
+                {psaMessage ? <InfoBox html={psaMessage} /> : null}
+                <DismissibleBanner
+                  id="pwa-install"
+                  icon={<HomeIcon />}
+                  title="Add Arkade to your home screen"
+                  description={pwaDescription}
+                  action={
+                    canPromptInstall()
+                      ? {
+                          label: 'Install',
+                          onClick: async () => {
+                            const outcome = await promptPwaInstall().catch(() => null)
+                            if (outcome) dismissPwaBanner()
+                          },
+                        }
+                      : undefined
+                  }
+                  onDismiss={dismissPwaBanner}
+                  visible={Boolean(nudgeCheckComplete && !nudgeVisible && showPwaBanner)}
+                />
+              </WalletStaggerChild>
             </FlexCol>
           </WalletStaggerContainer>
         </Padded>
       </Content>
+      <WalletActionBarOverlay
+        visible={showActionBar}
+        onSendClick={handleSend}
+        onSwapClick={handleSwap}
+        onReceiveClick={handleReceive}
+      />
     </>
   )
 }

--- a/src/screens/Wallet/PortfolioHero.tsx
+++ b/src/screens/Wallet/PortfolioHero.tsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react'
+import { ConfigContext } from '../../providers/config'
+import { FiatContext } from '../../providers/fiat'
+import { usePortfolioFiat } from '../../hooks/usePortfolioFiat'
+import { prettyNumber } from '../../lib/format'
+
+/**
+ * Fiat-primary total balance across BTC + all assets. Single line.
+ * A small "Total" eyebrow label sits above the number.
+ */
+export default function PortfolioHero() {
+  const { config } = useContext(ConfigContext)
+  const { fiatDecimals } = useContext(FiatContext)
+  const { totalFiat } = usePortfolioFiat()
+
+  const fiatText = prettyNumber(totalFiat, fiatDecimals(), true, fiatDecimals())
+
+  return (
+    <div className="mb-4 flex flex-col gap-1">
+      <span className="text-sm text-[var(--neutral-500)]">Total</span>
+      <div className="flex items-baseline gap-2">
+        <span className="font-heading text-3xl font-medium tracking-tight">{fiatText}</span>
+        <span className="font-heading text-lg text-[var(--neutral-500)]">{config.fiat}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/Wallet/RecentActivitySection.tsx
+++ b/src/screens/Wallet/RecentActivitySection.tsx
@@ -1,0 +1,54 @@
+import { useContext } from 'react'
+import ArrowIcon from '../../icons/Arrow'
+import TransactionsList from '../../components/TransactionsList'
+import { EmptyTxList } from '../../components/Empty'
+import { WalletContext } from '../../providers/wallet'
+import { NavigationContext, Pages } from '../../providers/navigation'
+import { hapticLight } from '../../lib/haptics'
+
+/**
+ * Compact "Recent activity" module for the home screen.
+ * Shows the most recent transactions with a View all link.
+ */
+export default function RecentActivitySection() {
+  const { txs } = useContext(WalletContext)
+  const { navigate } = useContext(NavigationContext)
+
+  const handleViewAll = () => {
+    hapticLight()
+    navigate(Pages.Activity)
+  }
+
+  if (!txs || txs.length === 0) {
+    return (
+      <div className="flex w-full flex-col gap-2">
+        <div className="flex w-full items-center justify-between px-1">
+          <span className="text-sm text-[var(--neutral-500)]">Recent activity</span>
+        </div>
+        <EmptyTxList />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex w-full items-center justify-between px-1">
+        <span className="text-sm text-[var(--neutral-500)]">Recent activity</span>
+        <button
+          type="button"
+          onClick={handleViewAll}
+          aria-label="View all activity"
+          data-testid="activity-view-all"
+          className="inline-flex cursor-pointer items-center border-none bg-transparent p-0 text-inherit"
+          style={{ touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent' }}
+        >
+          <span className="inline-flex items-center gap-1 text-sm font-medium leading-none text-[var(--purple)]">
+            View all
+            <ArrowIcon small />
+          </span>
+        </button>
+      </div>
+      <TransactionsList title="" mode="static" limit={3} />
+    </div>
+  )
+}

--- a/src/screens/Wallet/UpsellsSection.tsx
+++ b/src/screens/Wallet/UpsellsSection.tsx
@@ -1,0 +1,78 @@
+import { useContext, ReactNode } from 'react'
+import CoinsIcon from '../../icons/Coins'
+import LandmarkIcon from '../../icons/Landmark'
+import { NavigationContext, Pages } from '../../providers/navigation'
+import { hapticLight } from '../../lib/haptics'
+
+interface UpsellCardProps {
+  icon: ReactNode
+  title: string
+  description: string
+  testId: string
+  onClick: () => void
+}
+
+function UpsellCard({ icon, title, description, testId, onClick }: UpsellCardProps) {
+  const handleClick = () => {
+    hapticLight()
+    onClick()
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      data-testid={testId}
+      className="flex w-full cursor-pointer items-center gap-3.5 rounded-xl border border-[var(--neutral-100)] bg-[var(--bg)] px-4 py-3.5 text-left text-inherit shadow-sm transition-transform active:scale-[0.98]"
+      style={{ touchAction: 'manipulation', WebkitTapHighlightColor: 'transparent' }}
+    >
+      <div className="flex size-10 min-w-10 items-center justify-center rounded-full bg-[var(--neutral-100)] text-[var(--purple)]">
+        {icon}
+      </div>
+      <div className="flex flex-col items-start gap-0.5">
+        <span className="font-medium">{title}</span>
+        <span className="text-sm text-[var(--neutral-500)]">{description}</span>
+      </div>
+    </button>
+  )
+}
+
+/**
+ * Homepage product upsells. These are inline entry points to LendaSat loans
+ * and DFX buy/sell.
+ */
+export default function UpsellsSection() {
+  const { navigate } = useContext(NavigationContext)
+
+  const handleLoans = () => {
+    navigate(Pages.AppLendasat)
+  }
+
+  const handleBuySell = () => {
+    navigate(Pages.AppDfx)
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <div className="px-1">
+        <span className="text-sm text-[var(--neutral-500)]">Do more with bitcoin</span>
+      </div>
+      <div className="flex w-full flex-col gap-2">
+        <UpsellCard
+          icon={<LandmarkIcon size={20} />}
+          title="Borrow against your bitcoin"
+          description="Get a loan without selling. Self-custodial, no paperwork."
+          testId="upsell-loans"
+          onClick={handleLoans}
+        />
+        <UpsellCard
+          icon={<CoinsIcon size={20} />}
+          title="Buy or sell bitcoin"
+          description="Convert between bitcoin and your local currency."
+          testId="upsell-buy-sell"
+          onClick={handleBuySell}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -186,11 +186,11 @@ describe('Navbar visibility', () => {
     expect(appShell.className).not.toContain('has-pill-navbar')
   })
 
-  it('shows navbar on wallet root when authenticated and initialized', async () => {
+  it('hides navbar on wallet root (uses floating action bar instead)', async () => {
     renderApp({ authState: 'authenticated', initialized: true, screen: Pages.Wallet, tab: Tabs.Wallet })
 
     const appShell = await screen.findByTestId('app-shell')
-    expect(appShell.className).toContain('has-pill-navbar')
+    expect(appShell.className).not.toContain('has-pill-navbar')
   })
 
   it('shows navbar on apps root when authenticated and initialized', async () => {

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -5,9 +5,11 @@ import Wallet from '../../../screens/Wallet/Index'
 describe('Wallet screen', () => {
   it('renders the wallet screen with the correct elements', () => {
     render(<Wallet />)
-    expect(screen.getByText('$0.00')).toBeInTheDocument()
-    expect(screen.getByText('Send')).toBeInTheDocument()
-    expect(screen.getByText('Receive')).toBeInTheDocument()
-    expect(screen.getByText('No transactions yet')).toBeInTheDocument()
+    // New home screen structure: PortfolioHero, AssetsSection, etc.
+    expect(screen.getByText('Total')).toBeInTheDocument()
+    expect(screen.getByText('Assets')).toBeInTheDocument()
+    // Action bar is rendered via portal, so Send/Receive are in body
+    expect(document.body.querySelector('[data-testid="action-send"]')).toBeInTheDocument()
+    expect(document.body.querySelector('[data-testid="action-receive"]')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Rebuilds the homepage redesign from PR #532 on top of the Ionic migration PR #536, using Tailwind/ShadCN primitives instead of Ionic components.

- Portfolio hero with fiat-primary total display
- Asset cards showing BTC + imported assets (balance-only for assets without price feeds)
- Floating action bar with Send/Swap/Receive buttons
- Home header with logo, activity icon, and settings icon
- Recent activity section (last 3 transactions)
- Upsell cards for LendaSat and DFX
- Activity page for full transaction history
- Pill navbar hidden on wallet home (replaced by floating action bar)

## Test plan

- [ ] Verify portfolio total displays correctly
- [ ] Verify BTC row is non-interactive, asset rows navigate to detail
- [ ] Verify Send/Swap/Receive buttons work
- [ ] Verify Activity page accessible from header icon
- [ ] Verify Settings accessible from header icon
- [ ] Test on mobile device for haptics and safe areas