### PR TITLE
validate invoice amount against swap limits

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -388,6 +388,7 @@ export default function SendForm() {
     if (!address && !arkAddress && invoice) {
       const min = minSwapAllowed()
       const max = maxSwapAllowed()
+      if (min === 0 && max === 0) return // limits not loaded yet
       const amountSats = getInvoiceSatoshis(invoice)
       if (amountSats < min) return setError(`Invoice amount below min of ${prettyNumber(min)} sats`)
       if (amountSats > max) return setError(`Invoice amount above max of ${prettyNumber(max)} sats`)

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -62,8 +62,15 @@ export default function SendForm() {
   const { sendInfo, setNoteInfo, setSendInfo } = useContext(FlowContext)
   const { calcSubmarineSwapFee, calcArkToBtcSwapFee, createArkToBtcSwap, createSubmarineSwap, connected, getApiUrl } =
     useContext(SwapsContext)
-  const { amountIsAboveMaxLimit, amountIsBelowMinLimit, utxoTxsAllowed, vtxoTxsAllowed, validArkToBtc } =
-    useContext(LimitsContext)
+  const {
+    amountIsAboveMaxLimit,
+    amountIsBelowMinLimit,
+    minSwapAllowed,
+    maxSwapAllowed,
+    utxoTxsAllowed,
+    vtxoTxsAllowed,
+    validArkToBtc,
+  } = useContext(LimitsContext)
   const { setOption } = useContext(OptionsContext)
   const { navigate } = useContext(NavigationContext)
   const { assetBalances, assetMetadataCache, balance, setCacheEntry, svcWallet } = useContext(WalletContext)
@@ -376,6 +383,14 @@ export default function SendForm() {
     // check server limits for offchain transactions
     if (!address && (arkAddress || invoice) && !vtxoTxsAllowed()) {
       return setError('Sending offchain not allowed')
+    }
+    // check swap limits for lightning transactions
+    if (!address && !arkAddress && invoice) {
+      const min = minSwapAllowed()
+      const max = maxSwapAllowed()
+      const amountSats = getInvoiceSatoshis(invoice)
+      if (amountSats < min) return setError(`Invoice amount below min of ${prettyNumber(min)} sats`)
+      if (amountSats > max) return setError(`Invoice amount above max of ${prettyNumber(max)} sats`)
     }
     // check if server key is valid
     if (arkAddress && arkAddress.length > 0) {

--- a/src/test/e2e/swap.test.ts
+++ b/src/test/e2e/swap.test.ts
@@ -69,6 +69,25 @@ test('should receive funds from Lightning', async ({ page, isMobile }) => {
   expect(await page.getByTestId('Total').textContent()).toBe('2,000 SATS')
 })
 
+test('should raise error when trying to pay invoice with little amount', async ({ page }) => {
+  await createWallet(page)
+
+  const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt 21`)
+  const outputJSON = JSON.parse(stdout.trim())
+  const invoice = outputJSON.payment_request
+  expect(invoice).toBeDefined()
+  expect(invoice).toBeTruthy()
+  expect(invoice).toContain('lnbcrt')
+
+  // go to send page
+  await page.getByTestId('tab-wallet').click()
+  await page.getByText('Send').click()
+
+  // fill invoice
+  await page.locator('ion-input[name="send-address"] input').fill(invoice)
+  await page.waitForSelector('text=Invoice amount below min of 1,000 sats', { state: 'visible' })
+})
+
 test('should send funds to Lightning', async ({ page }) => {
   await createWallet(page)
   await fundWallet(page, 5000)


### PR DESCRIPTION
@gringokiwi please test and review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet send flow now enforces configured minimum and maximum limits for lightning invoice payments and shows clear errors when invoice amounts are outside allowed ranges.

* **Tests**
  * Added end-to-end test covering invoice-amount validation to ensure UI surfaces the appropriate error for amounts below the minimum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->