### PR TITLE
fix: prioritize VITE_ARK_SERVER env var over cached server URL

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
     "no-duplicate-imports": "error",
     "array-callback-return": ["error", { "allowImplicit": true }],
     "@typescript-eslint/no-explicit-any": ["off", { "ignoreRestArgs": false }],
-    "@typescript-eslint/no-unused-vars": ["warn", {}],
+    "@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "^_" }],
     "react/hook-use-state": ["error"],
     "react/no-array-index-key": ["error"],
     "react/jsx-boolean-value": ["error"],

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,9 +13,10 @@ export const maxPercentage = import.meta.env.VITE_MAX_PERCENTAGE ?? 10
 export const psaMessage = import.meta.env.VITE_PSA_MESSAGE ?? ''
 export const enableChainSwapsReceive = import.meta.env.VITE_CHAIN_SWAPS_RECEIVE_ENABLED === 'true'
 export const lnurlServerUrl: string | undefined = import.meta.env.VITE_LNURL_SERVER_URL
+export const envArkServer: string | undefined = import.meta.env.VITE_ARK_SERVER || undefined
 
 export const defaultArkServer = () => {
-  if (import.meta.env.VITE_ARK_SERVER) return import.meta.env.VITE_ARK_SERVER
+  if (envArkServer) return envArkServer
   for (const domain of testDomains) {
     if (window.location.hostname.includes(domain)) {
       return window.location.hostname.includes('localhost') ? devServer : testServer

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -25,7 +25,7 @@ const setStorageItem = (key: string, value: string): void => {
   localStorage.setItem(key, value)
 }
 
-export const saveConfigToStorage = (config: Config): void => {
+export const saveConfigToStorage = (config: Omit<Config, 'aspUrl'> & { aspUrl?: string }): void => {
   setStorageItem('config', JSON.stringify(config))
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -7,7 +7,7 @@ export async function clearStorage(): Promise<void> {
   localStorage.clear()
   if (config) {
     config.importedAssets = []
-    config.apps.assets.enabled = false
+    if (config.apps) config.apps.assets.enabled = false
     saveConfigToStorage(config)
   }
 }
@@ -25,11 +25,11 @@ const setStorageItem = (key: string, value: string): void => {
   localStorage.setItem(key, value)
 }
 
-export const saveConfigToStorage = (config: Omit<Config, 'aspUrl'> & { aspUrl?: string }): void => {
+export const saveConfigToStorage = (config: Partial<Config>): void => {
   setStorageItem('config', JSON.stringify(config))
 }
 
-export const readConfigFromStorage = (): Config | undefined => {
+export const readConfigFromStorage = (): Partial<Config> | undefined => {
   return getStorageItem('config', undefined, (val) => JSON.parse(val))
 }
 

--- a/src/providers/config.tsx
+++ b/src/providers/config.tsx
@@ -1,9 +1,9 @@
 import { ReactNode, createContext, useEffect, useState } from 'react'
 import { clearStorage, readConfigFromStorage, saveConfigToStorage } from '../lib/storage'
-import { defaultArkServer } from '../lib/constants'
+import { defaultArkServer, envArkServer } from '../lib/constants'
 import { Config, CurrencyDisplay, Fiats, Themes, Unit } from '../lib/types'
 import { BackupProvider } from '../lib/backup'
-import { consoleError } from '../lib/logs'
+import { consoleError, consoleLog } from '../lib/logs'
 import { setHapticsEnabled } from '../lib/haptics'
 import { IndexedDbSwapRepository } from '@arkade-os/boltz-swap'
 
@@ -61,9 +61,14 @@ const updateDefaultConfig = (config: Partial<Config>): Config => {
     ? config.announcementsSeen
     : defaultConfig.announcementsSeen
   const importedAssets = Array.isArray(config.importedAssets) ? config.importedAssets : defaultConfig.importedAssets
+  if (envArkServer && config.aspUrl && config.aspUrl !== envArkServer) {
+    consoleLog(`[config] VITE_ARK_SERVER overrides stored aspUrl (${config.aspUrl} → ${envArkServer})`)
+  }
+  const resolvedAspUrl = envArkServer || config.aspUrl || defaultConfig.aspUrl
   return {
     ...defaultConfig,
     ...config,
+    aspUrl: resolvedAspUrl,
     announcementsSeen: [...announcementsSeen],
     importedAssets: [...importedAssets],
     apps: {
@@ -121,7 +126,12 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
     setConfig(config)
     applyTheme(config.theme)
     setHapticsEnabled(config.haptics)
-    saveConfigToStorage(config)
+    if (envArkServer) {
+      const { aspUrl: _aspUrl, ...toSave } = config
+      saveConfigToStorage(toSave)
+    } else {
+      saveConfigToStorage(config)
+    }
   }
 
   const resetConfig = async () => {

--- a/src/screens/Settings/Server.tsx
+++ b/src/screens/Settings/Server.tsx
@@ -15,6 +15,8 @@ import Scanner from '../../components/Scanner'
 import { AspContext, AspInfo } from '../../providers/asp'
 import { consoleError } from '../../lib/logs'
 import LoadingLogo from '../../components/LoadingLogo'
+import Table from '../../components/Table'
+import { envArkServer } from '../../lib/constants'
 
 export default function Server() {
   const { aspInfo } = useContext(AspContext)
@@ -50,6 +52,22 @@ export default function Server() {
   }, [aspUrl])
 
   if (!svcWallet) return <LoadingLogo text='Loading...' />
+
+  if (envArkServer) {
+    return (
+      <>
+        <Header text='Server' back />
+        <Content>
+          <Padded>
+            <FlexCol>
+              <Table data={[['Server URL', envArkServer]]} />
+              <WarningBox text='Server URL is set by an environment variable and cannot be changed here.' />
+            </FlexCol>
+          </Padded>
+        </Content>
+      </>
+    )
+  }
 
   const handleConnect = async () => {
     setLoading(true)


### PR DESCRIPTION
fixes #594

Previously, a server URL saved from a previous session in localStorage would silently override VITE_ARK_SERVER, making the env var have no effect without manually clearing localStorage.                     
                                                                                                                                                                                                        
Now the env var always wins at runtime, is never written to localStorage (keeping deployment config and user preferences in separate layers), and the Server settings screen shows a clear message when the URL is env-controlled instead of silently ignoring user input.

<img width="749" height="502" alt="env priority fix" src="https://github.com/user-attachments/assets/96c6d73d-65bf-43ec-9d99-2675e7bad726" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable support for server configuration, allowing administrators to set a fixed server URL that cannot be changed by users.
  * When environment-configured, the server settings screen displays a read-only server URL with a warning message.

* **Chores**
  * Updated ESLint configuration to ignore unused variables starting with underscore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->