### PR TITLE
fix prettyAssetNumber

### DIFF
--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -42,10 +42,11 @@ export const prettyAssetAmountHide = (value: bigint, suffix: string): string => 
   return suffix ? `${dots} ${suffix}` : dots
 }
 
-export const prettyAssetNumber = (num?: string | number, maximumFractionDigits = 8): string => {
+export const prettyAssetNumber = (num?: string | number, maximumFractionDigits = MAX_DECIMALS): string => {
   if (num === undefined || num === null) return '0'
   if (typeof num === 'number') num = num.toString()
-  const [integer, fraction = ''] = num.split('.')
+  let [integer, fraction = ''] = num.split('.')
+  integer = integer.replace(/[^0-9-]+/g, '') // remove non-digit and non-negative sign characters
   const negative = integer === '-0'
   const paddedFraction = fraction
     .padEnd(MAX_DECIMALS, '0') // fill with zeros to ensure consistent formatting

--- a/src/test/lib/asset.test.ts
+++ b/src/test/lib/asset.test.ts
@@ -179,11 +179,23 @@ describe('asset utilities', () => {
     it('formats bigint with grouping by default', () => {
       expect(prettyAssetNumber('0')).toBe('0')
       expect(prettyAssetNumber('1000')).toBe('1,000')
+      expect(prettyAssetNumber('-1000')).toBe('-1,000')
       expect(prettyAssetNumber('123456789')).toBe('123,456,789')
+      expect(prettyAssetNumber('-123456789')).toBe('-123,456,789')
     })
 
     it('formats negative bigint', () => {
       expect(prettyAssetNumber('-1000')).toBe('-1,000')
+    })
+
+    it('formats very small number', () => {
+      expect(prettyAssetNumber('0.00000001')).toBe('0.00000001')
+      expect(prettyAssetNumber('-0.00000001')).toBe('-0.00000001')
+    })
+
+    it('formats number with grouping', () => {
+      expect(prettyAssetNumber('123,456.789')).toBe('123,456.789')
+      expect(prettyAssetNumber('-123,456.789')).toBe('-123,456.789')
     })
 
     it('formats very large bigints without precision loss', () => {


### PR DESCRIPTION
Related with [Sentry issue](https://ark-labs-o0.sentry.io/issues/121252070)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced asset number formatting to properly handle negative values, small decimals, and pre-formatted strings.

* **Tests**
  * Expanded test coverage for asset number formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/wallet/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->