### PR TITLE
Upgrade ts-sdk 0.4.23 - boltz-swap 0.3.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Environment variables can be passed at runtime to configure the wallet without r
 ```bash
 docker run -p 8080:80 \
   -e VITE_ARK_SERVER=https://arkade.computer \
-  -e VITE_BOLTZ_URL=https://api.ark.boltz.exchange \
+  -e VITE_BOLTZ_URL=https://api.boltz.exchange \
   ghcr.io/arkade-os/wallet:latest
 ```
 
@@ -74,7 +74,7 @@ docker build -t arkade-wallet .
 # With build-time configuration
 docker build \
   --build-arg VITE_ARK_SERVER=https://arkade.computer \
-  --build-arg VITE_BOLTZ_URL=https://api.ark.boltz.exchange \
+  --build-arg VITE_BOLTZ_URL=https://api.boltz.exchange \
   -t arkade-wallet .
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.3.24",
-    "@arkade-os/sdk": "0.4.22",
+    "@arkade-os/boltz-swap": "0.3.25",
+    "@arkade-os/sdk": "0.4.23",
     "@branta-ops/branta": "0.0.9",
     "@lendasat/lendasat-wallet-bridge": "^0.0.90",
     "@noble/curves": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
-    "@arkade-os/boltz-swap": "0.3.25",
+    "@arkade-os/boltz-swap": "0.3.26",
     "@arkade-os/sdk": "0.4.23",
     "@branta-ops/branta": "0.0.9",
     "@lendasat/lendasat-wallet-bridge": "^0.0.90",
@@ -32,7 +32,7 @@
   "scripts": {
     "prepare": "husky install",
     "start": "pnpm git-info && pnpm build:worker && vite",
-    "start:mainnet": "pnpm git-info && pnpm build:worker && cross-env VITE_ARK_SERVER=https://arkade.computer VITE_BOLTZ_URL=https://api.ark.boltz.exchange vite",
+    "start:mainnet": "pnpm git-info && pnpm build:worker && cross-env VITE_ARK_SERVER=https://arkade.computer VITE_BOLTZ_URL=https://api.boltz.exchange vite",
     "build": "pnpm git-info && pnpm build:worker && vite build",
     "build:worker": "vite build -c vite.worker.config.ts",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@arkade-os/boltz-swap':
-        specifier: 0.3.24
-        version: 0.3.24
+        specifier: 0.3.25
+        version: 0.3.25
       '@arkade-os/sdk':
-        specifier: 0.4.22
-        version: 0.4.22
+        specifier: 0.4.23
+        version: 0.4.23
       '@branta-ops/branta':
         specifier: 0.0.9
         version: 0.0.9
@@ -183,12 +183,12 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@arkade-os/boltz-swap@0.3.24':
-    resolution: {integrity: sha512-V8QOK5jYCHKcfEpLQEsHtQWtjjZBHlf0IJSTZUUJdE8PNHetRMeXdnMbo6kGMgy7lpdOev7rvMSRR0+PmMHoMA==}
+  '@arkade-os/boltz-swap@0.3.25':
+    resolution: {integrity: sha512-eUkI+dZn9rUHBvn7ITbp5zh2ZBlnnWxsdsfZ2MJroc7PwSQJAghZtG0l21dg+RddlNEG2v6G3r3OnlSsrNUv2A==}
     engines: {node: '>=22.12.0 <23', pnpm: '>=10.25.0 <11'}
 
-  '@arkade-os/sdk@0.4.22':
-    resolution: {integrity: sha512-MARRLuDN359DYa5Y4BXtC/zakqDmWU3ipalbCEpubSH1i3xp1o7EUjzsAYETLHXTenxyft+NZ0IloQthULMRRg==}
+  '@arkade-os/sdk@0.4.23':
+    resolution: {integrity: sha512-09ewNFflv3RrEN1iFln5xKXWoxGKKYeBovAu7zJSOmMZ3SzOpLxUOFGPus6q5tHLjVD7mTeyc0GzZ9e1tUmgLQ==}
     engines: {node: '>=22.12.0 <23', pnpm: '>=10.25.0 <11'}
     peerDependencies:
       '@react-native-async-storage/async-storage': '>=1.0.0'
@@ -2757,9 +2757,9 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@arkade-os/boltz-swap@0.3.24':
+  '@arkade-os/boltz-swap@0.3.25':
     dependencies:
-      '@arkade-os/sdk': 0.4.22
+      '@arkade-os/sdk': 0.4.23
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
       '@scure/base': 2.0.0
@@ -2779,7 +2779,7 @@ snapshots:
       - expo-task-manager
       - utf-8-validate
 
-  '@arkade-os/sdk@0.4.22':
+  '@arkade-os/sdk@0.4.23':
     dependencies:
       '@bitcoinerlab/descriptors-scure': 3.1.7
       '@marcbachmann/cel-js': 7.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@arkade-os/boltz-swap':
-        specifier: 0.3.25
-        version: 0.3.25
+        specifier: 0.3.26
+        version: 0.3.26
       '@arkade-os/sdk':
         specifier: 0.4.23
         version: 0.4.23
@@ -183,8 +183,8 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@arkade-os/boltz-swap@0.3.25':
-    resolution: {integrity: sha512-eUkI+dZn9rUHBvn7ITbp5zh2ZBlnnWxsdsfZ2MJroc7PwSQJAghZtG0l21dg+RddlNEG2v6G3r3OnlSsrNUv2A==}
+  '@arkade-os/boltz-swap@0.3.26':
+    resolution: {integrity: sha512-WNGoPmo2MTNikv6/5Rl6uXR9w+QujQx7/0LxNIc4tVYMFS+0y7R/kv4eG+Qf2CDyy9wD0Ef3zrJQulcj43Xz3g==}
     engines: {node: '>=22.12.0 <23', pnpm: '>=10.25.0 <11'}
 
   '@arkade-os/sdk@0.4.23':
@@ -2757,7 +2757,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@arkade-os/boltz-swap@0.3.25':
+  '@arkade-os/boltz-swap@0.3.26':
     dependencies:
       '@arkade-os/sdk': 0.4.23
       '@noble/curves': 2.0.1

--- a/src/components/AssetAvatar.tsx
+++ b/src/components/AssetAvatar.tsx
@@ -57,7 +57,7 @@ export default function AssetAvatar({ icon, ticker, name, size, onError, assetId
   return (
     <div
       onClick={() => {
-        setAssetInfo({ assetId, supply: 0 })
+        setAssetInfo({ assetId, supply: BigInt(0) })
         navigate(Pages.AppAssetDetail)
       }}
       style={{ cursor: 'pointer', transition: 'transform 0.1s', lineHeight: 0 }}

--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -3,12 +3,11 @@ import Shadow from './Shadow'
 import FlexCol from './FlexCol'
 import FlexRow from './FlexRow'
 import AssetAvatar from './AssetAvatar'
-import { centsToUnits, truncatedAssetId } from '../lib/assets'
-import { prettyNumber } from '../lib/format'
+import { prettyAssetAmount, truncatedAssetId } from '../lib/assets'
 
 interface AssetCardProps {
   assetId: string
-  balance: number
+  balance: bigint
   darkPurple?: boolean
   decimals?: number
   icon?: string
@@ -41,7 +40,7 @@ export default function AssetCard({
           </FlexCol>
         </FlexRow>
         <FlexCol end>
-          <Text>{prettyNumber(centsToUnits(balance, decimals ?? 8))}</Text>
+          <Text>{prettyAssetAmount(balance, decimals ?? 8)}</Text>
         </FlexCol>
       </FlexRow>
     </Shadow>

--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -68,7 +68,7 @@ export default function InputAmount({
   const handleInput: ChangeEventHandler<HTMLInputElement> = (ev) => {
     const value = Number(ev.currentTarget.value)
     if (Number.isNaN(value)) return
-    onSats(asset?.assetId ? unitsToCents(value, asset.decimals) : useFiat ? fromFiat(value) : value)
+    onSats(asset?.assetId ? Number(unitsToCents(BigInt(value), asset.decimals)) : useFiat ? fromFiat(value) : value)
   }
 
   const minimumSats = min ? Math.max(min, minSwapAllowed()) : 0

--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -68,7 +68,12 @@ export default function InputAmount({
   const handleInput: ChangeEventHandler<HTMLInputElement> = (ev) => {
     const value = Number(ev.currentTarget.value)
     if (Number.isNaN(value)) return
-    onSats(asset?.assetId ? Number(unitsToCents(BigInt(value), asset.decimals)) : useFiat ? fromFiat(value) : value)
+    if (asset?.assetId) {
+      const integer = value >= 0 ? BigInt(Math.trunc(value)) : 0n
+      onSats(Number(unitsToCents(integer, asset.decimals)))
+      return
+    }
+    onSats(useFiat ? fromFiat(value) : value)
   }
 
   const minimumSats = min ? Math.max(min, minSwapAllowed()) : 0

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -3,7 +3,7 @@ import Content from './Content'
 import { useContext, useEffect, useState } from 'react'
 import Text, { TextSecondary } from './Text'
 import { FiatContext } from '../providers/fiat'
-import { formatAssetAmount, prettyAmount, prettyFiatAmount, prettyNumber } from '../lib/format'
+import { prettyAmount, prettyFiatAmount, prettyNumber } from '../lib/format'
 import { WalletContext } from '../providers/wallet'
 import { defaultFee } from '../lib/constants'
 import ErrorMessage from './Error'
@@ -13,7 +13,7 @@ import { ConfigContext } from '../providers/config'
 import FlexCol from './FlexCol'
 import SwapIcon from '../icons/Swap'
 import { AssetOption } from '../lib/types'
-import { centsToUnits, unitsToCents } from '../lib/assets'
+import { centsToUnits, prettyAssetAmount, unitsToCents } from '../lib/assets'
 
 interface KeyboardProps {
   asset?: AssetOption
@@ -54,7 +54,7 @@ export default function Keyboard({ asset, back, hideBalance, onSave, value }: Ke
       inputMode === 'fiat'
         ? fromFiat(value)
         : inputMode === 'asset'
-          ? unitsToCents(value, asset?.decimals ?? 0)
+          ? Number(unitsToCents(BigInt(value), asset?.decimals ?? 0))
           : value,
     )
   }, [textValue])
@@ -103,7 +103,7 @@ export default function Keyboard({ asset, back, hideBalance, onSave, value }: Ke
     if (asset) {
       const { balance, decimals } = asset
       const units = centsToUnits(balance, decimals)
-      setTextValue(prettyNumber(units, decimals, false))
+      setTextValue(prettyNumber(Number(units), decimals, false))
     } else {
       const maxSats = available - defaultFee
       const maxTextValue = inputMode === 'fiat' ? toFiat(maxSats) : maxSats
@@ -147,7 +147,7 @@ export default function Keyboard({ asset, back, hideBalance, onSave, value }: Ke
           : prettyFiatAmount(toFiat(amountInSats), config.fiat),
     balance:
       inputMode === 'asset'
-        ? `${formatAssetAmount(asset?.balance ?? 0, asset?.decimals ?? 0)} ${asset?.ticker}`
+        ? `${prettyAssetAmount(asset?.balance ?? BigInt(0), asset?.decimals ?? 0)} ${asset?.ticker}`
         : inputMode === 'fiat'
           ? prettyFiatAmount(toFiat(available), config.fiat)
           : prettyAmount(available),

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -4,7 +4,6 @@ import { WalletContext } from '../providers/wallet'
 import Text, { TextSecondary } from './Text'
 import { CurrencyDisplay, Tx } from '../lib/types'
 import {
-  formatAssetAmount,
   isBurn,
   isIssuance,
   prettyAmount,
@@ -24,6 +23,7 @@ import { FiatContext } from '../providers/fiat'
 import PreconfirmedIcon from '../icons/Preconfirmed'
 import Focusable from './Focusable'
 import { hapticSubtle } from '../lib/haptics'
+import { prettyAssetAmount, prettyAssetAmountHide } from '../lib/assets'
 
 const border = '1px solid var(--dark10)'
 
@@ -104,8 +104,8 @@ const TransactionLine = ({ tx, onClick, isFirst }: { tx: Tx; onClick: () => void
               <AssetAvatar icon={icon} ticker={ticker} size={16} assetId={a.assetId} clickable />
               <Text color={color} thin>
                 {config.showBalance
-                  ? `${formatAssetAmount(a.amount, decimals)} ${ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`}`
-                  : prettyHide(a.amount, ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`)}
+                  ? `${prettyAssetAmount(a.amount, decimals)} ${ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`}`
+                  : prettyAssetAmountHide(a.amount, ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`)}
               </Text>
             </FlexRow>
           )

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -2,17 +2,47 @@ export function isValidAssetId(id: string) {
   return /^[0-9a-fA-F]{68}$/.test(id)
 }
 
-export function unitsToCents(units: number, decimals?: number): number {
-  decimals = decimals ?? 8
-  return Math.round(units * 10 ** decimals)
+export function unitsToCents(units: bigint, decimals = 8): bigint {
+  return units * BigInt(10 ** decimals)
 }
 
-export function centsToUnits(cents: number, decimals?: number): number {
-  decimals = decimals ?? 8
-  return Number((cents / 10 ** decimals).toFixed(decimals))
+export function centsToUnits(cents: bigint, decimals = 8): bigint {
+  return cents / BigInt(10 ** decimals)
 }
 
 export const truncatedAssetId = (id: string): string => {
   if (!id || id.length < 24) return ''
   return `${id.slice(0, 12)}...${id.slice(-12)}`
+}
+
+const hideDots = (value: bigint): string => {
+  const str = value.toString()
+  const length = str.length * 2 > 6 ? str.length * 2 : 6
+  return '·'.repeat(length)
+}
+
+export const prettyAssetAmountHide = (value: bigint, suffix: string): string => {
+  if (!value) return ''
+  const dots = hideDots(value)
+  return suffix ? `${dots} ${suffix}` : dots
+}
+
+export const prettyAssetNumber = (
+  num?: bigint,
+  maximumFractionDigits = 8,
+  useGrouping = true,
+  minimumFractionDigits?: number,
+): string => {
+  if (num === undefined || num === null) return '0'
+  return new Intl.NumberFormat('en', {
+    style: 'decimal',
+    maximumFractionDigits,
+    minimumFractionDigits,
+    useGrouping,
+  }).format(num)
+}
+
+export const prettyAssetAmount = (amount: bigint, decimals: number): string => {
+  if (decimals === 0) return prettyAssetNumber(amount, 0)
+  return prettyAssetNumber(centsToUnits(amount, decimals), decimals)
 }

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -50,5 +50,16 @@ export const prettyAssetNumber = (
 
 export const prettyAssetAmount = (amount: bigint, decimals: number): string => {
   if (!isValidDecimals(decimals) || decimals === 0) return prettyAssetNumber(amount, 0)
-  return prettyAssetNumber(centsToUnits(amount, decimals), decimals)
+
+  const divisor = 10n ** BigInt(decimals)
+  const negative = amount < 0n
+  const abs = negative ? -amount : amount
+  const whole = abs / divisor
+  const frac = abs % divisor
+  const sign = negative ? '-' : ''
+
+  if (frac === 0n) return `${sign}${prettyAssetNumber(whole, 0)}`
+
+  const fracStr = frac.toString().padStart(decimals, '0').replace(/0+$/, '')
+  return `${sign}${prettyAssetNumber(whole, 0)}.${fracStr}`
 }

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,13 +1,19 @@
+const MAX_DECIMALS = 18
+
 export function isValidAssetId(id: string) {
   return /^[0-9a-fA-F]{68}$/.test(id)
 }
 
+export const isValidDecimals = (d: number): boolean => Number.isInteger(d) && d >= 0 && d <= MAX_DECIMALS
+
 export function unitsToCents(units: bigint, decimals = 8): bigint {
-  return units * BigInt(10 ** decimals)
+  if (!isValidDecimals(decimals)) return units
+  return units * 10n ** BigInt(decimals)
 }
 
 export function centsToUnits(cents: bigint, decimals = 8): bigint {
-  return cents / BigInt(10 ** decimals)
+  if (!isValidDecimals(decimals)) return cents
+  return cents / 10n ** BigInt(decimals)
 }
 
 export const truncatedAssetId = (id: string): string => {
@@ -43,6 +49,6 @@ export const prettyAssetNumber = (
 }
 
 export const prettyAssetAmount = (amount: bigint, decimals: number): string => {
-  if (decimals === 0) return prettyAssetNumber(amount, 0)
+  if (!isValidDecimals(decimals) || decimals === 0) return prettyAssetNumber(amount, 0)
   return prettyAssetNumber(centsToUnits(amount, decimals), decimals)
 }

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -48,8 +48,8 @@ export const prettyAssetNumber = (
   }).format(num)
 }
 
-export const prettyAssetAmount = (amount: bigint, decimals: number): string => {
-  if (!isValidDecimals(decimals) || decimals === 0) return prettyAssetNumber(amount, 0)
+export const prettyAssetAmount = (amount: bigint, decimals: number, useGrouping = true): string => {
+  if (!isValidDecimals(decimals) || decimals === 0) return prettyAssetNumber(amount, 0, useGrouping)
 
   const divisor = 10n ** BigInt(decimals)
   const negative = amount < 0n
@@ -58,8 +58,8 @@ export const prettyAssetAmount = (amount: bigint, decimals: number): string => {
   const frac = abs % divisor
   const sign = negative ? '-' : ''
 
-  if (frac === 0n) return `${sign}${prettyAssetNumber(whole, 0)}`
+  if (frac === 0n) return `${sign}${prettyAssetNumber(whole, 0, useGrouping)}`
 
   const fracStr = frac.toString().padStart(decimals, '0').replace(/0+$/, '')
-  return `${sign}${prettyAssetNumber(whole, 0)}.${fracStr}`
+  return `${sign}${prettyAssetNumber(whole, 0, useGrouping)}.${fracStr}`
 }

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,4 +1,4 @@
-const MAX_DECIMALS = 18
+const MAX_DECIMALS = 8 // Arbitrary value to allow at least 1 sat/asset
 
 export function isValidAssetId(id: string) {
   return /^[0-9a-fA-F]{68}$/.test(id)

--- a/src/lib/explorers.ts
+++ b/src/lib/explorers.ts
@@ -2,7 +2,7 @@ import { NetworkName } from '@arkade-os/sdk/'
 import { Wallet } from '../lib/types'
 
 type ExplorerURLs = {
-  api: string
+  api?: string
   web: string
 }
 
@@ -10,7 +10,6 @@ type Explorers = Record<NetworkName, ExplorerURLs>
 
 const explorers: Explorers = {
   bitcoin: {
-    api: 'https://mempool.space/api',
     web: 'https://mempool.space',
   },
   regtest: {
@@ -37,8 +36,8 @@ const vmempoolDefaults: Partial<Record<NetworkName, string>> = {
   regtest: 'http://localhost:7080',
 }
 
-export const getRestApiExplorerURL = (network: NetworkName): string => {
-  return explorers[network]?.api ?? ''
+export const getRestApiExplorerURL = (network: NetworkName): string | undefined => {
+  return explorers[network]?.api
 }
 
 export const getWebExplorerURL = (network: NetworkName): string => {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,4 +1,4 @@
-import { centsToUnits } from './assets'
+import { centsToUnits, prettyAssetNumber } from './assets'
 import { fiatDecimalsFor, FIAT_SYMBOLS } from './fiat'
 import { Fiats, Satoshis, Tx } from './types'
 import { Decimal } from 'decimal.js'
@@ -118,9 +118,9 @@ export const prettyNumber = (
   }).format(num)
 }
 
-export const formatAssetAmount = (amount: number, decimals: number): string => {
-  if (decimals === 0) return prettyNumber(amount, 0)
-  return prettyNumber(centsToUnits(amount, decimals), decimals)
+export const formatAssetAmount = (amount: bigint, decimals: number): string => {
+  if (decimals === 0) return prettyAssetNumber(amount, 0)
+  return prettyAssetNumber(centsToUnits(amount, decimals), decimals)
 }
 
 export const isIssuance = (tx: Tx): boolean => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -54,12 +54,16 @@ export const saveAssetMetadataToStorage = (cache: Map<string, CachedAssetDetails
     if (now - v.cachedAt >= ASSET_METADATA_TTL_MS) return
     obj[k] = v
   })
-  setStorageItem('assetMetadataCache', JSON.stringify(obj))
+  setStorageItem(
+    'assetMetadataCache',
+    JSON.stringify(obj, (key, value) => (typeof value === 'bigint' ? value.toString() : value)),
+  )
 }
 
 export const readAssetMetadataFromStorage = (): Map<string, CachedAssetDetails> | undefined => {
   return getStorageItem('assetMetadataCache', undefined, (val) => {
     const obj = JSON.parse(val) as Record<string, CachedAssetDetails>
+    Object.values(obj).forEach((x) => (x.supply = BigInt(x.supply)))
     return new Map(Object.entries(obj))
   })
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -126,7 +126,7 @@ export interface AssetOption {
   assetId: string
   name: string
   ticker: string
-  balance: number
+  balance: bigint
   decimals: number
   icon?: string
 }

--- a/src/providers/flow.tsx
+++ b/src/providers/flow.tsx
@@ -88,7 +88,7 @@ export const emptyRecvInfo: RecvInfo = {
   satoshis: 0,
 }
 
-export const emptyAssetInfo: AssetDetails = { assetId: '', supply: 0 }
+export const emptyAssetInfo: AssetDetails = { assetId: '', supply: BigInt(0) }
 
 export const emptySendInfo: SendInfo = {
   address: '',

--- a/src/providers/swaps.tsx
+++ b/src/providers/swaps.tsx
@@ -24,7 +24,7 @@ import { ArkAddress, RestIndexerProvider } from '@arkade-os/sdk'
 import { hex } from '@scure/base'
 
 const BASE_URLS: Record<Network, string | null> = {
-  bitcoin: import.meta.env.VITE_BOLTZ_URL ?? 'https://api.ark.boltz.exchange',
+  bitcoin: import.meta.env.VITE_BOLTZ_URL ?? null,
   mutinynet: 'https://api.boltz.mutinynet.arkade.sh',
   signet: 'https://boltz.signet.arkade.sh',
   regtest: 'http://localhost:9069',

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -348,7 +348,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     delegatorUrl,
   }: {
     arkServerUrl: string
-    esploraUrl: string
+    esploraUrl?: string
     privateKey: string
     retryCount?: number
     maxRetries?: number
@@ -522,7 +522,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const initWallet = async (privateKey: Uint8Array) => {
     const arkServerUrl = aspInfo.url
     const network = aspInfo.network as NetworkName
-    const esploraUrl = getRestApiExplorerURL(network) ?? ''
+    const esploraUrl = getRestApiExplorerURL(network)
     const pubkey = hex.encode(secp.getPublicKey(privateKey))
     updateConfig({ ...config, pubkey })
     const delegatorUrl = config.delegate ? getDelegateUrlForNetwork(network).url : undefined

--- a/src/screens/Apps/Assets/Burn.tsx
+++ b/src/screens/Apps/Assets/Burn.tsx
@@ -15,17 +15,17 @@ import { FlowContext } from '../../../providers/flow'
 import { WalletContext } from '../../../providers/wallet'
 import { consoleError } from '../../../lib/logs'
 import { extractError } from '../../../lib/error'
-import { formatAssetAmount, prettyNumber } from '../../../lib/format'
+import { prettyNumber } from '../../../lib/format'
 import Input from '../../../components/Input'
 import AssetCard from '../../../components/AssetCard'
-import { centsToUnits, unitsToCents } from '../../../lib/assets'
+import { centsToUnits, prettyAssetAmount, unitsToCents } from '../../../lib/assets'
 
 export default function AppAssetBurn() {
   const { navigate } = useContext(NavigationContext)
   const { assetInfo } = useContext(FlowContext)
   const { assetBalances, svcWallet, reloadWallet } = useContext(WalletContext)
 
-  const [amount, setAmount] = useState(0)
+  const [amount, setAmount] = useState(BigInt(0))
   const [error, setError] = useState('')
   const [processing, setProcessing] = useState(false)
   const [opDone, setOpDone] = useState(false)
@@ -36,7 +36,7 @@ export default function AppAssetBurn() {
   const ticker = assetInfo.metadata?.ticker ?? assetInfo.assetId.slice(0, 8)
   const icon = assetInfo.metadata?.icon
   const decimals = assetInfo.metadata?.decimals ?? 8
-  const balance = assetBalances.find((a) => a.assetId === assetInfo.assetId)?.amount ?? 0
+  const balance = assetBalances.find((a) => a.assetId === assetInfo.assetId)?.amount ?? BigInt(0)
 
   const handleMax = () => setAmount(centsToUnits(balance, decimals))
 
@@ -47,7 +47,7 @@ export default function AppAssetBurn() {
       return
     }
     if (parsedAmount > balance) {
-      setError(`Cannot burn more than your balance (${formatAssetAmount(balance, decimals)} ${ticker})`)
+      setError(`Cannot burn more than your balance (${prettyAssetAmount(balance, decimals)} ${ticker})`)
       return
     }
     setError('')
@@ -92,7 +92,7 @@ export default function AppAssetBurn() {
                 Confirm Burn
               </Text>
               <Text centered wrap color='dark50'>
-                You are about to burn {prettyNumber(amount)} {ticker || name}. This action is irreversible.
+                You are about to burn {prettyNumber(Number(amount))} {ticker || name}. This action is irreversible.
               </Text>
             </FlexCol>
             <FlexRow>
@@ -123,15 +123,15 @@ export default function AppAssetBurn() {
                 </span>
               }
               type='number'
-              value={amount}
-              onChange={setAmount}
+              value={Number(amount)}
+              onChange={(value) => setAmount(BigInt(value))}
               placeholder='0'
             />
           </FlexCol>
         </Padded>
       </Content>
       <ButtonsOnBottom>
-        <Button label='Burn' onClick={handleBurnRequest} disabled={!amount} />
+        <Button label='Burn' onClick={handleBurnRequest} disabled={amount <= 0} />
       </ButtonsOnBottom>
     </>
   )

--- a/src/screens/Apps/Assets/Burn.tsx
+++ b/src/screens/Apps/Assets/Burn.tsx
@@ -123,8 +123,10 @@ export default function AppAssetBurn() {
                 </span>
               }
               type='number'
+              min='0'
+              step='1'
               value={Number(amount)}
-              onChange={(value) => setAmount(BigInt(value))}
+              onChange={(value) => setAmount(Number.isFinite(value) && value >= 0 ? BigInt(Math.trunc(value)) : 0n)}
               placeholder='0'
             />
           </FlexCol>

--- a/src/screens/Apps/Assets/Detail.tsx
+++ b/src/screens/Apps/Assets/Detail.tsx
@@ -15,8 +15,8 @@ import { ConfigContext } from '../../../providers/config'
 import { FlowContext, emptyRecvInfo, emptySendInfo } from '../../../providers/flow'
 import { WalletContext } from '../../../providers/wallet'
 import { consoleError } from '../../../lib/logs'
-import { formatAssetAmount } from '../../../lib/format'
 import type { AssetDetails } from '@arkade-os/sdk'
+import { prettyAssetAmount } from '../../../lib/assets'
 
 export default function AppAssetDetail() {
   const { navigate } = useContext(NavigationContext)
@@ -30,7 +30,7 @@ export default function AppAssetDetail() {
   const cachedEntry = assetMetadataCache.get(assetInfo.assetId)
   const hasIcon = cachedEntry?.hasIcon ?? false
 
-  const balance = assetBalances.find((a) => a.assetId === assetInfo.assetId)?.amount ?? 0
+  const balance = assetBalances.find((a) => a.assetId === assetInfo.assetId)?.amount ?? BigInt(0)
 
   const fetchDetails = async (forceRefresh = false) => {
     if (!svcWallet || !assetInfo.assetId) return
@@ -77,10 +77,10 @@ export default function AppAssetDetail() {
     : false
 
   const isImported = config.importedAssets.includes(assetInfo.assetId)
-  const canRemove = isImported && balance === 0
+  const canRemove = isImported && balance === BigInt(0)
 
   const handleSend = () => {
-    setSendInfo({ ...emptySendInfo, assets: [{ assetId: assetInfo.assetId, amount: 0 }] })
+    setSendInfo({ ...emptySendInfo, assets: [{ assetId: assetInfo.assetId, amount: BigInt(0) }] })
     navigate(Pages.SendForm)
   }
 
@@ -113,7 +113,7 @@ export default function AppAssetDetail() {
 
             <FlexCol gap='0.25rem' centered>
               <Text bigger bold centered>
-                {formatAssetAmount(balance, decimals)} {ticker}
+                {prettyAssetAmount(balance, decimals)} {ticker}
               </Text>
               <TextSecondary centered>{name}</TextSecondary>
             </FlexCol>
@@ -155,7 +155,7 @@ export default function AppAssetDetail() {
                 ) : null}
                 <FlexRow between>
                   <TextSecondary>Supply</TextSecondary>
-                  <Text bold>{typeof supply === 'number' ? formatAssetAmount(supply, decimals) : 'Unknown'}</Text>
+                  <Text bold>{prettyAssetAmount(supply, decimals) ?? 'Unknown'}</Text>
                 </FlexRow>
                 <FlexRow between>
                   <TextSecondary>Decimals</TextSecondary>
@@ -208,7 +208,7 @@ export default function AppAssetDetail() {
       </Content>
       <ButtonsOnBottom>
         <FlexRow gap='0.75rem'>
-          <Button label='Send' onClick={handleSend} disabled={balance === 0} />
+          <Button label='Send' onClick={handleSend} disabled={balance === BigInt(0)} />
           <Button label='Receive' onClick={handleReceive} />
         </FlexRow>
         <FlexRow gap='0.75rem'>

--- a/src/screens/Apps/Assets/Index.tsx
+++ b/src/screens/Apps/Assets/Index.tsx
@@ -19,7 +19,7 @@ import AssetCard from '../../../components/AssetCard'
 
 interface AssetListItem {
   assetId: string
-  balance: number
+  balance: bigint
   name?: string
   ticker?: string
   icon?: string
@@ -63,7 +63,7 @@ export default function AppAssets() {
         const meta = assetMetadataCache.get(assetId)
         return {
           assetId,
-          balance: bal?.amount ?? 0,
+          balance: bal?.amount ?? BigInt(0),
           name: meta?.metadata?.name,
           ticker: meta?.metadata?.ticker,
           icon: meta?.metadata?.icon,
@@ -79,7 +79,7 @@ export default function AppAssets() {
   }, [svcWallet, assetBalances, config.importedAssets])
 
   const handleAssetClick = (assetId: string) => {
-    setAssetInfo({ assetId, supply: 0 })
+    setAssetInfo({ assetId, supply: BigInt(0) })
     navigate(Pages.AppAssetDetail)
   }
 

--- a/src/screens/Apps/Assets/Mint.tsx
+++ b/src/screens/Apps/Assets/Mint.tsx
@@ -36,7 +36,7 @@ export default function AppAssetMint() {
   const { setAssetInfo } = useContext(FlowContext)
   const { svcWallet, assetBalances, assetMetadataCache, setCacheEntry, iconApprovalManager } = useContext(WalletContext)
 
-  const [amount, setAmount] = useState(0)
+  const [amount, setAmount] = useState(BigInt(0))
   const [name, setName] = useState('')
   const [ticker, setTicker] = useState('')
   const [decimals, setDecimals] = useState('0')
@@ -103,7 +103,7 @@ export default function AppAssetMint() {
       metadata.decimals = parsedDecimals
       if (iconUrl) metadata.icon = iconUrl
 
-      const rawAmount = unitsToCents(parsedUnits, parsedDecimals)
+      const rawAmount = unitsToCents(BigInt(parsedUnits), parsedDecimals)
 
       let resolvedControlAssetId = controlMode === 'Existing' ? controlAssetId : ''
 
@@ -112,7 +112,7 @@ export default function AppAssetMint() {
         const ctrlMeta: KnownMetadata = { decimals: 0 }
         if (name) ctrlMeta.name = `ctrl-${name}`
         if (ticker) ctrlMeta.ticker = `ctrl-${ticker}`
-        const ctrlRawAmount = parseInt(ctrlAmount.toString())
+        const ctrlRawAmount = BigInt(parseInt(ctrlAmount.toString()))
 
         const ctrlResult = await svcWallet.assetManager.issue({
           amount: ctrlRawAmount,
@@ -208,7 +208,7 @@ export default function AppAssetMint() {
             <ErrorMessage error={Boolean(error)} text={error} />
             <AssetCard
               assetId='preview'
-              balance={unitsToCents(parsedUnits, parsedDecimals) || 0}
+              balance={unitsToCents(BigInt(parsedUnits), parsedDecimals) || BigInt(0)}
               name={name}
               ticker={ticker}
               icon={iconUrl && !iconError ? iconUrl : undefined}
@@ -243,7 +243,7 @@ export default function AppAssetMint() {
                 <Input
                   label='Amount *'
                   type='number'
-                  value={amount}
+                  value={Number(amount)}
                   onChange={setAmount}
                   placeholder='1000'
                   testId='asset-amount'

--- a/src/screens/Apps/Assets/Mint.tsx
+++ b/src/screens/Apps/Assets/Mint.tsx
@@ -112,7 +112,7 @@ export default function AppAssetMint() {
         const ctrlMeta: KnownMetadata = { decimals: 0 }
         if (name) ctrlMeta.name = `ctrl-${name}`
         if (ticker) ctrlMeta.ticker = `ctrl-${ticker}`
-        const ctrlRawAmount = BigInt(parseInt(ctrlAmount.toString()))
+        const ctrlRawAmount = BigInt(ctrlAmount)
 
         const ctrlResult = await svcWallet.assetManager.issue({
           amount: ctrlRawAmount,
@@ -369,8 +369,10 @@ export default function AppAssetMint() {
                   <Input
                     label='Control Amount'
                     type='number'
+                    min='0'
+                    step='1'
                     value={ctrlAmount}
-                    onChange={setCtrlAmount}
+                    onChange={(v: number) => setCtrlAmount(Number.isFinite(v) && v >= 0 ? Math.trunc(v) : 0)}
                     placeholder='1'
                     testId='control-asset-amount'
                   />

--- a/src/screens/Apps/Assets/Mint.tsx
+++ b/src/screens/Apps/Assets/Mint.tsx
@@ -243,8 +243,10 @@ export default function AppAssetMint() {
                 <Input
                   label='Amount *'
                   type='number'
+                  min='0'
+                  step='1'
                   value={Number(amount)}
-                  onChange={setAmount}
+                  onChange={(value) => setAmount(Number.isFinite(value) && value >= 0 ? BigInt(Math.trunc(value)) : 0n)}
                   placeholder='1000'
                   testId='asset-amount'
                 />

--- a/src/screens/Apps/Assets/Reissue.tsx
+++ b/src/screens/Apps/Assets/Reissue.tsx
@@ -17,16 +17,15 @@ import { FlowContext } from '../../../providers/flow'
 import { WalletContext } from '../../../providers/wallet'
 import { consoleError } from '../../../lib/logs'
 import { extractError } from '../../../lib/error'
-import { formatAssetAmount } from '../../../lib/format'
 import Input from '../../../components/Input'
-import { unitsToCents } from '../../../lib/assets'
+import { prettyAssetAmount, unitsToCents } from '../../../lib/assets'
 
 export default function AppAssetReissue() {
   const { navigate } = useContext(NavigationContext)
   const { assetInfo } = useContext(FlowContext)
   const { assetBalances, svcWallet, reloadWallet } = useContext(WalletContext)
 
-  const [amount, setAmount] = useState(0)
+  const [amount, setAmount] = useState(BigInt(0))
   const [error, setError] = useState('')
   const [processing, setProcessing] = useState(false)
   const [opDone, setOpDone] = useState(false)
@@ -37,7 +36,7 @@ export default function AppAssetReissue() {
   const ticker = assetInfo.metadata?.ticker ?? ''
   const icon = assetInfo.metadata?.icon
   const decimals = assetInfo.metadata?.decimals ?? 8
-  const balance = assetBalances.find((a) => a.assetId === assetInfo.assetId)?.amount ?? 0
+  const balance = assetBalances.find((a) => a.assetId === assetInfo.assetId)?.amount ?? BigInt(0)
 
   const handleReissueRequest = () => {
     if (!assetInfo.assetId) {
@@ -91,7 +90,7 @@ export default function AppAssetReissue() {
                 Confirm Reissue
               </Text>
               <Text centered wrap color='dark50'>
-                You are about to mint {amount} additional {ticker || name}.
+                You are about to mint {prettyAssetAmount(amount, decimals)} additional {ticker || name}.
               </Text>
             </FlexCol>
             <FlexRow>
@@ -118,7 +117,7 @@ export default function AppAssetReissue() {
                   </FlexCol>
                 </div>
                 <Text>
-                  {formatAssetAmount(balance, decimals)} {ticker}
+                  {prettyAssetAmount(balance, decimals)} {ticker}
                 </Text>
               </FlexRow>
             </Shadow>
@@ -126,8 +125,8 @@ export default function AppAssetReissue() {
             <Input
               label='Additional Amount'
               type='number'
-              value={amount}
-              onChange={setAmount}
+              value={Number(amount)}
+              onChange={(value) => setAmount(BigInt(value))}
               placeholder='1000'
               testId='asset-amount'
             />

--- a/src/screens/Apps/Assets/Reissue.tsx
+++ b/src/screens/Apps/Assets/Reissue.tsx
@@ -125,8 +125,10 @@ export default function AppAssetReissue() {
             <Input
               label='Additional Amount'
               type='number'
+              min='0'
+              step='1'
               value={Number(amount)}
-              onChange={(value) => setAmount(BigInt(value))}
+              onChange={(value) => setAmount(Number.isFinite(value) && value >= 0 ? BigInt(Math.trunc(value)) : 0n)}
               placeholder='1000'
               testId='asset-amount'
             />

--- a/src/screens/Apps/Assets/Reissue.tsx
+++ b/src/screens/Apps/Assets/Reissue.tsx
@@ -90,7 +90,8 @@ export default function AppAssetReissue() {
                 Confirm Reissue
               </Text>
               <Text centered wrap color='dark50'>
-                You are about to mint {prettyAssetAmount(amount, decimals)} additional {ticker || name}.
+                You are about to mint {prettyAssetAmount(unitsToCents(amount, decimals), decimals)} additional{' '}
+                {ticker || name}.
               </Text>
             </FlexCol>
             <FlexRow>

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -4,7 +4,7 @@ import ButtonsOnBottom from '../../components/ButtonsOnBottom'
 import Padded from '../../components/Padded'
 import Content from '../../components/Content'
 import { WalletContext } from '../../providers/wallet'
-import { formatAssetAmount, prettyAgo, prettyDate, prettyDelta, prettyHide, prettyNumber } from '../../lib/format'
+import { prettyAgo, prettyDate, prettyDelta, prettyHide, prettyNumber } from '../../lib/format'
 import Header from './Header'
 import Text, { TextSecondary } from '../../components/Text'
 import FlexCol from '../../components/FlexCol'
@@ -25,6 +25,7 @@ import { ExtendedCoin, ExtendedVirtualCoin, isVtxoExpiringSoon } from '@arkade-o
 import { consoleError } from '../../lib/logs'
 import * as Sentry from '@sentry/react'
 import Grid from '../../components/Grid'
+import { prettyAssetAmount } from '../../lib/assets'
 
 export default function Vtxos() {
   const { aspInfo, calcBestMarketHour } = useContext(AspContext)
@@ -255,7 +256,7 @@ export default function Vtxos() {
           const meta = assetMetadataCache.get(a.assetId)?.metadata
           const decimals = meta?.decimals ?? 8
           const label = meta?.ticker ?? `${a.assetId.slice(0, 8)}...`
-          return `${formatAssetAmount(a.amount, decimals)} ${label}`
+          return `${prettyAssetAmount(a.amount, decimals)} ${label}`
         })
       : []
     const expiry = vtxo.virtualStatus?.batchExpiry ? prettyAgo(vtxo.virtualStatus.batchExpiry) : 'Unknown'

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -173,7 +173,7 @@ export default function ReceiveQRCode() {
     const ark = validVtxoTx(sats) && vtxoTxsAllowed() ? recvInfo.offchainAddr : ''
     const btc = validUtxoTx(sats) && utxoTxsAllowed() ? swapAddress || recvInfo.boardingAddr : ''
     const bip21 = isAssetReceive
-      ? encodeBip21Asset(ark, assetId, centsToUnits(sats, assetMeta?.metadata?.decimals))
+      ? encodeBip21Asset(ark, assetId, Number(centsToUnits(BigInt(sats), assetMeta?.metadata?.decimals)))
       : encodeBip21(btc, ark, invoice, sats, lnurlSession.lnurl)
 
     return { ark, btc, bip21 }
@@ -331,13 +331,13 @@ export default function ReceiveQRCode() {
 
   const handleAmountChange = (sats: number) => {
     setAmountInput(sats)
-    const value = assetMeta ? centsToUnits(sats, assetMeta.metadata?.decimals) : useFiat ? toFiat(sats) : sats
+    const value = assetMeta ? centsToUnits(BigInt(sats), assetMeta.metadata?.decimals) : useFiat ? toFiat(sats) : sats
     const maximumFractionDigits = useFiat
       ? fiatDecimals()
       : assetMeta?.metadata?.decimals
         ? assetMeta?.metadata?.decimals
         : 0
-    setAmountTextValue(prettyNumber(value, maximumFractionDigits, false))
+    setAmountTextValue(prettyNumber(Number(value), maximumFractionDigits, false))
   }
 
   const handleAmountConfirm = (sats = amountInput) => {
@@ -362,7 +362,7 @@ export default function ReceiveQRCode() {
     assetId: assetId ?? '',
     name: assetMeta?.metadata?.name ?? '',
     ticker: assetMeta?.metadata?.ticker ?? '',
-    balance: 0,
+    balance: BigInt(0),
     decimals: assetMeta?.metadata?.decimals ?? 0,
     icon: assetMeta?.metadata?.icon,
   }

--- a/src/screens/Wallet/Receive/Success.tsx
+++ b/src/screens/Wallet/Receive/Success.tsx
@@ -11,13 +11,14 @@ import { NotificationsContext } from '../../../providers/notifications'
 import { FlowContext } from '../../../providers/flow'
 import Header from '../../../components/Header'
 import { NavigationContext, Pages } from '../../../providers/navigation'
-import { formatAssetAmount, prettyAmount, prettyFiatAmount } from '../../../lib/format'
+import { prettyAmount, prettyFiatAmount } from '../../../lib/format'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 import { WalletContext } from '../../../providers/wallet'
 import { consoleError } from '../../../lib/logs'
 import type { AssetDetails } from '@arkade-os/sdk'
 import AssetCard from '../../../components/AssetCard'
+import { prettyAssetAmount } from '../../../lib/assets'
 
 export default function ReceiveSuccess() {
   const { config, useFiat } = useContext(ConfigContext)
@@ -63,7 +64,7 @@ export default function ReceiveSuccess() {
       if (assetDetails.size < receivedAssets.length) return
       const labels = receivedAssets.map((a) => {
         const meta = assetDetails.get(a.assetId)?.metadata
-        const amount = formatAssetAmount(a.amount, meta?.decimals ?? 0)
+        const amount = prettyAssetAmount(a.amount, meta?.decimals ?? 0)
         const ticker = meta?.ticker ?? meta?.name ?? 'assets'
         return `${amount} ${ticker}`
       })

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -9,7 +9,7 @@ import ErrorMessage from '../../../components/Error'
 import { WalletContext } from '../../../providers/wallet'
 import Header from '../../../components/Header'
 import { defaultFee } from '../../../lib/constants'
-import { formatAssetAmount, prettyNumber } from '../../../lib/format'
+import { prettyNumber } from '../../../lib/format'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import { collaborativeExitWithFees, sendOffChain } from '../../../lib/asp'
@@ -21,6 +21,7 @@ import { SwapsContext } from '../../../providers/swaps'
 import Text from '../../../components/Text'
 import { isPendingChainSwap, isPendingSubmarineSwap } from '@arkade-os/boltz-swap'
 import { FeesContext } from '../../../providers/fees'
+import { prettyAssetAmount } from '../../../lib/assets'
 
 export default function SendDetails() {
   const { navigate } = useContext(NavigationContext)
@@ -35,7 +36,7 @@ export default function SendDetails() {
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
   const assetTicker = assetMeta?.metadata?.ticker ?? ''
   const assetName = assetMeta?.metadata?.name ?? 'Asset'
-  const assetAmountValue = sendInfo.assets?.[0]?.amount ?? 0
+  const assetAmountValue = sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
   const [buttonLabel, setButtonLabel] = useState('')
   const [details, setDetails] = useState<DetailsProps>()
@@ -138,10 +139,7 @@ export default function SendDetails() {
     if (isAssetSend && arkAddress) {
       // Asset send via wallet.send()
       const recipients = [{ address: arkAddress, amount: details.satoshis, assets: sendInfo.assets }]
-      svcWallet
-        .send(...recipients)
-        .then(handleTxid)
-        .catch(handleError)
+      svcWallet.send(recipients[0]).then(handleTxid).catch(handleError)
     } else if (arkAddress) {
       if (!details.total) return handleError('Missing total amount')
       sendOffChain(svcWallet, details.total, arkAddress).then(handleTxid).catch(handleError)
@@ -201,7 +199,7 @@ export default function SendDetails() {
                     {assetName} ({assetTicker})
                   </Text>
                   <Text bold testId='send-details-asset-amount'>
-                    {formatAssetAmount(assetAmountValue, assetMeta?.metadata?.decimals ?? 8)} {assetTicker}
+                    {prettyAssetAmount(assetAmountValue, assetMeta?.metadata?.decimals ?? 8)} {assetTicker}
                   </Text>
                 </FlexCol>
               ) : null}

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -19,7 +19,7 @@ import InputAmount from '../../../components/InputAmount'
 import InputAddress from '../../../components/InputAddress'
 import Header from '../../../components/Header'
 import { WalletContext } from '../../../providers/wallet'
-import { formatAssetAmount, prettyAmount, prettyFiatAmount, prettyNumber } from '../../../lib/format'
+import { prettyAmount, prettyFiatAmount, prettyNumber } from '../../../lib/format'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import FlexRow from '../../../components/FlexRow'
@@ -43,7 +43,7 @@ import { getInvoiceSatoshis } from '@arkade-os/boltz-swap'
 import { SwapsContext } from '../../../providers/swaps'
 import { decodeBip21, isBip21 } from '../../../lib/bip21'
 import { InfoLine } from '../../../components/Info'
-import { centsToUnits, unitsToCents } from '../../../lib/assets'
+import { centsToUnits, prettyAssetAmount, unitsToCents } from '../../../lib/assets'
 import { FeesContext } from '../../../providers/fees'
 import SheetModal from '../../../components/SheetModal'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -225,7 +225,7 @@ export default function SendForm() {
             }
             found = {
               assetId,
-              balance: 0,
+              balance: BigInt(0),
               name: meta?.metadata?.name ?? `${assetId.slice(0, 8)}...`,
               ticker: meta?.metadata?.ticker ?? '',
               icon: meta?.metadata?.icon,
@@ -233,7 +233,7 @@ export default function SendForm() {
             }
           }
           setSelectedAsset(found)
-          const rawAmount = assetAmount != null ? unitsToCents(assetAmount, found.decimals) : 0
+          const rawAmount = assetAmount != null ? unitsToCents(BigInt(assetAmount), found.decimals) : BigInt(0)
           setTextValue(String(assetAmount))
           return setState({
             address,
@@ -527,9 +527,9 @@ export default function SendForm() {
 
   const handleAmountChange = (sats: number) => {
     if (isAssetSend) {
-      setTextValue(String(centsToUnits(sats, selectedAsset?.decimals ?? 8)))
+      setTextValue(String(centsToUnits(BigInt(sats), selectedAsset?.decimals ?? 8)))
       if (selectedAsset) {
-        setState({ ...sendInfo, assets: [{ assetId: selectedAsset.assetId, amount: sats }], satoshis: 0 })
+        setState({ ...sendInfo, assets: [{ assetId: selectedAsset.assetId, amount: BigInt(sats) }], satoshis: 0 })
       }
     } else {
       setTextValue(useFiat ? prettyNumber(toFiat(sats), 2, false) : prettyNumber(sats, 0, false))
@@ -547,7 +547,7 @@ export default function SendForm() {
       if (isBTCAddress(recipient)) {
         return setError('Assets can only be sent to Arkade addresses')
       }
-      setState({ ...sendInfo, address: '', assets: [{ assetId: asset.assetId, amount: 0 }], satoshis: 0 })
+      setState({ ...sendInfo, address: '', assets: [{ assetId: asset.assetId, amount: BigInt(0) }], satoshis: 0 })
     } else {
       setState({ ...sendInfo, assets: undefined, satoshis: 0 })
     }
@@ -625,7 +625,7 @@ export default function SendForm() {
     if (isAssetSend && selectedAsset) {
       const { assetId, balance, decimals } = selectedAsset
       const units = centsToUnits(balance, decimals)
-      setTextValue(prettyNumber(units, decimals, false))
+      setTextValue(prettyNumber(Number(units), decimals, false))
       setState({
         ...sendInfo,
         assets: [{ assetId, amount: balance }],
@@ -658,7 +658,7 @@ export default function SendForm() {
       return (
         <div onClick={handleSendAll} style={{ cursor: 'pointer' }}>
           <Text color='dark50' smaller>
-            {`${formatAssetAmount(selectedAsset.balance, selectedAsset.decimals)} ${selectedAsset.ticker} available`}
+            {`${prettyAssetAmount(selectedAsset.balance, selectedAsset.decimals)} ${selectedAsset.ticker} available`}
           </Text>
         </div>
       )
@@ -929,7 +929,7 @@ export default function SendForm() {
                                   </Text>
                                 </FlexRow>
                                 <Text color='dark50' smaller>
-                                  {formatAssetAmount(asset.balance, asset.decimals)} {asset.ticker}
+                                  {prettyAssetAmount(asset.balance, asset.decimals)} {asset.ticker}
                                 </Text>
                               </FlexRow>
                             </Shadow>

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -43,7 +43,7 @@ import { getInvoiceSatoshis } from '@arkade-os/boltz-swap'
 import { SwapsContext } from '../../../providers/swaps'
 import { decodeBip21, isBip21 } from '../../../lib/bip21'
 import { InfoLine } from '../../../components/Info'
-import { centsToUnits, prettyAssetAmount, unitsToCents } from '../../../lib/assets'
+import { prettyAssetAmount, unitsToCents } from '../../../lib/assets'
 import { FeesContext } from '../../../providers/fees'
 import SheetModal from '../../../components/SheetModal'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -527,7 +527,7 @@ export default function SendForm() {
 
   const handleAmountChange = (sats: number) => {
     if (isAssetSend) {
-      setTextValue(String(centsToUnits(BigInt(sats), selectedAsset?.decimals ?? 8)))
+      setTextValue(prettyAssetAmount(BigInt(sats), selectedAsset?.decimals ?? 8, false))
       if (selectedAsset) {
         setState({ ...sendInfo, assets: [{ assetId: selectedAsset.assetId, amount: BigInt(sats) }], satoshis: 0 })
       }
@@ -624,8 +624,7 @@ export default function SendForm() {
   const applySendAll = () => {
     if (isAssetSend && selectedAsset) {
       const { assetId, balance, decimals } = selectedAsset
-      const units = centsToUnits(balance, decimals)
-      setTextValue(prettyNumber(Number(units), decimals, false))
+      setTextValue(prettyAssetAmount(balance, decimals, false))
       setState({
         ...sendInfo,
         assets: [{ assetId, amount: balance }],

--- a/src/screens/Wallet/Send/Success.tsx
+++ b/src/screens/Wallet/Send/Success.tsx
@@ -11,11 +11,12 @@ import FlexCol from '../../../components/FlexCol'
 import Padded from '../../../components/Padded'
 import Text from '../../../components/Text'
 import SuccessIcon from '../../../icons/Success'
-import { formatAssetAmount, prettyAmount, prettyFiatAmount } from '../../../lib/format'
+import { prettyAmount, prettyFiatAmount } from '../../../lib/format'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 import { WalletContext } from '../../../providers/wallet'
 import AssetCard from '../../../components/AssetCard'
+import { prettyAssetAmount } from '../../../lib/assets'
 
 export default function SendSuccess() {
   const { config, useFiat } = useContext(ConfigContext)
@@ -31,7 +32,7 @@ export default function SendSuccess() {
   const assetName = assetMeta?.metadata?.name ?? 'Unknown Asset'
   const assetTicker = assetMeta?.metadata?.ticker ?? ''
   const assetIcon = assetMeta?.metadata?.icon
-  const assetAmountValue = sendInfo.assets?.[0]?.amount ?? 0
+  const assetAmountValue = sendInfo.assets?.[0]?.amount ?? BigInt(0)
   const assetDecimals = assetMeta?.metadata?.decimals ?? 8
 
   // Show payment sent notification
@@ -41,7 +42,7 @@ export default function SendSuccess() {
 
   const totalSats = sendInfo.total ?? 0
   const displayAmount = isAssetSend
-    ? `${formatAssetAmount(assetAmountValue, assetDecimals)} ${assetTicker}`
+    ? `${prettyAssetAmount(assetAmountValue, assetDecimals)} ${assetTicker}`
     : useFiat
       ? prettyFiatAmount(toFiat(totalSats), config.fiat)
       : prettyAmount(totalSats)

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -4,7 +4,7 @@ import ButtonsOnBottom from '../../components/ButtonsOnBottom'
 import Padded from '../../components/Padded'
 import { WalletContext } from '../../providers/wallet'
 import { FlowContext } from '../../providers/flow'
-import { formatAssetAmount, isBurn, isIssuance, prettyAgo, prettyDate } from '../../lib/format'
+import { isBurn, isIssuance, prettyAgo, prettyDate } from '../../lib/format'
 import { defaultFee } from '../../lib/constants'
 import ErrorMessage from '../../components/Error'
 import { extractError } from '../../lib/error'
@@ -24,6 +24,7 @@ import { AspContext } from '../../providers/asp'
 import Reminder from '../../components/Reminder'
 import { LimitsContext } from '../../providers/limits'
 import { getInputsToSettle } from '../../lib/asp'
+import { prettyAssetAmount } from '../../lib/assets'
 
 export default function Transaction() {
   const { utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
@@ -163,7 +164,7 @@ export default function Transaction() {
                     <AssetAvatar icon={icon} ticker={ticker} size={32} assetId={a.assetId} clickable />
                     <FlexCol gap='0'>
                       <Text color={color}>
-                        {formatAssetAmount(a.amount, decimals)} {label}
+                        {prettyAssetAmount(a.amount, decimals)} {label}
                       </Text>
                       {name && ticker ? <TextSecondary>{name}</TextSecondary> : null}
                     </FlexCol>

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -164,7 +164,7 @@ export default function Transaction() {
                     <AssetAvatar icon={icon} ticker={ticker} size={32} assetId={a.assetId} clickable />
                     <FlexCol gap='0'>
                       <Text color={color}>
-                        {prettyAssetAmount(BigInt(a.amount), decimals)} {label}
+                        {prettyAssetAmount(a.amount, decimals)} {label}
                       </Text>
                       {name && ticker ? <TextSecondary>{name}</TextSecondary> : null}
                     </FlexCol>

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -164,7 +164,7 @@ export default function Transaction() {
                     <AssetAvatar icon={icon} ticker={ticker} size={32} assetId={a.assetId} clickable />
                     <FlexCol gap='0'>
                       <Text color={color}>
-                        {prettyAssetAmount(a.amount, decimals)} {label}
+                        {prettyAssetAmount(BigInt(a.amount), decimals)} {label}
                       </Text>
                       {name && ticker ? <TextSecondary>{name}</TextSecondary> : null}
                     </FlexCol>

--- a/src/test/lib/asset.test.ts
+++ b/src/test/lib/asset.test.ts
@@ -235,12 +235,29 @@ describe('asset utilities', () => {
       expect(prettyAssetAmount(0n, 8)).toBe('0')
     })
 
-    // Documents a current logic shortcoming: `centsToUnits` floors before
-    // formatting, so any sub-unit precision is lost. 1.5 units (with 8
-    // decimals) renders as "1", not "1.5".
-    it('drops fractional units due to BigInt floor-division (current behavior)', () => {
-      expect(prettyAssetAmount(150_000_000n, 8)).toBe('1')
-      expect(prettyAssetAmount(99_999_999n, 8)).toBe('0')
+    it('formats fractional units precisely', () => {
+      expect(prettyAssetAmount(150_000_000n, 8)).toBe('1.5')
+      expect(prettyAssetAmount(99_999_999n, 8)).toBe('0.99999999')
+    })
+
+    it('renders smallest representable unit with leading zeros', () => {
+      expect(prettyAssetAmount(1n, 8)).toBe('0.00000001')
+      expect(prettyAssetAmount(10n, 8)).toBe('0.0000001')
+    })
+
+    it('strips trailing zeros from the fractional part', () => {
+      expect(prettyAssetAmount(110_000_000n, 8)).toBe('1.1')
+      expect(prettyAssetAmount(120_000_000n, 8)).toBe('1.2')
+    })
+
+    it('formats negative fractional amounts', () => {
+      expect(prettyAssetAmount(-150_000_000n, 8)).toBe('-1.5')
+      expect(prettyAssetAmount(-1n, 8)).toBe('-0.00000001')
+    })
+
+    it('preserves precision beyond Number.MAX_SAFE_INTEGER', () => {
+      // 9_007_199_254_740_993 is 2^53 + 1 — not representable as a Number.
+      expect(prettyAssetAmount(9_007_199_254_740_993n, 8)).toBe('90,071,992.54740993')
     })
 
     // ---- bad-decimals fallback: format as integer (no throw) ----

--- a/src/test/lib/asset.test.ts
+++ b/src/test/lib/asset.test.ts
@@ -260,6 +260,14 @@ describe('asset utilities', () => {
       expect(prettyAssetAmount(9_007_199_254_740_993n, 8)).toBe('90,071,992.54740993')
     })
 
+    it('omits thousand separators when useGrouping=false', () => {
+      // Required for echoing the value back into a numeric <input>, where
+      // commas would parse as NaN.
+      expect(prettyAssetAmount(9_007_199_254_740_993n, 8, false)).toBe('90071992.54740993')
+      expect(prettyAssetAmount(150_000_000n, 8, false)).toBe('1.5')
+      expect(prettyAssetAmount(1_234_567n, 0, false)).toBe('1234567')
+    })
+
     // ---- bad-decimals fallback: format as integer (no throw) ----
 
     it('falls back to integer format for negative decimals', () => {

--- a/src/test/lib/asset.test.ts
+++ b/src/test/lib/asset.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import fixtures from '../fixtures.json'
-import { isValidAssetId } from '../../lib/assets'
+import {
+  centsToUnits,
+  isValidAssetId,
+  isValidDecimals,
+  prettyAssetAmount,
+  prettyAssetAmountHide,
+  prettyAssetNumber,
+  truncatedAssetId,
+  unitsToCents,
+} from '../../lib/assets'
 
 describe('asset utilities', () => {
   describe('isValidAssetId', () => {
@@ -8,8 +17,266 @@ describe('asset utilities', () => {
       expect(isValidAssetId(fixtures.lib.asset.id)).toBe(true)
     })
 
+    it('should accept uppercase hex', () => {
+      expect(isValidAssetId('A'.repeat(68))).toBe(true)
+    })
+
     it('should return false for an invalid asset ID', () => {
       expect(isValidAssetId('invalidAssetId')).toBe(false)
+    })
+
+    it('should return false for empty string', () => {
+      expect(isValidAssetId('')).toBe(false)
+    })
+
+    it('should return false for a 67-char hex string', () => {
+      expect(isValidAssetId('a'.repeat(67))).toBe(false)
+    })
+
+    it('should return false for a 69-char hex string', () => {
+      expect(isValidAssetId('a'.repeat(69))).toBe(false)
+    })
+
+    it('should return false for a 68-char string with non-hex chars', () => {
+      expect(isValidAssetId('z'.repeat(68))).toBe(false)
+    })
+  })
+
+  describe('isValidDecimals', () => {
+    it('accepts non-negative integers up to 18', () => {
+      expect(isValidDecimals(0)).toBe(true)
+      expect(isValidDecimals(8)).toBe(true)
+      expect(isValidDecimals(18)).toBe(true)
+    })
+
+    it('rejects values above 18', () => {
+      expect(isValidDecimals(19)).toBe(false)
+      expect(isValidDecimals(309)).toBe(false)
+    })
+
+    it('rejects negative values', () => {
+      expect(isValidDecimals(-1)).toBe(false)
+    })
+
+    it('rejects non-integers', () => {
+      expect(isValidDecimals(1.5)).toBe(false)
+    })
+
+    it('rejects NaN and Infinity', () => {
+      expect(isValidDecimals(NaN)).toBe(false)
+      expect(isValidDecimals(Infinity)).toBe(false)
+    })
+  })
+
+  describe('truncatedAssetId', () => {
+    it('should truncate a long id to first12...last12', () => {
+      const id = fixtures.lib.asset.id
+      expect(truncatedAssetId(id)).toBe(`${id.slice(0, 12)}...${id.slice(-12)}`)
+    })
+
+    it('should return empty string for empty input', () => {
+      expect(truncatedAssetId('')).toBe('')
+    })
+
+    it('should return empty string for input shorter than 24 chars', () => {
+      expect(truncatedAssetId('abcdef')).toBe('')
+      expect(truncatedAssetId('a'.repeat(23))).toBe('')
+    })
+
+    it('should truncate inputs of exactly 24 chars', () => {
+      const id = 'a'.repeat(24)
+      expect(truncatedAssetId(id)).toBe(`${id.slice(0, 12)}...${id.slice(-12)}`)
+    })
+
+    it('should treat undefined as empty', () => {
+      expect(truncatedAssetId(undefined as unknown as string)).toBe('')
+    })
+  })
+
+  describe('unitsToCents', () => {
+    it('should convert units to cents using default decimals=8', () => {
+      expect(unitsToCents(0n)).toBe(0n)
+      expect(unitsToCents(1n)).toBe(100_000_000n)
+      expect(unitsToCents(123n)).toBe(12_300_000_000n)
+    })
+
+    it('should support decimals=0 as a no-op', () => {
+      expect(unitsToCents(0n, 0)).toBe(0n)
+      expect(unitsToCents(123n, 0)).toBe(123n)
+    })
+
+    it('should support arbitrary integer decimals', () => {
+      expect(unitsToCents(2n, 2)).toBe(200n)
+      expect(unitsToCents(2n, 18)).toBe(2_000_000_000_000_000_000n)
+    })
+
+    it('should preserve sign for negative units', () => {
+      expect(unitsToCents(-5n, 8)).toBe(-500_000_000n)
+    })
+
+    // ---- bad-decimals fallback: returns units unchanged (no throw) ----
+
+    it('returns units unchanged for negative decimals', () => {
+      expect(unitsToCents(1n, -1)).toBe(1n)
+    })
+
+    it('returns units unchanged for non-integer decimals', () => {
+      expect(unitsToCents(1n, 1.5)).toBe(1n)
+    })
+
+    it('returns units unchanged for NaN decimals', () => {
+      expect(unitsToCents(1n, NaN)).toBe(1n)
+    })
+
+    it('returns units unchanged for decimals beyond MAX_DECIMALS', () => {
+      expect(unitsToCents(1n, 19)).toBe(1n)
+      expect(unitsToCents(1n, 309)).toBe(1n)
+    })
+  })
+
+  describe('centsToUnits', () => {
+    it('should convert cents to units using default decimals=8', () => {
+      expect(centsToUnits(0n)).toBe(0n)
+      expect(centsToUnits(100_000_000n)).toBe(1n)
+    })
+
+    it('should floor-divide (truncate fractional units)', () => {
+      // 1.5 units expressed as cents — fractional part is dropped.
+      expect(centsToUnits(150_000_000n, 8)).toBe(1n)
+      // 0.99999999 units — also truncates to 0.
+      expect(centsToUnits(99_999_999n, 8)).toBe(0n)
+    })
+
+    it('should support decimals=0 as a no-op', () => {
+      expect(centsToUnits(123n, 0)).toBe(123n)
+    })
+
+    it('should preserve sign for negative cents', () => {
+      expect(centsToUnits(-200_000_000n, 8)).toBe(-2n)
+    })
+
+    // ---- bad-decimals fallback: returns cents unchanged (no throw) ----
+
+    it('returns cents unchanged for negative decimals', () => {
+      expect(centsToUnits(1n, -1)).toBe(1n)
+    })
+
+    it('returns cents unchanged for non-integer decimals', () => {
+      expect(centsToUnits(1n, 1.5)).toBe(1n)
+    })
+
+    it('returns cents unchanged for NaN decimals', () => {
+      expect(centsToUnits(1n, NaN)).toBe(1n)
+    })
+
+    it('returns cents unchanged for decimals beyond MAX_DECIMALS', () => {
+      expect(centsToUnits(100_000_000n, 19)).toBe(100_000_000n)
+    })
+
+    // The TS signature requires bigint; passing a Number is a programmer
+    // error caught by the type checker. We don't soft-coerce at runtime —
+    // callers should fix their types instead.
+    it('still throws TypeError when cents is a Number (TS contract violation)', () => {
+      expect(() => centsToUnits(150_000_000 as unknown as bigint, 8)).toThrow(TypeError)
+    })
+  })
+
+  describe('prettyAssetNumber', () => {
+    it('returns "0" when num is undefined', () => {
+      expect(prettyAssetNumber(undefined)).toBe('0')
+    })
+
+    it('returns "0" when num is null', () => {
+      expect(prettyAssetNumber(null as unknown as bigint)).toBe('0')
+    })
+
+    it('formats bigint with grouping by default', () => {
+      expect(prettyAssetNumber(0n)).toBe('0')
+      expect(prettyAssetNumber(1_000n)).toBe('1,000')
+      expect(prettyAssetNumber(123_456_789n)).toBe('123,456,789')
+    })
+
+    it('formats negative bigint', () => {
+      expect(prettyAssetNumber(-1_000n)).toBe('-1,000')
+    })
+
+    it('formats without grouping when useGrouping=false', () => {
+      expect(prettyAssetNumber(123_456_789n, 8, false)).toBe('123456789')
+    })
+
+    it('formats very large bigints without precision loss', () => {
+      expect(prettyAssetNumber(10n ** 30n, 0, false)).toBe('1' + '0'.repeat(30))
+    })
+
+    // ---- critical error paths: Intl.NumberFormat rejects out-of-range options ----
+
+    it('throws RangeError for negative maximumFractionDigits', () => {
+      expect(() => prettyAssetNumber(1n, -1)).toThrow(RangeError)
+    })
+
+    it('throws RangeError for maximumFractionDigits > 100', () => {
+      expect(() => prettyAssetNumber(1n, 101)).toThrow(RangeError)
+    })
+
+    it('throws RangeError for NaN maximumFractionDigits', () => {
+      expect(() => prettyAssetNumber(1n, NaN)).toThrow(RangeError)
+    })
+  })
+
+  describe('prettyAssetAmount', () => {
+    it('formats with decimals=0 (no division)', () => {
+      expect(prettyAssetAmount(0n, 0)).toBe('0')
+      expect(prettyAssetAmount(123n, 0)).toBe('123')
+      expect(prettyAssetAmount(1_000_000n, 0)).toBe('1,000,000')
+    })
+
+    it('formats whole units with decimals=8', () => {
+      expect(prettyAssetAmount(100_000_000n, 8)).toBe('1')
+      expect(prettyAssetAmount(0n, 8)).toBe('0')
+    })
+
+    // Documents a current logic shortcoming: `centsToUnits` floors before
+    // formatting, so any sub-unit precision is lost. 1.5 units (with 8
+    // decimals) renders as "1", not "1.5".
+    it('drops fractional units due to BigInt floor-division (current behavior)', () => {
+      expect(prettyAssetAmount(150_000_000n, 8)).toBe('1')
+      expect(prettyAssetAmount(99_999_999n, 8)).toBe('0')
+    })
+
+    // ---- bad-decimals fallback: format as integer (no throw) ----
+
+    it('falls back to integer format for negative decimals', () => {
+      expect(prettyAssetAmount(123n, -1)).toBe('123')
+    })
+
+    it('falls back to integer format for non-integer decimals', () => {
+      expect(prettyAssetAmount(123n, 1.5)).toBe('123')
+    })
+
+    it('falls back to integer format for NaN decimals', () => {
+      // Previously crashed <Mint /> when the decimals input was empty
+      // (parsedDecimals became NaN in the live preview).
+      expect(prettyAssetAmount(123n, NaN)).toBe('123')
+    })
+  })
+
+  describe('prettyAssetAmountHide', () => {
+    it('returns empty string for falsy value (0n)', () => {
+      expect(prettyAssetAmountHide(0n, 'TKN')).toBe('')
+    })
+
+    it('returns dots + suffix for non-zero value', () => {
+      // "123".length === 3 → max(6, 6) = 6 dots
+      expect(prettyAssetAmountHide(123n, 'TKN')).toBe(`${'·'.repeat(6)} TKN`)
+    })
+
+    it('returns dots only when suffix is empty', () => {
+      expect(prettyAssetAmountHide(123n, '')).toBe('·'.repeat(6))
+    })
+
+    it('scales dot count to 2x the digit count when value is long', () => {
+      // "123456789".length === 9 → max(18, 6) = 18 dots
+      expect(prettyAssetAmountHide(123_456_789n, 'TKN')).toBe(`${'·'.repeat(18)} TKN`)
     })
   })
 })

--- a/src/test/lib/storage.test.ts
+++ b/src/test/lib/storage.test.ts
@@ -14,7 +14,7 @@ describe('asset metadata storage', () => {
 
   const makeCached = (assetId: string, name: string, cachedAt = Date.now()): CachedAssetDetails => ({
     assetId,
-    supply: 1000,
+    supply: BigInt(1000),
     metadata: { name, ticker: 'TKN', decimals: 8 },
     cachedAt,
   })

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -174,7 +174,7 @@ export const mockFlowContextValue = {
   setSendInfo: () => {},
   setSwapInfo: () => {},
   setTxInfo: () => {},
-  assetInfo: { assetId: '', supply: 0 },
+  assetInfo: { assetId: '', supply: BigInt(0) },
   setAssetInfo: () => {},
   deepLinkInfo: undefined,
   setDeepLinkInfo: () => {},

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -35,7 +35,7 @@ export const mockTxInfo = {
 
 export const mockIssuanceTxInfo = {
   amount: 0,
-  assets: [{ assetId: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd', amount: 10000 }],
+  assets: [{ assetId: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd', amount: 10_000n }],
   boardingTxid: '',
   redeemTxid: mockTxId,
   roundTxid: '',

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -254,7 +254,7 @@ describe('Transaction screen', () => {
   it('renders burn transaction with correct direction', async () => {
     const mockBurnTxInfo = {
       ...mockIssuanceTxInfo,
-      assets: [{ assetId: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd', amount: -5000 }],
+      assets: [{ assetId: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd', amount: -5_000n }],
     }
     const localFlowContextValue = { ...mockFlowContextValue, txInfo: mockBurnTxInfo }
     const localWalletContextValue = { ...mockWalletContextValue, txs: [mockBurnTxInfo] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default Boltz provider endpoint in Docker/build and mainnet startup (VITE_BOLTZ_URL -> https://api.boltz.exchange)
  * Bumped swap and SDK dependency versions
  * Made Boltz URL nullable when unset and improved local cache serialization for bigint values

* **Refactor**
  * Migrated asset amounts and balances to bigint across the app
  * Replaced legacy asset formatting with new prettyAssetAmount utilities
  * Made REST API explorer URL handling optional

* **Tests**
  * Expanded asset-formatting/conversion tests and updated mocks to bigint usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->