### PR TITLE
fix(layout): fix Init screen spacing regression from Ionic migration

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -315,8 +315,9 @@ button.reminder-button {
   height: 100%;
   display: block;
   position: relative;
-  overflow-y: auto;
+overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  flex: 1;
   font-family:
     'Geist',
     -apple-system,

--- a/src/index.css
+++ b/src/index.css
@@ -315,7 +315,7 @@ button.reminder-button {
   height: 100%;
   display: block;
   position: relative;
-overflow-y: auto;
+  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   flex: 1;
   font-family:


### PR DESCRIPTION
## Summary
- Adds `flex: 1` to `.content` CSS class to fix spacing regression on Init screen
- Content was bunched at top with excessive whitespace; now properly distributed

## Root cause
The Ionic→Tailwind migration (commit a6118aa5) replaced `IonContent` with a plain `<div>` but didn't add `flex: 1` to make `.content` expand properly in the `PageTransition` flex container. This broke the `justifyContent: flex-end` layout in Init.tsx.

## Test plan
- [x] Verified Init screen spacing is fixed (content pushed down, proper gradient distribution)
- [x] Verified wallet screens still work (auto-login with dev nsec, receive screen)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved content container layout flexibility within flexbox-based layouts so main content better fills available space, reducing unexpected gaps or overflow and improving scrolling/visual balance across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->