### PR TITLE
update regtes images to arkd:v0.9.4 and fulmine:v0.3.21

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -1,7 +1,7 @@
 # wallet arkade-regtest overrides
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.2
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.2
-FULMINE_IMAGE=ghcr.io/arklabshq/fulmine:v0.3.19
+ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.4
+ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.4
+FULMINE_IMAGE=ghcr.io/arklabshq/fulmine:v0.3.21
 
 # nbxplorer guard in start-env.sh handles missing container gracefully
 BITCOIN_LOW_FEE=true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated essential service versions to their latest stable releases for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->