### PR TITLE
Validate LN swap amount when scanning/pasting invoice

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -262,6 +262,17 @@ export default function SendForm() {
         }
         const satoshis = getInvoiceSatoshis(lowerCaseData)
         if (!satoshis) return setError('Invoice must have amount defined')
+        // Check swap limits proactively
+        if (!lnSwapsAllowed()) {
+          setError('Lightning sends are currently unavailable')
+        } else if (satoshis < minSwapAllowed()) {
+          setError(`Minimum Lightning send is ${minSwapAllowed()} sats`)
+        } else {
+          const maxSwap = maxSwapAllowed()
+          if (maxSwap > 0 && satoshis > maxSwap) {
+            setError(`Maximum Lightning send is ${maxSwap} sats`)
+          }
+        }
         setState({ ...base, invoice: lowerCaseData, satoshis })
         setAmountIsReadOnly(true)
         setAmount(satoshis)
@@ -443,6 +454,22 @@ export default function SendForm() {
     }
     const satoshis = sendInfo.satoshis ?? 0
     const isLightningSend = Boolean(sendInfo.invoice)
+
+    // Set error for Lightning limit violations
+    if (isLightningSend && satoshis > 0) {
+      if (!lnSwapsAllowed()) {
+        setError('Lightning sends are currently unavailable')
+      } else {
+        const minSwap = minSwapAllowed()
+        const maxSwap = maxSwapAllowed()
+        if (minSwap > 0 && satoshis < minSwap) {
+          setError(`Minimum Lightning send is ${minSwap} sats`)
+        } else if (maxSwap > 0 && satoshis > maxSwap) {
+          setError(`Maximum Lightning send is ${maxSwap} sats`)
+        }
+      }
+    }
+
     setLabel(
       satoshis > liquidBalance
         ? 'Insufficient funds'
@@ -452,15 +479,11 @@ export default function SendForm() {
             ? 'Amount above LNURL max limit'
             : satoshis && satoshis < 1
               ? 'Amount below 1 satoshi'
-              : isLightningSend && !lnSwapsAllowed()
-                ? 'Lightning swaps not enabled'
-                : isLightningSend && !validLnSwap(satoshis)
-                  ? 'Amount outside Lightning swap limits'
-                  : amountIsAboveMaxLimit(satoshis)
-                    ? 'Amount above max limit'
-                    : satoshis && amountIsBelowMinLimit(satoshis)
-                      ? 'Amount below min limit'
-                      : 'Continue',
+              : amountIsAboveMaxLimit(satoshis)
+                ? 'Amount above max limit'
+                : satoshis && amountIsBelowMinLimit(satoshis)
+                  ? 'Amount below min limit'
+                  : 'Continue',
     )
   }, [sendInfo.satoshis, sendInfo.assets, sendInfo.invoice, liquidBalance, selectedAsset])
 
@@ -481,8 +504,11 @@ export default function SendForm() {
     if (!sendInfo.address && !sendInfo.arkAddress && !sendInfo.invoice) return
     if (sendInfo.arkAddress || sendInfo.pendingSwap) return navigate(Pages.SendDetails)
     if (sendInfo.invoice) {
-      if (!lnSwapsAllowed()) return handleError('Lightning swaps not enabled')
-      if (!validLnSwap(sendInfo.satoshis ?? 0)) return handleError('Amount outside Lightning swap limits')
+      if (!lnSwapsAllowed()) return handleError('Lightning sends are currently unavailable')
+      const invoiceSats = sendInfo.satoshis ?? 0
+      if (invoiceSats < minSwapAllowed()) return handleError(`Minimum Lightning send is ${minSwapAllowed()} sats`)
+      const maxSwap = maxSwapAllowed()
+      if (maxSwap > 0 && invoiceSats > maxSwap) return handleError(`Maximum Lightning send is ${maxSwap} sats`)
       createSubmarineSwap(sendInfo.invoice)
         .then((pendingSwap) => {
           if (!pendingSwap) return handleError('Unable to create swap')
@@ -606,8 +632,10 @@ export default function SendForm() {
           setState({ ...sendInfo, arkAddress: arkResponse.address, invoice: undefined })
         } else {
           // Fallback to Lightning invoice
-          if (!lnSwapsAllowed()) return handleError('Lightning swaps not enabled')
-          if (!validLnSwap(satoshis)) return handleError('Amount outside Lightning swap limits')
+          if (!lnSwapsAllowed()) return handleError('Lightning sends are currently unavailable')
+          if (satoshis < minSwapAllowed()) return handleError(`Minimum Lightning send is ${minSwapAllowed()} sats`)
+          const maxSwap = maxSwapAllowed()
+          if (maxSwap > 0 && satoshis > maxSwap) return handleError(`Maximum Lightning send is ${maxSwap} sats`)
           const amountForInvoice = deductFromAmount ? satoshis - calcSubmarineSwapFee(satoshis) : satoshis
           if (amountForInvoice < 1) return handleError('Amount too low to cover fees')
           const invoice = await fetchInvoice(sendInfo.lnUrl, amountForInvoice, '')
@@ -615,8 +643,10 @@ export default function SendForm() {
         }
       } else {
         if (sendInfo.invoice) {
-          if (!lnSwapsAllowed()) return handleError('Lightning swaps not enabled')
-          if (!validLnSwap(satoshis)) return handleError('Amount outside Lightning swap limits')
+          if (!lnSwapsAllowed()) return handleError('Lightning sends are currently unavailable')
+          if (satoshis < minSwapAllowed()) return handleError(`Minimum Lightning send is ${minSwapAllowed()} sats`)
+          const maxSwap = maxSwapAllowed()
+          if (maxSwap > 0 && satoshis > maxSwap) return handleError(`Maximum Lightning send is ${maxSwap} sats`)
         }
         setState({ ...sendInfo, satoshis })
       }

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -453,7 +453,7 @@ export default function SendForm() {
       return
     }
     const satoshis = sendInfo.satoshis ?? 0
-    const isLightningSend = Boolean(sendInfo.invoice)
+    const isLightningSend = Boolean(sendInfo.invoice && !sendInfo.arkAddress)
 
     // Set error for Lightning limit violations
     if (isLightningSend && satoshis > 0) {
@@ -485,7 +485,7 @@ export default function SendForm() {
                   ? 'Amount below min limit'
                   : 'Continue',
     )
-  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.invoice, liquidBalance, selectedAsset])
+  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.invoice, sendInfo.arkAddress, liquidBalance, selectedAsset])
 
   // manage server unreachable error
   useEffect(() => {
@@ -642,7 +642,7 @@ export default function SendForm() {
           setState({ ...sendInfo, invoice, arkAddress: undefined })
         }
       } else {
-        if (sendInfo.invoice) {
+        if (sendInfo.invoice && !sendInfo.arkAddress) {
           if (!lnSwapsAllowed()) return handleError('Lightning sends are currently unavailable')
           if (satoshis < minSwapAllowed()) return handleError(`Minimum Lightning send is ${minSwapAllowed()} sats`)
           const maxSwap = maxSwapAllowed()
@@ -735,8 +735,8 @@ export default function SendForm() {
     : !((address || arkAddress || lnUrl || invoice) && satoshis && satoshis > 0) ||
       (lnUrlLimits.max && satoshis > lnUrlLimits.max) ||
       (lnUrlLimits.min && satoshis < lnUrlLimits.min) ||
-      (invoice && !lnSwapsAllowed()) ||
-      (invoice && !validLnSwap(satoshis)) ||
+      (invoice && !arkAddress && !lnSwapsAllowed()) ||
+      (invoice && !arkAddress && !validLnSwap(satoshis)) ||
       amountIsAboveMaxLimit(satoshis) ||
       amountIsBelowMinLimit(satoshis) ||
       satoshis > liquidBalance ||

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -77,6 +77,8 @@ export default function SendForm() {
     utxoTxsAllowed,
     vtxoTxsAllowed,
     validArkToBtc,
+    lnSwapsAllowed,
+    validLnSwap,
   } = useContext(LimitsContext)
   const { setOption } = useContext(OptionsContext)
   const { navigate } = useContext(NavigationContext)
@@ -440,6 +442,7 @@ export default function SendForm() {
       return
     }
     const satoshis = sendInfo.satoshis ?? 0
+    const isLightningSend = Boolean(sendInfo.invoice)
     setLabel(
       satoshis > liquidBalance
         ? 'Insufficient funds'
@@ -449,13 +452,17 @@ export default function SendForm() {
             ? 'Amount above LNURL max limit'
             : satoshis && satoshis < 1
               ? 'Amount below 1 satoshi'
-              : amountIsAboveMaxLimit(satoshis)
-                ? 'Amount above max limit'
-                : satoshis && amountIsBelowMinLimit(satoshis)
-                  ? 'Amount below min limit'
-                  : 'Continue',
+              : isLightningSend && !lnSwapsAllowed()
+                ? 'Lightning swaps not enabled'
+                : isLightningSend && !validLnSwap(satoshis)
+                  ? 'Amount outside Lightning swap limits'
+                  : amountIsAboveMaxLimit(satoshis)
+                    ? 'Amount above max limit'
+                    : satoshis && amountIsBelowMinLimit(satoshis)
+                      ? 'Amount below min limit'
+                      : 'Continue',
     )
-  }, [sendInfo.satoshis, sendInfo.assets, liquidBalance, selectedAsset])
+  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.invoice, liquidBalance, selectedAsset])
 
   // manage server unreachable error
   useEffect(() => {
@@ -474,6 +481,8 @@ export default function SendForm() {
     if (!sendInfo.address && !sendInfo.arkAddress && !sendInfo.invoice) return
     if (sendInfo.arkAddress || sendInfo.pendingSwap) return navigate(Pages.SendDetails)
     if (sendInfo.invoice) {
+      if (!lnSwapsAllowed()) return handleError('Lightning swaps not enabled')
+      if (!validLnSwap(sendInfo.satoshis ?? 0)) return handleError('Amount outside Lightning swap limits')
       createSubmarineSwap(sendInfo.invoice)
         .then((pendingSwap) => {
           if (!pendingSwap) return handleError('Unable to create swap')
@@ -491,7 +500,7 @@ export default function SendForm() {
         })
         .catch(() => navigate(Pages.SendDetails))
     }
-  }, [proceed, sendInfo.address, sendInfo.arkAddress, sendInfo.invoice, sendInfo.pendingSwap])
+  }, [proceed, sendInfo.address, sendInfo.arkAddress, sendInfo.invoice, sendInfo.pendingSwap, sendInfo.satoshis])
 
   // deal with fees deduction from amount
   useEffect(() => {
@@ -597,12 +606,18 @@ export default function SendForm() {
           setState({ ...sendInfo, arkAddress: arkResponse.address, invoice: undefined })
         } else {
           // Fallback to Lightning invoice
+          if (!lnSwapsAllowed()) return handleError('Lightning swaps not enabled')
+          if (!validLnSwap(satoshis)) return handleError('Amount outside Lightning swap limits')
           const amountForInvoice = deductFromAmount ? satoshis - calcSubmarineSwapFee(satoshis) : satoshis
           if (amountForInvoice < 1) return handleError('Amount too low to cover fees')
           const invoice = await fetchInvoice(sendInfo.lnUrl, amountForInvoice, '')
           setState({ ...sendInfo, invoice, arkAddress: undefined })
         }
       } else {
+        if (sendInfo.invoice) {
+          if (!lnSwapsAllowed()) return handleError('Lightning swaps not enabled')
+          if (!validLnSwap(satoshis)) return handleError('Amount outside Lightning swap limits')
+        }
         setState({ ...sendInfo, satoshis })
       }
       setProceed(true)
@@ -690,6 +705,8 @@ export default function SendForm() {
     : !((address || arkAddress || lnUrl || invoice) && satoshis && satoshis > 0) ||
       (lnUrlLimits.max && satoshis > lnUrlLimits.max) ||
       (lnUrlLimits.min && satoshis < lnUrlLimits.min) ||
+      (invoice && !lnSwapsAllowed()) ||
+      (invoice && !validLnSwap(satoshis)) ||
       amountIsAboveMaxLimit(satoshis) ||
       amountIsBelowMinLimit(satoshis) ||
       satoshis > liquidBalance ||


### PR DESCRIPTION
https://github.com/user-attachments/assets/3ac59da5-1557-4826-aa5c-e6dd740caac8

also cleans up some type errors with the `brantaPayment` hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lightning swap validation across the send flow, including invoice eligibility and min/max limits.
  * Updated QR-code payment handling to support multiple payment entries.

* **Bug Fixes**
  * Button state and proceed flows now block Lightning invoice sends when swaps are disabled or limits are exceeded.
  * Improved, user-facing error messages for Lightning send attempts that violate swap rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->