### PR TITLE
Add contracts view

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -4,13 +4,14 @@ import Refresher from './Refresher'
 interface ContentProps {
   children: ReactNode
   noFade?: boolean
+  noRefresh?: boolean
 }
 
-export default function Content({ children, noFade }: ContentProps) {
+export default function Content({ children, noFade, noRefresh }: ContentProps) {
   const className = noFade ? 'content no-content-fade' : 'content'
   return (
     <div className={className}>
-      <Refresher />
+      {noRefresh ? null : <Refresher />}
       <div className='content-shell'>{children}</div>
     </div>
   )

--- a/src/components/LoadingLogo.tsx
+++ b/src/components/LoadingLogo.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, useAnimationControls } from 'framer-motion'
 import { EASE_OUT_QUINT_TUPLE, EASE_IN_OUT_QUINT_TUPLE } from '../lib/animations'
@@ -9,6 +9,7 @@ import PixelLogoSvg from './PixelLogoSvg'
 import PixelSplash from './PixelSplash'
 import Text from './Text'
 import { gitCommit } from '../_gitCommit'
+import { DevModeContext } from '../providers/devMode'
 
 const LARGE_SIZE = 100
 // Max frames to wait for the header logo anchor to mount before falling back to fly-up
@@ -22,13 +23,11 @@ interface LoadingLogoProps {
 }
 
 export default function LoadingLogo({ text, done, exitMode = 'none', onExitComplete }: LoadingLogoProps) {
+  const { devMode, handleTap } = useContext(DevModeContext)
   const reducedMotion = useReducedMotion()
   const [visible, setVisible] = useState(true)
-  const [statusRevealed, setStatusRevealed] = useState(false)
   const showBackground = exitMode !== 'none'
   const containerRef = useRef<HTMLDivElement>(null)
-  const tapCountRef = useRef(0)
-  const tapTimerRef = useRef<ReturnType<typeof setTimeout>>()
   const flyControls = useAnimationControls()
   const flyControlsRef = useRef(flyControls)
   flyControlsRef.current = flyControls
@@ -41,28 +40,10 @@ export default function LoadingLogo({ text, done, exitMode = 'none', onExitCompl
     reducedMotion,
   })
 
-  const handleLogoTap = useCallback(() => {
-    tapCountRef.current += 1
-    clearTimeout(tapTimerRef.current)
-    if (tapCountRef.current >= 3) {
-      tapCountRef.current = 0
-      setStatusRevealed((v) => !v)
-    } else {
-      tapTimerRef.current = setTimeout(() => {
-        tapCountRef.current = 0
-      }, 600)
-    }
-  }, [])
-
   // When done signal arrives, request the bounce loop to stop
   useEffect(() => {
     if (done) requestStop()
   }, [done, requestStop])
-
-  // Clean up tap timer on unmount
-  useEffect(() => {
-    return () => clearTimeout(tapTimerRef.current)
-  }, [])
 
   // When bounce loop has stopped, play exit animation
   useEffect(() => {
@@ -163,7 +144,7 @@ export default function LoadingLogo({ text, done, exitMode = 'none', onExitCompl
           gap: '1rem',
         }}
       >
-        <div style={{ pointerEvents: 'auto', cursor: 'default' }} onClick={handleLogoTap}>
+        <div style={{ pointerEvents: 'auto', cursor: 'default' }} onClick={handleTap}>
           <motion.div
             ref={containerRef}
             animate={flyControls}
@@ -181,7 +162,7 @@ export default function LoadingLogo({ text, done, exitMode = 'none', onExitCompl
             <PixelSplash bounceCount={bounceCount} reducedMotion={reducedMotion} />
           </motion.div>
         </div>
-        {text && statusRevealed ? (
+        {text && devMode ? (
           <motion.div
             style={{ paddingTop: '0.5rem' }}
             animate={{ opacity: exiting ? 0 : 1 }}
@@ -193,7 +174,7 @@ export default function LoadingLogo({ text, done, exitMode = 'none', onExitCompl
           </motion.div>
         ) : null}
       </div>
-      {showBackground && statusRevealed ? (
+      {showBackground && devMode ? (
         <div
           style={{
             position: 'fixed',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ import { FeesProvider } from './providers/fees'
 import { AnnouncementProvider } from './providers/announcements'
 import { ToastProvider } from './components/Toast'
 import ErrorBoundary from './components/ErrorBoundary'
+import { DevModeProvider } from './providers/devMode'
 
 // Initialize Sentry only in production and when DSN is provided
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN
@@ -67,36 +68,38 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 
 root.render(
   // <React.StrictMode>
-  <NavigationProvider>
-    <ConfigProvider>
-      <AspProvider>
-        <NotificationsProvider>
-          <FiatProvider>
-            <FlowProvider>
-              <WalletProvider>
-                <SwapsProvider>
-                  <LimitsProvider>
-                    <FeesProvider>
-                      <OptionsProvider>
-                        <NudgeProvider>
-                          <AnnouncementProvider>
-                            <ToastProvider>
-                              <ErrorBoundary>
-                                <App />
-                              </ErrorBoundary>
-                            </ToastProvider>
-                          </AnnouncementProvider>
-                        </NudgeProvider>
-                      </OptionsProvider>
-                    </FeesProvider>
-                  </LimitsProvider>
-                </SwapsProvider>
-              </WalletProvider>
-            </FlowProvider>
-          </FiatProvider>
-        </NotificationsProvider>
-      </AspProvider>
-    </ConfigProvider>
-  </NavigationProvider>,
+  <DevModeProvider>
+    <NavigationProvider>
+      <ConfigProvider>
+        <AspProvider>
+          <NotificationsProvider>
+            <FiatProvider>
+              <FlowProvider>
+                <WalletProvider>
+                  <SwapsProvider>
+                    <LimitsProvider>
+                      <FeesProvider>
+                        <OptionsProvider>
+                          <NudgeProvider>
+                            <AnnouncementProvider>
+                              <ToastProvider>
+                                <ErrorBoundary>
+                                  <App />
+                                </ErrorBoundary>
+                              </ToastProvider>
+                            </AnnouncementProvider>
+                          </NudgeProvider>
+                        </OptionsProvider>
+                      </FeesProvider>
+                    </LimitsProvider>
+                  </SwapsProvider>
+                </WalletProvider>
+              </FlowProvider>
+            </FiatProvider>
+          </NotificationsProvider>
+        </AspProvider>
+      </ConfigProvider>
+    </NavigationProvider>
+  </DevModeProvider>,
   // </React.StrictMode>,
 )

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,7 @@ export enum SettingsOptions {
   Reset = 'reset wallet',
   Server = 'server',
   Support = 'support',
+  Contracts = 'contracts',
   Vtxos = 'coin control',
   Theme = 'theme',
   Fiat = 'fiat currency',

--- a/src/providers/devMode.tsx
+++ b/src/providers/devMode.tsx
@@ -1,0 +1,42 @@
+import { ReactNode, createContext, useCallback, useEffect, useRef, useState } from 'react'
+
+const DEV_MODE_KEY = 'dev_mode'
+
+interface DevModeContextProps {
+  devMode: boolean
+  handleTap: () => void
+}
+
+export const DevModeContext = createContext<DevModeContextProps>({
+  devMode: false,
+  handleTap: () => {},
+})
+
+export function DevModeProvider({ children }: { children: ReactNode }) {
+  const [devMode, setDevMode] = useState(() => localStorage.getItem(DEV_MODE_KEY) === 'true')
+  const tapCountRef = useRef(0)
+  const tapTimerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  const handleTap = useCallback(() => {
+    tapCountRef.current += 1
+    clearTimeout(tapTimerRef.current)
+    if (tapCountRef.current >= 3) {
+      tapCountRef.current = 0
+      setDevMode((v) => {
+        const next = !v
+        localStorage.setItem(DEV_MODE_KEY, String(next))
+        return next
+      })
+    } else {
+      tapTimerRef.current = setTimeout(() => {
+        tapCountRef.current = 0
+      }, 600)
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => clearTimeout(tapTimerRef.current)
+  }, [])
+
+  return <DevModeContext.Provider value={{ devMode, handleTap }}>{children}</DevModeContext.Provider>
+}

--- a/src/providers/options.tsx
+++ b/src/providers/options.tsx
@@ -88,6 +88,11 @@ export const options: Option[] = [
   },
   {
     icon: <></>,
+    option: SettingsOptions.Contracts,
+    section: SettingsSections.Advanced,
+  },
+  {
+    icon: <></>,
     option: SettingsOptions.Theme,
     section: SettingsSections.Config,
   },

--- a/src/screens/Settings/Advanced.tsx
+++ b/src/screens/Settings/Advanced.tsx
@@ -1,11 +1,16 @@
+import { useContext } from 'react'
 import Header from './Header'
 import { options } from '../../providers/options'
 import Content from '../../components/Content'
-import { SettingsSections } from '../../lib/types'
+import { SettingsOptions, SettingsSections } from '../../lib/types'
 import Menu from '../../components/Menu'
+import { DevModeContext } from '../../providers/devMode'
 
 export default function Advanced() {
-  const rows = options.filter((o) => o.section === SettingsSections.Advanced)
+  const { devMode } = useContext(DevModeContext)
+  const rows = options
+    .filter((o) => o.section === SettingsSections.Advanced)
+    .filter((o) => o.option !== SettingsOptions.Contracts || devMode)
 
   return (
     <>

--- a/src/screens/Settings/Contracts.tsx
+++ b/src/screens/Settings/Contracts.tsx
@@ -1,0 +1,112 @@
+import { useContext, useEffect, useRef, useState } from 'react'
+import type { Contract } from '@arkade-os/sdk'
+import Header from './Header'
+import Content from '../../components/Content'
+import Padded from '../../components/Padded'
+import FlexCol from '../../components/FlexCol'
+import FlexRow from '../../components/FlexRow'
+import Shadow from '../../components/Shadow'
+import Text, { TextSecondary } from '../../components/Text'
+import LoadingLogo from '../../components/LoadingLogo'
+import CopyIcon from '../../icons/Copy'
+import CheckMarkIcon from '../../icons/CheckMark'
+import { WalletContext } from '../../providers/wallet'
+import { prettyLongText } from '../../lib/format'
+import { copyToClipboard } from '../../lib/clipboard'
+import { hapticSubtle } from '../../lib/haptics'
+import { useToast } from '../../components/Toast'
+import { consoleError } from '../../lib/logs'
+
+const cardStyle: React.CSSProperties = {
+  backgroundColor: 'var(--neutral-100)',
+  border: '1px solid var(--neutral-200)',
+  borderRadius: '0.25rem',
+  padding: '10px',
+  width: '100%',
+}
+
+function CopyRow({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+  const { toast } = useToast()
+
+  useEffect(() => () => clearTimeout(timerRef.current), [])
+
+  const handleCopy = async () => {
+    hapticSubtle()
+    await copyToClipboard(value)
+    toast('Copied to clipboard')
+    setCopied(true)
+    clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <FlexRow between onClick={handleCopy}>
+      <FlexCol gap='0'>
+        <TextSecondary>{label}</TextSecondary>
+        <Text small>{prettyLongText(value)}</Text>
+      </FlexCol>
+      <Shadow flex>{copied ? <CheckMarkIcon /> : <CopyIcon />}</Shadow>
+    </FlexRow>
+  )
+}
+
+function ContractCard({ contract }: { contract: Contract }) {
+  return (
+    <div style={cardStyle}>
+      <FlexCol gap='0.5rem'>
+        <FlexRow between>
+          <Text>{contract.type}</Text>
+          <Text tiny color={contract.state === 'active' ? 'green' : 'neutral-500'}>
+            {contract.state}
+          </Text>
+        </FlexRow>
+        <hr className='dashed' />
+        <CopyRow label='address' value={contract.address} />
+        <CopyRow label='script' value={contract.script} />
+      </FlexCol>
+    </div>
+  )
+}
+
+export default function Contracts() {
+  const { svcWallet } = useContext(WalletContext)
+  const [contracts, setContracts] = useState<Contract[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!svcWallet) return
+    const fetchContracts = async () => {
+      try {
+        const cm = await svcWallet.getContractManager()
+        const data = await cm.getContracts()
+        setContracts(data.slice().sort((a, b) => (a.state === b.state ? 0 : a.state === 'active' ? -1 : 1)))
+      } catch (err) {
+        consoleError(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchContracts()
+  }, [svcWallet])
+
+  if (!svcWallet || loading) return <LoadingLogo text='Loading...' />
+
+  return (
+    <>
+      <Header text='Contracts' back />
+      <Content noRefresh>
+        <Padded>
+          <FlexCol className='scroll-fade'>
+            <FlexCol gap='0.5rem'>
+              {contracts.map((c) => (
+                <ContractCard key={c.script} contract={c} />
+              ))}
+            </FlexCol>
+          </FlexCol>
+        </Padded>
+      </Content>
+    </>
+  )
+}

--- a/src/screens/Settings/Index.tsx
+++ b/src/screens/Settings/Index.tsx
@@ -21,6 +21,7 @@ import Password from './Password'
 import Delegates from './Delegates'
 import SettingsPageTransition from '../../components/SettingsPageTransition'
 import Haptics from './Haptics'
+import Contracts from './Contracts'
 
 function settingsContent(option: SettingsOptions): JSX.Element {
   switch (option) {
@@ -52,6 +53,8 @@ function settingsContent(option: SettingsOptions): JSX.Element {
       return <Support />
     case SettingsOptions.Vtxos:
       return <Vtxos />
+    case SettingsOptions.Contracts:
+      return <Contracts />
     case SettingsOptions.Theme:
       return <Theme />
     case SettingsOptions.Fiat:

--- a/src/test/providers/devMode.test.tsx
+++ b/src/test/providers/devMode.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useContext } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DevModeContext, DevModeProvider } from '../../providers/devMode'
+
+function Harness() {
+  const { devMode, handleTap } = useContext(DevModeContext)
+  return (
+    <div>
+      <span data-testid='status'>{devMode ? 'on' : 'off'}</span>
+      <button onClick={handleTap}>tap</button>
+    </div>
+  )
+}
+
+describe('DevModeProvider', () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => localStorage.clear())
+
+  it('starts with dev mode off', () => {
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    expect(screen.getByTestId('status').textContent).toBe('off')
+  })
+
+  it('reads initial state from localStorage', () => {
+    localStorage.setItem('dev_mode', 'true')
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    expect(screen.getByTestId('status').textContent).toBe('on')
+  })
+
+  it('does not toggle after fewer than 3 taps', async () => {
+    const user = userEvent.setup()
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    await user.click(screen.getByRole('button'))
+    await user.click(screen.getByRole('button'))
+    expect(screen.getByTestId('status').textContent).toBe('off')
+  })
+
+  it('toggles on after exactly 3 taps and persists to localStorage', async () => {
+    const user = userEvent.setup()
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    const btn = screen.getByRole('button')
+    await user.click(btn)
+    await user.click(btn)
+    await user.click(btn)
+    expect(screen.getByTestId('status').textContent).toBe('on')
+    expect(localStorage.getItem('dev_mode')).toBe('true')
+  })
+
+  it('toggles back off on the next triple-tap', async () => {
+    const user = userEvent.setup()
+    localStorage.setItem('dev_mode', 'true')
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    const btn = screen.getByRole('button')
+    await user.click(btn)
+    await user.click(btn)
+    await user.click(btn)
+    expect(screen.getByTestId('status').textContent).toBe('off')
+    expect(localStorage.getItem('dev_mode')).toBe('false')
+  })
+
+  it('resets tap counter after 600 ms so a stale sequence does not toggle', async () => {
+    const user = userEvent.setup({ delay: null })
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    const btn = screen.getByRole('button')
+    await user.click(btn)
+    await user.click(btn)
+    // Advance past the 600 ms reset window
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 700))
+    })
+    // This is now tap 1 of a new sequence — not a 3rd tap of the old one
+    await user.click(btn)
+    expect(screen.getByTestId('status').textContent).toBe('off')
+  })
+})

--- a/src/test/screens/settings/advanced.test.tsx
+++ b/src/test/screens/settings/advanced.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Advanced from '../../../screens/Settings/Advanced'
+import { DevModeContext } from '../../../providers/devMode'
+import { OptionsContext } from '../../../providers/options'
+import { mockOptionsContextValue } from '../mocks'
+
+function renderAdvanced(devMode: boolean) {
+  return render(
+    <DevModeContext.Provider value={{ devMode, handleTap: () => {} }}>
+      <OptionsContext.Provider value={mockOptionsContextValue as any}>
+        <Advanced />
+      </OptionsContext.Provider>
+    </DevModeContext.Provider>,
+  )
+}
+
+describe('Advanced screen', () => {
+  it('does not show Contracts when dev mode is off', () => {
+    renderAdvanced(false)
+    expect(screen.queryByText('contracts')).not.toBeInTheDocument()
+  })
+
+  it('shows Contracts when dev mode is on', () => {
+    renderAdvanced(true)
+    expect(screen.getByText('contracts')).toBeInTheDocument()
+  })
+})

--- a/src/test/screens/settings/contracts.test.tsx
+++ b/src/test/screens/settings/contracts.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Contracts from '../../../screens/Settings/Contracts'
+import { WalletContext } from '../../../providers/wallet'
+import { mockWalletContextValue, mockSvcWallet } from '../mocks'
+import type { Contract } from '@arkade-os/sdk'
+
+const mockContracts: Contract[] = [
+  {
+    type: 'vhtlc',
+    state: 'inactive',
+    address: 'ark1qinactive000000000000000000000000',
+    script: 'abcdef1234567890inactive',
+  },
+  {
+    type: 'default',
+    state: 'active',
+    address: 'ark1qactive0000000000000000000000000',
+    script: 'abcdef1234567890active00',
+  },
+]
+
+function renderContracts(svcWallet: typeof mockSvcWallet | undefined) {
+  return render(
+    <WalletContext.Provider value={{ ...mockWalletContextValue, svcWallet } as any}>
+      <Contracts />
+    </WalletContext.Provider>,
+  )
+}
+
+describe('Contracts screen', () => {
+  it('renders a loading state when svcWallet is undefined', () => {
+    renderContracts(undefined)
+    // Loading logo renders — no crash, no contract content
+    expect(screen.queryByText('Contracts')).not.toBeInTheDocument()
+  })
+
+  it('renders contract cards with type and state', async () => {
+    const svcWalletWithContracts = {
+      ...mockSvcWallet,
+      getContractManager: () =>
+        Promise.resolve({
+          getContracts: () => Promise.resolve(mockContracts),
+        }),
+    }
+    renderContracts(svcWalletWithContracts as any)
+
+    await screen.findByText('Contracts')
+    expect(screen.getByText('default')).toBeInTheDocument()
+    expect(screen.getByText('vhtlc')).toBeInTheDocument()
+    expect(screen.getByText('active')).toBeInTheDocument()
+    expect(screen.getByText('inactive')).toBeInTheDocument()
+  })
+
+  it('sorts active contracts before inactive ones', async () => {
+    const svcWalletWithContracts = {
+      ...mockSvcWallet,
+      getContractManager: () =>
+        Promise.resolve({
+          getContracts: () => Promise.resolve(mockContracts),
+        }),
+    }
+    renderContracts(svcWalletWithContracts as any)
+
+    await screen.findByText('Contracts')
+    const cards = screen.getAllByText(/^(active|inactive)$/)
+    expect(cards[0].textContent).toBe('active')
+    expect(cards[1].textContent).toBe('inactive')
+  })
+})


### PR DESCRIPTION
Triple-tapping the loading logo toggles a global dev mode persisted in localStorage (DevModeProvider). The tap logic is lifted out of LoadingLogo into the new context so any loading logo in the app shares the same state.

A new "Contracts" entry appears in the Advanced settings list only when dev mode is active. It renders all contracts from ContractManager sorted active-first, each card showing type, state, address, and script — the latter two shortened and copyable. Pull-to-refresh is disabled on this screen since it is a static view on ContractManager data.

<img width="435" height="912" alt="image" src="https://github.com/user-attachments/assets/9e19f7af-40ea-484a-b102-e5b567b51885" />
