### PR TITLE
fix swap detail crash on restored chain swaps

### DIFF
--- a/src/screens/Apps/Boltz/Swap.tsx
+++ b/src/screens/Apps/Boltz/Swap.tsx
@@ -78,7 +78,13 @@ export default function AppBoltzSwap() {
 
   if (!swapInfo) return null
 
-  const formatAmount = (amt: number) => (config.showBalance ? prettyAmount(amt) : prettyHide(amt))
+  const formatAmount = (amt: number | undefined) => {
+    if (amt === undefined || Number.isNaN(amt)) return '—'
+    return config.showBalance ? prettyAmount(amt) : prettyHide(amt)
+  }
+
+  const diff = (a: number | undefined, b: number | undefined) =>
+    a === undefined || b === undefined ? undefined : a - b
 
   const date = prettyDate(swapInfo.createdAt)
   const when = prettyAgo(swapInfo.createdAt)
@@ -89,12 +95,12 @@ export default function AppBoltzSwap() {
   let tableData: TableData = []
 
   if (swapInfo.type === 'chain') {
-    const sentSats = swapInfo.response.lockupDetails.amount
-    const rcvdSats = swapInfo.response.claimDetails.amount
+    const sentSats = swapInfo.response.lockupDetails?.amount
+    const rcvdSats = swapInfo.response.claimDetails?.amount
     const btcAddress =
       swapInfo.request.from === 'ARK'
-        ? swapInfo.response.lockupDetails.lockupAddress
-        : swapInfo.response.claimDetails.lockupAddress
+        ? swapInfo.response.lockupDetails?.lockupAddress
+        : swapInfo.response.claimDetails?.lockupAddress
 
     tableData = [
       ['When', when],
@@ -106,12 +112,12 @@ export default function AppBoltzSwap() {
       ['BTC Address', btcAddress],
       ['Status', status],
       ['Amount', formatAmount(rcvdSats)],
-      ['Fees', formatAmount(sentSats - rcvdSats)],
+      ['Fees', formatAmount(diff(sentSats, rcvdSats))],
       ['Total', formatAmount(sentSats)],
     ]
   } else if (swapInfo.type === 'reverse') {
     const sentSats = swapInfo.request.invoiceAmount
-    const rcvdSats = swapInfo.response.onchainAmount ?? 0
+    const rcvdSats = swapInfo.response.onchainAmount
 
     tableData = [
       ['When', when],
@@ -123,12 +129,14 @@ export default function AppBoltzSwap() {
       ['Invoice', swapInfo.response.invoice],
       ['Status', swapInfo.status],
       ['Amount', formatAmount(rcvdSats)],
-      ['Fees', formatAmount(sentSats - rcvdSats)],
+      ['Fees', formatAmount(diff(sentSats, rcvdSats))],
       ['Total', formatAmount(sentSats)],
     ]
   } else if (swapInfo.type === 'submarine') {
     const sentSats = swapInfo.response.expectedAmount
-    const rcvdSats = isValidInvoice(swapInfo.request.invoice) ? decodeInvoice(swapInfo.request.invoice).amountSats : 0
+    const rcvdSats = isValidInvoice(swapInfo.request.invoice)
+      ? decodeInvoice(swapInfo.request.invoice).amountSats
+      : undefined
 
     tableData = [
       ['When', when],
@@ -140,7 +148,7 @@ export default function AppBoltzSwap() {
       ['Invoice', swapInfo.request.invoice],
       ['Status', status],
       ['Amount', formatAmount(rcvdSats)],
-      ['Fees', formatAmount(sentSats - rcvdSats)],
+      ['Fees', formatAmount(diff(sentSats, rcvdSats))],
       ['Total', formatAmount(sentSats)],
     ]
   }

--- a/src/test/screens/apps/boltz-swap.test.tsx
+++ b/src/test/screens/apps/boltz-swap.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { BoltzChainSwap } from '@arkade-os/boltz-swap'
+import AppBoltzSwap from '../../../screens/Apps/Boltz/Swap'
+import { ConfigContext } from '../../../providers/config'
+import { FlowContext } from '../../../providers/flow'
+import { SwapsContext } from '../../../providers/swaps'
+import { ToastProvider } from '../../../components/Toast'
+import { mockConfigContextValue, mockFlowContextValue, mockSwapsContextValue } from '../mocks'
+
+const baseChainSwap = {
+  id: 'swap-id',
+  type: 'chain',
+  createdAt: Math.floor(Date.now() / 1000),
+  preimage: '',
+  ephemeralKey: '',
+  feeSatsPerByte: 1,
+  status: 'transaction.claimed',
+  request: { from: 'ARK', to: 'BTC' },
+}
+
+function renderWithSwap(swapInfo: BoltzChainSwap) {
+  return render(
+    <ConfigContext.Provider value={mockConfigContextValue}>
+      <FlowContext.Provider value={{ ...mockFlowContextValue, swapInfo }}>
+        <SwapsContext.Provider value={mockSwapsContextValue}>
+          <ToastProvider>
+            <AppBoltzSwap />
+          </ToastProvider>
+        </SwapsContext.Provider>
+      </FlowContext.Provider>
+    </ConfigContext.Provider>,
+  )
+}
+
+describe('AppBoltzSwap', () => {
+  it('renders restored chain swap without crashing when claimDetails is missing', () => {
+    // Restored chain swaps from @arkade-os/boltz-swap only populate lockupDetails,
+    // and refundDetails.amount is optional — both ends can be undefined.
+    const swap = {
+      ...baseChainSwap,
+      response: {
+        id: 'swap-id',
+        lockupDetails: {
+          amount: undefined as unknown as number,
+          lockupAddress: 'bcrt1qlockup',
+          serverPublicKey: '',
+          timeoutBlockHeight: 0,
+        },
+      },
+    } as unknown as BoltzChainSwap
+
+    renderWithSwap(swap)
+
+    expect(screen.getByText('Chain Swap')).toBeInTheDocument()
+    expect(screen.getByTestId('Amount').textContent).toBe('—')
+    expect(screen.getByTestId('Fees').textContent).toBe('—')
+    expect(screen.getByTestId('Total').textContent).toBe('—')
+  })
+
+  it('renders chain swap with full lockup/claim details', () => {
+    const swap = {
+      ...baseChainSwap,
+      response: {
+        id: 'swap-id',
+        lockupDetails: {
+          amount: 2275,
+          lockupAddress: 'bcrt1qlockup',
+          serverPublicKey: '',
+          timeoutBlockHeight: 0,
+        },
+        claimDetails: {
+          amount: 2111,
+          lockupAddress: 'bcrt1qclaim',
+          serverPublicKey: '',
+          timeoutBlockHeight: 0,
+        },
+      },
+    } as unknown as BoltzChainSwap
+
+    renderWithSwap(swap)
+
+    expect(screen.getByTestId('Amount').textContent).toBe('2,111 SATS')
+    expect(screen.getByTestId('Fees').textContent).toBe('164 SATS')
+    expect(screen.getByTestId('Total').textContent).toBe('2,275 SATS')
+  })
+})


### PR DESCRIPTION
## Summary
- Restored chain swaps from `@arkade-os/boltz-swap` only populate `response.lockupDetails`; tapping them in the swap list crashed on `response.claimDetails.amount`.
- Guard the chain branch with optional chaining and render `—` for unknown amounts/fees across all three swap types instead of misleading `0 SATS`.

## Test plan
- [x] `pnpm test:unit` — added two cases in `src/test/screens/apps/boltz-swap.test.tsx` (restored chain swap with no `claimDetails` renders without crashing; full chain swap still renders amounts correctly)
- [ ] Manually tap a restored chain swap with amount 0 in the Boltz app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of incomplete swap data by displaying consistent placeholders for missing values
  * Fixed issues where invalid or missing swap information could cause display errors in chain and submarine swap tables
  * Enhanced fee calculation to safely handle undefined values

* **Tests**
  * Added test coverage for swap scenarios with missing or incomplete swap data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->