### PR TITLE
fix: prevent swap autoclaim race between service worker and UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:e2e:ui": "VITE_NOSTR_RELAY_URL=http://localhost:10547 playwright test --ui",
     "test:codegen": "playwright codegen localhost:3002",
     "lint": "eslint \"src/**/*.{ts,tsx,js,jsx}\"",
-    "lint:fix": "eslint 'src/**/*.{ts,tsx,js,jsx}' --fix",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx,js,jsx}\" --fix",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
     "git-info": "node scripts/git-commit-info.js",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:e2e": "VITE_NOSTR_RELAY_URL=http://localhost:10547 playwright test",
     "test:e2e:ui": "VITE_NOSTR_RELAY_URL=http://localhost:10547 playwright test --ui",
     "test:codegen": "playwright codegen localhost:3002",
-    "lint": "eslint 'src/**/*.{ts,tsx,js,jsx}'",
+    "lint": "eslint \"src/**/*.{ts,tsx,js,jsx}\"",
     "lint:fix": "eslint 'src/**/*.{ts,tsx,js,jsx}' --fix",
     "format": "prettier --write src",
     "format:check": "prettier --check src",

--- a/src/screens/Apps/Boltz/Swap.tsx
+++ b/src/screens/Apps/Boltz/Swap.tsx
@@ -51,6 +51,7 @@ export default function AppBoltzSwap() {
   const [processing, setProcessing] = useState<boolean>(false)
   const [opDone, setOpDone] = useState(false)
   const [success, setSuccess] = useState<boolean>(false)
+  const [swapManagerProcessing, setSwapManagerProcessing] = useState(false)
 
   // Subscribe to real-time updates for this swap
   useEffect(() => {
@@ -58,9 +59,17 @@ export default function AppBoltzSwap() {
 
     let unsub: (() => void) | null = null
     let cancelled = false
+
+    swapManager.isProcessing(swapInfo.id).then((p) => {
+      if (!cancelled) setSwapManagerProcessing(p)
+    })
+
     swapManager
       .subscribeToSwapUpdates(swapInfo.id, (updatedSwap) => {
         setSwapInfo(updatedSwap)
+        swapManager.isProcessing(updatedSwap.id).then((p) => {
+          if (!cancelled) setSwapManagerProcessing(p)
+        })
       })
       .then((unsubscribe) => {
         if (cancelled) {
@@ -147,11 +156,15 @@ export default function AppBoltzSwap() {
 
   const isRefundable = isSubmarineSwapRefundable(swapInfo) || isChainSwapRefundable(swapInfo)
   const isClaimable = isReverseSwapClaimable(swapInfo) || isChainSwapClaimable(swapInfo)
-  const buttonLabel = isClaimable ? 'Complete swap' : 'Refund swap'
+  const buttonLabel = swapManagerProcessing ? 'Claiming...' : isClaimable ? 'Complete swap' : 'Refund swap'
   const refunded = swapInfo.status === 'transaction.refunded'
 
   const buttonHandler = async () => {
     try {
+      if (swapManager) {
+        const alreadyProcessing = await swapManager.isProcessing(swapInfo.id)
+        if (alreadyProcessing) return
+      }
       setProcessing(true)
       if (isReverseSwapClaimable(swapInfo)) {
         await claimVHTLC(swapInfo)
@@ -217,9 +230,9 @@ export default function AppBoltzSwap() {
           )}
         </Padded>
       </Content>
-      {!success && (isRefundable || isClaimable) ? (
+      {!success && (isRefundable || isClaimable || swapManagerProcessing) ? (
         <ButtonsOnBottom>
-          <Button onClick={buttonHandler} label={buttonLabel} disabled={processing} />
+          <Button onClick={buttonHandler} label={buttonLabel} disabled={processing || swapManagerProcessing} />
         </ButtonsOnBottom>
       ) : null}
     </>


### PR DESCRIPTION
## Summary
- Queries `SwapManager.isProcessing(swapId)` on mount and after each status update to reactively track whether the service worker is already claiming/refunding the swap
- Checks `isProcessing` again at button-press time as a final guard before calling claim/refund
- Button shows "Claiming..." and disables when the SwapManager is processing
- Fixes Windows lint script (single-quoted globs don't expand on Windows)

## Problem
When the service worker's `SwapManager` auto-claims a swap (via `executeAutonomousAction`), the user can simultaneously tap "Complete swap" on the swap detail screen. Both paths call `claimVHTLC` concurrently, causing a double-claim race.

The `SwapManager` already tracks in-progress operations in its `swapsInProgress` Set and exposes `isProcessing(swapId)` via the service worker message protocol. This PR queries that source of truth from the UI rather than building a parallel tracking system in the main thread.

## Test plan
- [ ] Create a reverse swap (Lightning → Arkade) and verify the swap detail button shows "Claiming..." while SwapManager auto-claims
- [ ] Tap "Complete swap" while auto-claim is in progress — button should be disabled, handler returns early
- [ ] Verify the button re-enables after processing completes (status update triggers re-check)
- [ ] Verify refund flows still work normally
- [ ] Verify swap detail screen shows correct initial state when opened during an in-progress claim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate claim/refund operations by validating processing state before user actions.
  * Improved claim flow UX: button shows persistent "Claiming…" and is disabled while processing.

* **Chores**
  * Adjusted lint script quoting/escaping in project scripts for consistent command handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->