### PR TITLE
fix showing unlock when server is unreachable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,7 +132,7 @@ export default function App() {
   const isNewUser = walletLoaded && !wallet.pubkey
   const allChecksReady = jsCapabilitiesChecked && configLoaded && aspReady
   const hasStoredWallet = walletLoaded && !!wallet.pubkey
-  const shouldShowUnlock = hasStoredWallet && authState === 'locked'
+  const shouldShowUnlock = hasStoredWallet && authState === 'locked' && !aspInfo.unreachable
   // Hold the loading screen during boot until wallet data is ready.
   // Skip during the init/connect flow (creating or restoring a wallet) so the
   // Connect component stays mounted and can run swap recovery before navigating.


### PR DESCRIPTION
Avoid showing unlock screen (even when wallet is not locked) when arkd is unreachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unlock page routing logic to handle scenarios where the authentication service is unreachable. The app now correctly manages page selection when users have a stored wallet but the service becomes unavailable, preventing unexpected page displays during service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->