### PR TITLE
Fix dead service worker

### DIFF
--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -149,21 +149,27 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const reloadTimerRef = useRef<ReturnType<typeof setTimeout>>()
   const swMessageHandlerRef = useRef<(event: MessageEvent) => void>()
   const reinitInProgress = useRef(false)
-  const walletGeneration = useRef(0)
-  const walletGenerationInvalidatedBy = useRef<'init' | 'lock-reset'>('init')
+  const initAbortRef = useRef<AbortController | null>(null)
   const reinitSvcWalletRef = useRef<((identity: SingleKey) => Promise<void>) | null>(null)
 
-  const bumpWalletGeneration = (reason: 'init' | 'lock-reset') => {
-    walletGenerationInvalidatedBy.current = reason
-    walletGeneration.current = (walletGeneration.current + 1) >>> 0
-    return walletGeneration.current
+  // Each init gets its own AbortSignal; lock/reset aborts the current signal
+  // with 'lock-reset' so stale paths can decide whether to tear down the SW.
+  // A new init aborts the previous with 'init', which means "abandon, don't clear".
+  const startInitSession = (): AbortSignal => {
+    initAbortRef.current?.abort('init')
+    initAbortRef.current = new AbortController()
+    return initAbortRef.current.signal
   }
 
-  const clearStaleSvcWallet = async (staleSvcWallet: ServiceWorkerWallet, generation: number) => {
-    if (generation === walletGeneration.current) return
-    if (walletGenerationInvalidatedBy.current !== 'lock-reset') return
+  const abortInitSession = () => {
+    initAbortRef.current?.abort('lock-reset')
+    initAbortRef.current = null
+  }
+
+  const clearIfLockReset = async (svcWallet: ServiceWorkerWallet, signal: AbortSignal) => {
+    if (!signal.aborted || signal.reason !== 'lock-reset') return
     try {
-      await staleSvcWallet.clear()
+      await svcWallet.clear()
     } catch (err) {
       consoleError(err, 'Error clearing stale service worker wallet')
     }
@@ -379,14 +385,14 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const initSvcWorkerWallet = async (params: InitSvcWorkerWalletParams): Promise<boolean> => {
     const identity = params.identity ?? (params.privateKey ? SingleKey.fromHex(params.privateKey) : undefined)
     if (!identity) throw new Error('initSvcWorkerWallet requires identity or privateKey')
-    const generation = bumpWalletGeneration('init')
-    return runInitAttempt(generation, identity, params)
+    const signal = startInitSession()
+    return runInitAttempt(signal, identity, params)
   }
 
-  // Retries inherit the generation minted by the top-level call so that a
-  // lock/reset that fires between retries is still detected via the mismatch.
+  // Retries inherit the signal minted by the top-level call so a lock/reset
+  // that fires between retries is observable via signal.aborted.
   const runInitAttempt = async (
-    generation: number,
+    signal: AbortSignal,
     identity: SingleKey,
     params: InitSvcWorkerWalletParams,
   ): Promise<boolean> => {
@@ -440,11 +446,6 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         settlementConfig: { vtxoThreshold: wallet.thresholdMs ? Math.floor(wallet.thresholdMs / 1000) : 1 },
       })
 
-      if (generation !== walletGeneration.current) {
-        await clearStaleSvcWallet(svcWallet, generation)
-        return false
-      }
-
       if (!skipMigration) {
         setLoadingStatus('Migrating data...')
         try {
@@ -471,18 +472,20 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         }
       }
 
-      if (generation !== walletGeneration.current) {
-        await clearStaleSvcWallet(svcWallet, generation)
+      const vtxoMgr = await svcWallet.getVtxoManager()
+      const { walletInitialized } = await svcWallet.getStatus()
+
+      // Single checkpoint before any state/listener commits. Migration and
+      // getVtxoManager/getStatus are side-effect-free w.r.t. React/DOM, so
+      // running them after an abort is wasteful but safe.
+      if (signal.aborted) {
+        await clearIfLockReset(svcWallet, signal)
         return false
       }
 
-      const vtxoMgr = await svcWallet.getVtxoManager()
-      if (generation !== walletGeneration.current) {
-        await clearStaleSvcWallet(svcWallet, generation)
-        return false
-      }
       setSvcWallet(svcWallet)
       setVtxoManager(vtxoMgr)
+      setInitialized(walletInitialized)
 
       // Cancel any pending reload from a previous wallet instance
       clearTimeout(reloadTimerRef.current)
@@ -499,21 +502,11 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         }
       }
 
-      // listen for messages from the service worker
       if (swMessageHandlerRef.current) {
         removeServiceWorkerMessageHandler(swMessageHandlerRef.current)
       }
       navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessages)
       swMessageHandlerRef.current = handleServiceWorkerMessages
-
-      // check if the service worker wallet is initialized
-      const { walletInitialized } = await svcWallet.getStatus()
-      if (generation !== walletGeneration.current) {
-        removeServiceWorkerMessageHandler(handleServiceWorkerMessages)
-        await clearStaleSvcWallet(svcWallet, generation)
-        return false
-      }
-      setInitialized(walletInitialized)
 
       // ping the service worker wallet status every 1 second
       if (statusPingInterval.current) clearInterval(statusPingInterval.current)
@@ -528,13 +521,13 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
           )
           const { walletInitialized } = await Promise.race([svcWallet.getStatus(), statusTimeout])
           consecutivePingFailures = 0
-          if (generation === walletGeneration.current) setInitialized(walletInitialized)
+          if (!signal.aborted) setInitialized(walletInitialized)
         } catch (err) {
           consoleError(err, 'Error pinging wallet status')
           consecutivePingFailures++
-          // Guard with generation so a stale in-flight ping from a dead session
+          // Guard with signal so a stale in-flight ping from a dead session
           // cannot clear the new session's interval or trigger a reinit.
-          if (consecutivePingFailures >= 3 && generation === walletGeneration.current) {
+          if (consecutivePingFailures >= 3 && !signal.aborted) {
             clearInterval(statusPingInterval.current)
             reinitSvcWalletRef.current?.(identity)
           }
@@ -551,7 +544,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       }
       return true
     } catch (err) {
-      if (generation !== walletGeneration.current) return false
+      if (signal.aborted) return false
 
       const isTimeoutError =
         err instanceof Error &&
@@ -568,8 +561,8 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
           'Service worker activation retry',
         )
         await new Promise((resolve) => setTimeout(resolve, delay))
-        if (generation !== walletGeneration.current) return false
-        return runInitAttempt(generation, identity, { ...params, retryCount: retryCount + 1 })
+        if (signal.aborted) return false
+        return runInitAttempt(signal, identity, { ...params, retryCount: retryCount + 1 })
       }
 
       // If we are here, either retries are exhausted or it's a different error.
@@ -687,7 +680,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   })
 
   const lockWallet = async () => {
-    bumpWalletGeneration('lock-reset')
+    abortInitSession()
     if (!svcWallet) throw new Error('Service worker not initialized')
     if (statusPingInterval.current) clearInterval(statusPingInterval.current)
     statusPingInterval.current = undefined
@@ -702,7 +695,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   }
 
   const resetWallet = async () => {
-    bumpWalletGeneration('lock-reset')
+    abortInitSession()
     if (statusPingInterval.current) clearInterval(statusPingInterval.current)
     statusPingInterval.current = undefined
     clearTimeout(reloadTimerRef.current)

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -47,6 +47,17 @@ import { IndexedDbSwapRepository, migrateToSwapRepository, Network } from '@arka
 const SERVICE_WORKER_ACTIVATION_TIMEOUT_MS = 5_000
 const MESSAGE_BUS_INIT_TIMEOUT_MS = 30_000
 
+interface InitSvcWorkerWalletParams {
+  arkServerUrl: string
+  esploraUrl?: string
+  privateKey?: string
+  identity?: SingleKey
+  skipMigration?: boolean
+  retryCount?: number
+  maxRetries?: number
+  delegatorUrl?: string
+}
+
 const defaultWallet: Wallet = {
   network: '',
   nextRollover: 0,
@@ -137,6 +148,32 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const statusPingInterval = useRef<ReturnType<typeof setInterval>>()
   const reloadTimerRef = useRef<ReturnType<typeof setTimeout>>()
   const swMessageHandlerRef = useRef<(event: MessageEvent) => void>()
+  const reinitInProgress = useRef(false)
+  const walletGeneration = useRef(0)
+  const walletGenerationInvalidatedBy = useRef<'init' | 'lock-reset'>('init')
+  const reinitSvcWalletRef = useRef<((identity: SingleKey) => Promise<void>) | null>(null)
+
+  const bumpWalletGeneration = (reason: 'init' | 'lock-reset') => {
+    walletGenerationInvalidatedBy.current = reason
+    walletGeneration.current = (walletGeneration.current + 1) >>> 0
+    return walletGeneration.current
+  }
+
+  const clearStaleSvcWallet = async (staleSvcWallet: ServiceWorkerWallet, generation: number) => {
+    if (generation === walletGeneration.current) return
+    if (walletGenerationInvalidatedBy.current !== 'lock-reset') return
+    try {
+      await staleSvcWallet.clear()
+    } catch (err) {
+      consoleError(err, 'Error clearing stale service worker wallet')
+    }
+  }
+
+  const removeServiceWorkerMessageHandler = (handler = swMessageHandlerRef.current) => {
+    if (!handler) return
+    navigator.serviceWorker.removeEventListener('message', handler)
+    if (swMessageHandlerRef.current === handler) swMessageHandlerRef.current = undefined
+  }
 
   const setCacheEntry = (assetId: string, details: AssetDetails): CachedAssetDetails => {
     const hasIcon = !!details.metadata?.icon
@@ -339,21 +376,21 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     setDataReady(true)
   }
 
-  const initSvcWorkerWallet = async ({
-    arkServerUrl,
-    esploraUrl,
-    privateKey,
-    retryCount = 0,
-    maxRetries = 2,
-    delegatorUrl,
-  }: {
-    arkServerUrl: string
-    esploraUrl?: string
-    privateKey: string
-    retryCount?: number
-    maxRetries?: number
-    delegatorUrl?: string
-  }) => {
+  const initSvcWorkerWallet = async (params: InitSvcWorkerWalletParams): Promise<boolean> => {
+    const identity = params.identity ?? (params.privateKey ? SingleKey.fromHex(params.privateKey) : undefined)
+    if (!identity) throw new Error('initSvcWorkerWallet requires identity or privateKey')
+    const generation = bumpWalletGeneration('init')
+    return runInitAttempt(generation, identity, params)
+  }
+
+  // Retries inherit the generation minted by the top-level call so that a
+  // lock/reset that fires between retries is still detected via the mismatch.
+  const runInitAttempt = async (
+    generation: number,
+    identity: SingleKey,
+    params: InitSvcWorkerWalletParams,
+  ): Promise<boolean> => {
+    const { arkServerUrl, esploraUrl, skipMigration = false, retryCount = 0, maxRetries = 2, delegatorUrl } = params
     try {
       setLoadingStatus('Starting wallet...')
       const walletRepository = new IndexedDBWalletRepository()
@@ -389,7 +426,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       setLoadingStatus('Connecting to service worker...')
       const svcWallet = await ServiceWorkerWallet.setup({
         serviceWorkerPath: '/wallet-service-worker.mjs',
-        identity: SingleKey.fromHex(privateKey),
+        identity,
         arkServerUrl,
         esploraUrl,
         delegatorUrl,
@@ -403,32 +440,47 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         settlementConfig: { vtxoThreshold: wallet.thresholdMs ? Math.floor(wallet.thresholdMs / 1000) : 1 },
       })
 
-      // Migration!
-      setLoadingStatus('Migrating data...')
-      try {
-        const oldStorage = new IndexedDBStorageAdapter('arkade-service-worker')
-        const walletStatus = await getMigrationStatus('wallet', oldStorage)
-        if (walletStatus !== 'not-needed') {
-          if (walletStatus === 'pending' || walletStatus === 'in-progress') {
-            const arkAddress = await svcWallet.getAddress()
-            const boardingAddress = await svcWallet.getBoardingAddress()
-            try {
-              await migrateWalletRepository(oldStorage, svcWallet.walletRepository, {
-                offchain: [arkAddress],
-                onchain: [boardingAddress],
-              })
-            } catch (err) {
-              await rollbackMigration('wallet', oldStorage)
-              throw err
+      if (generation !== walletGeneration.current) {
+        await clearStaleSvcWallet(svcWallet, generation)
+        return false
+      }
+
+      if (!skipMigration) {
+        setLoadingStatus('Migrating data...')
+        try {
+          const oldStorage = new IndexedDBStorageAdapter('arkade-service-worker')
+          const walletStatus = await getMigrationStatus('wallet', oldStorage)
+          if (walletStatus !== 'not-needed') {
+            if (walletStatus === 'pending' || walletStatus === 'in-progress') {
+              const arkAddress = await svcWallet.getAddress()
+              const boardingAddress = await svcWallet.getBoardingAddress()
+              try {
+                await migrateWalletRepository(oldStorage, svcWallet.walletRepository, {
+                  offchain: [arkAddress],
+                  onchain: [boardingAddress],
+                })
+              } catch (err) {
+                await rollbackMigration('wallet', oldStorage)
+                throw err
+              }
             }
+            await migrateToSwapRepository(oldStorage, new IndexedDbSwapRepository())
           }
-          await migrateToSwapRepository(oldStorage, new IndexedDbSwapRepository())
+        } catch (err) {
+          consoleError(err, 'Error migrating wallet repository')
         }
-      } catch (err) {
-        consoleError(err, 'Error migrating wallet repository')
+      }
+
+      if (generation !== walletGeneration.current) {
+        await clearStaleSvcWallet(svcWallet, generation)
+        return false
       }
 
       const vtxoMgr = await svcWallet.getVtxoManager()
+      if (generation !== walletGeneration.current) {
+        await clearStaleSvcWallet(svcWallet, generation)
+        return false
+      }
       setSvcWallet(svcWallet)
       setVtxoManager(vtxoMgr)
 
@@ -449,23 +501,45 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
 
       // listen for messages from the service worker
       if (swMessageHandlerRef.current) {
-        navigator.serviceWorker.removeEventListener('message', swMessageHandlerRef.current)
+        removeServiceWorkerMessageHandler(swMessageHandlerRef.current)
       }
       navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessages)
       swMessageHandlerRef.current = handleServiceWorkerMessages
 
       // check if the service worker wallet is initialized
       const { walletInitialized } = await svcWallet.getStatus()
+      if (generation !== walletGeneration.current) {
+        removeServiceWorkerMessageHandler(handleServiceWorkerMessages)
+        await clearStaleSvcWallet(svcWallet, generation)
+        return false
+      }
       setInitialized(walletInitialized)
 
       // ping the service worker wallet status every 1 second
       if (statusPingInterval.current) clearInterval(statusPingInterval.current)
+      let consecutivePingFailures = 0
+      let pingInProgress = false
       statusPingInterval.current = setInterval(async () => {
+        if (pingInProgress) return
+        pingInProgress = true
         try {
-          const { walletInitialized } = await svcWallet.getStatus()
-          setInitialized(walletInitialized)
+          const statusTimeout = new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('status ping timed out')), 3_000),
+          )
+          const { walletInitialized } = await Promise.race([svcWallet.getStatus(), statusTimeout])
+          consecutivePingFailures = 0
+          if (generation === walletGeneration.current) setInitialized(walletInitialized)
         } catch (err) {
           consoleError(err, 'Error pinging wallet status')
+          consecutivePingFailures++
+          // Guard with generation so a stale in-flight ping from a dead session
+          // cannot clear the new session's interval or trigger a reinit.
+          if (consecutivePingFailures >= 3 && generation === walletGeneration.current) {
+            clearInterval(statusPingInterval.current)
+            reinitSvcWalletRef.current?.(identity)
+          }
+        } finally {
+          pingInProgress = false
         }
       }, 1_000)
 
@@ -475,7 +549,10 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       if (!config.delegate) {
         vtxoMgr.renewVtxos().catch(() => {})
       }
+      return true
     } catch (err) {
+      if (generation !== walletGeneration.current) return false
+
       const isTimeoutError =
         err instanceof Error &&
         (err.message.includes('Service worker activation timed out') || err.message.includes('MessageBus timed out'))
@@ -491,14 +568,8 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
           'Service worker activation retry',
         )
         await new Promise((resolve) => setTimeout(resolve, delay))
-        return initSvcWorkerWallet({
-          arkServerUrl,
-          esploraUrl,
-          privateKey,
-          retryCount: retryCount + 1,
-          maxRetries,
-          delegatorUrl,
-        })
+        if (generation !== walletGeneration.current) return false
+        return runInitAttempt(generation, identity, { ...params, retryCount: retryCount + 1 })
       }
 
       // If we are here, either retries are exhausted or it's a different error.
@@ -526,12 +597,13 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     const pubkey = hex.encode(secp.getPublicKey(privateKey))
     updateConfig({ ...config, pubkey })
     const delegatorUrl = config.delegate ? getDelegateUrlForNetwork(network).url : undefined
-    await initSvcWorkerWallet({
+    const initialized = await initSvcWorkerWallet({
       privateKey: hex.encode(privateKey),
       arkServerUrl,
       esploraUrl,
       delegatorUrl,
     })
+    if (!initialized) return
     updateWallet({ ...wallet, network, pubkey })
     setInitialized(true)
   }
@@ -577,13 +649,51 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       arkServerUrl,
       esploraUrl,
       delegatorUrl,
+      skipMigration: true,
     })
   }
 
+  // Self-heal when the SW dies: re-run setup with the existing identity so
+  // SwapsProvider and other consumers re-bind via setSvcWallet, instead of
+  // reloading the page (which would discard FlowProvider state and UI context).
+  // Identity is passed in by the caller because the setInterval that triggers
+  // reinit captures this closure from the render before svcWallet state was
+  // populated.
+  const reinitSvcWallet = async (identity: SingleKey) => {
+    if (reinitInProgress.current) return
+    reinitInProgress.current = true
+    try {
+      const arkServerUrl = aspInfo.url
+      const esploraUrl = getRestApiExplorerURL(aspInfo.network as NetworkName) ?? ''
+      const delegatorUrl = config.delegate ? getDelegateUrlForNetwork(aspInfo.network as Network).url : undefined
+      const initialized = await initSvcWorkerWallet({
+        identity,
+        arkServerUrl,
+        esploraUrl,
+        delegatorUrl,
+        skipMigration: true,
+      })
+      if (!initialized) return
+    } catch (err) {
+      consoleError(err, 'SW reinit failed; falling back to full reload')
+      window.location.reload()
+    } finally {
+      reinitInProgress.current = false
+    }
+  }
+
+  useEffect(() => {
+    reinitSvcWalletRef.current = reinitSvcWallet
+  })
+
   const lockWallet = async () => {
+    bumpWalletGeneration('lock-reset')
     if (!svcWallet) throw new Error('Service worker not initialized')
     if (statusPingInterval.current) clearInterval(statusPingInterval.current)
     statusPingInterval.current = undefined
+    clearTimeout(reloadTimerRef.current)
+    reloadTimerRef.current = undefined
+    removeServiceWorkerMessageHandler()
     await svcWallet.clear()
     setAuthState('locked')
     setInitialized(false)
@@ -592,6 +702,12 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   }
 
   const resetWallet = async () => {
+    bumpWalletGeneration('lock-reset')
+    if (statusPingInterval.current) clearInterval(statusPingInterval.current)
+    statusPingInterval.current = undefined
+    clearTimeout(reloadTimerRef.current)
+    reloadTimerRef.current = undefined
+    removeServiceWorkerMessageHandler()
     if (!svcWallet) throw new Error('Service worker not initialized')
     await clearStorage()
     await svcWallet.clear()


### PR DESCRIPTION
## Note
With https://github.com/arkade-os/boltz-swap/pull/145 this fix is not relevant for that specific issue. It's still an improvement for the app's robustness.

## Description

Detect a service worker that the browser has killed and re-setup the SW wallet in-place, instead of failing operations (e.g. "Cannot create submarine swap") until a page reload.

A 1s status ping with a 3s timeout marks the SW dead after 3 consecutive failures and triggers a reinit with the existing identity. An `AbortSignal` per init session lets lock/reset/concurrent inits cancel in-flight setups cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced wallet initialization and recovery mechanisms to improve stability and reliability.
  * Improved error handling and timeout detection for wallet status monitoring to support faster issue recovery.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/wallet/pull/613)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->