### PR TITLE
fix: improve timeout error messages and increase service worker timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:e2e": "VITE_NOSTR_RELAY_URL=http://localhost:10547 playwright test",
     "test:e2e:ui": "VITE_NOSTR_RELAY_URL=http://localhost:10547 playwright test --ui",
     "test:codegen": "playwright codegen localhost:3002",
-    "lint": "eslint 'src/**/*.{ts,tsx,js,jsx}'",
+    "lint": "eslint \"src/**/*.{ts,tsx,js,jsx}\"",
     "lint:fix": "eslint 'src/**/*.{ts,tsx,js,jsx}' --fix",
     "format": "prettier --write src",
     "format:check": "prettier --check src",

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,3 +1,5 @@
+const TIMEOUT_PATTERN = /timed out after \d+ms/i
+
 export const extractError = (error: any): string => {
   if (typeof error === 'string') return error
   if (error?.response?.data?.error) return error.response.data.error
@@ -7,4 +9,18 @@ export const extractError = (error: any): string => {
     return error.message
   }
   return JSON.stringify(error)
+}
+
+export const isTimeoutError = (error: unknown): boolean => {
+  const msg = error instanceof Error ? error.message : String(error)
+  return TIMEOUT_PATTERN.test(msg)
+}
+
+export const friendlyError = (error: unknown, operation?: string): string => {
+  const raw = extractError(error)
+  if (TIMEOUT_PATTERN.test(raw)) {
+    const op = operation ?? 'Operation'
+    return `${op} is taking longer than expected. It may still complete in the background — check back in a moment.`
+  }
+  return raw
 }

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -11,7 +11,7 @@ import FlexCol from '../../components/FlexCol'
 import { Vtxo } from '../../lib/types'
 import FlexRow from '../../components/FlexRow'
 import { ConfigContext } from '../../providers/config'
-import { extractError } from '../../lib/error'
+import { friendlyError } from '../../lib/error'
 import ErrorMessage from '../../components/Error'
 import WaitingForRound from '../../components/WaitingForRound'
 import { AspContext } from '../../providers/asp'
@@ -156,7 +156,7 @@ export default function Vtxos() {
       Sentry.captureException(err, {
         tags: { function: 'renewVtxos:handleRollover' },
       })
-      setError(extractError(err))
+      setError(friendlyError(err, 'Settlement'))
       setRollingover(false)
     }
   }

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -13,7 +13,7 @@ import { formatAssetAmount, prettyNumber } from '../../../lib/format'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import { collaborativeExitWithFees, sendOffChain } from '../../../lib/asp'
-import { extractError } from '../../../lib/error'
+import { friendlyError } from '../../../lib/error'
 import LoadingLogo from '../../../components/LoadingLogo'
 import { consoleError } from '../../../lib/logs'
 import { LimitsContext } from '../../../providers/limits'
@@ -123,7 +123,7 @@ export default function SendDetails() {
 
   const handleError = (err: any) => {
     consoleError(err, 'error sending payment')
-    setError(extractError(err))
+    setError(friendlyError(err, 'Payment'))
     setSendDone(true)
   }
 

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -7,7 +7,7 @@ import { FlowContext } from '../../providers/flow'
 import { formatAssetAmount, isBurn, isIssuance, prettyAgo, prettyDate } from '../../lib/format'
 import { defaultFee } from '../../lib/constants'
 import ErrorMessage from '../../components/Error'
-import { extractError } from '../../lib/error'
+import { friendlyError } from '../../lib/error'
 import Header from '../../components/Header'
 import Content from '../../components/Content'
 import Info from '../../components/Info'
@@ -95,7 +95,7 @@ export default function Transaction() {
       setSettleSuccess(true)
       if (tx) setTxInfo({ ...tx, preconfirmed: false, settled: true })
     } catch (err) {
-      setError(extractError(err))
+      setError(friendlyError(err, 'Settlement'))
     }
     setSettling(false)
   }

--- a/src/wallet-service-worker.ts
+++ b/src/wallet-service-worker.ts
@@ -30,7 +30,7 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
 const worker = new MessageBus(walletRepository, contractRepository, {
   messageHandlers: [new WalletMessageHandler(), new ArkadeSwapsMessageHandler(swapRepository)],
   tickIntervalMs: 5000,
-  messageTimeoutMs: 60_000,
+  messageTimeoutMs: 120_000,
 })
 worker.start().catch(console.error)
 


### PR DESCRIPTION
## Summary
- Increases MessageBus timeout from 60s → 120s — settlement/send can legitimately take over a minute waiting for ASP round participation
- Adds `friendlyError()` utility that detects timeout patterns and translates them to actionable, user-facing messages
- Applied in Transaction (settle boarding), Send/Details (payments), and Settings/Vtxos (rollover) screens
- Exports `isTimeoutError()` for callers that need to branch on timeout vs other failures

## Problem
Users see `"Settlement failed: Error: Message handler timed out after 60000ms (WALLET_UPDATER)"` when clicking "Complete boarding". This is:
1. **Cryptic** — `WALLET_UPDATER` is the handler tag, not the operation (SETTLE). The SDK passes the tag to `withTimeout()` instead of the message type.
2. **Misleading** — the SDK's `withTimeout()` does NOT cancel the underlying work. The settlement may actually succeed in the background, but the user sees "failed".
3. **Too aggressive** — 60s is tight for settlement which requires round participation and signing.

## Before / After
**Before:** `Settlement failed: Error: Message handler timed out after 60000ms (WALLET_UPDATER)`
**After:** `Settlement is taking longer than expected. It may still complete in the background — check back in a moment.`

## SDK root cause
Filed https://github.com/arkade-os/ts-sdk/issues/448 for the underlying issues:
1. Timeout error includes handler tag (`WALLET_UPDATER`) instead of message type (`SETTLE`)
2. No per-operation timeout configuration
3. `withTimeout` doesn't cancel underlying work but implies failure

## Test plan
- [ ] Trigger a boarding settlement that takes >60s — should no longer fail (120s timeout)
- [ ] If timeout still occurs at 120s, user sees friendly message instead of cryptic error
- [ ] Send payment timeout shows "Payment is taking longer than expected..."
- [ ] Vtxos rollover timeout shows "Settlement is taking longer than expected..."
- [ ] Non-timeout errors display normally (unchanged behavior)
- [ ] All 177 unit tests pass