### PR TITLE
feat(send): align send flow with redesign prototype

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,7 @@ export default function App() {
   const devAutoInitHomeRedirected = useRef(false)
   const hasDevAutoInit =
     import.meta.env.DEV &&
-    Boolean(import.meta.env.VITE_DEV_NSEC) &&
+    Boolean(import.meta.env.VITE_DEV_MNEMONIC || import.meta.env.VITE_DEV_NSEC) &&
     import.meta.env.VITE_DEV_AUTO_INIT !== 'false' &&
     !devAutoInitFailed
 
@@ -102,7 +102,7 @@ export default function App() {
     // avoid redirect if the user is still setting up the wallet
     if (initInfo.password || initInfo.privateKey) return
     if (!walletLoaded) return navigate(Pages.Loading)
-    // dev auto-init: stay on loading screen while VITE_DEV_NSEC initializes the wallet
+    // dev auto-init: stay on loading screen while the configured dev seed initializes the wallet
     if (hasDevAutoInit && !initialized) return
     if (!wallet.pubkey) return navigate(Pages.Init)
     if (authState === 'locked') return navigate(Pages.Unlock)
@@ -189,7 +189,7 @@ export default function App() {
 
   // Boot animation: persists on Loading, then flies to the LogoIcon position when
   // Wallet is reached. For any other destination (Unlock, Init, etc.), exits with fly-up.
-  // Skip in dev with VITE_DEV_NSEC — the fast auto-init races with the animation.
+  // Skip in dev auto-init — the fast seed restore races with the animation.
   useEffect(() => {
     if (hasDevAutoInit) return
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -80,10 +80,11 @@ export default function Button({
 
   const handleClick = useCallback(
     (event: any) => {
+      if (disabled || loading) return
       hapticTap()
       onClick(event)
     },
-    [onClick],
+    [disabled, loading, onClick],
   )
 
   return (
@@ -92,6 +93,8 @@ export default function Button({
       type='button'
       className={cn(buttonVariants({ variant: resolvedVariant }), pressed && 'pressed', className)}
       disabled={disabled}
+      aria-busy={loading || undefined}
+      aria-disabled={loading || undefined}
       onClick={handleClick}
       onMouseDown={handlePressStart}
       onMouseUp={handlePressEnd}

--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -5,9 +5,9 @@ import { ConfigContext } from '../providers/config'
 import { prettyNumber } from '../lib/format'
 import { FIAT_SYMBOLS } from '../lib/fiat'
 import { LimitsContext } from '../providers/limits'
-import Focusable from './Focusable'
 import { AssetOption } from '../lib/types'
 import { TextSecondary } from './Text'
+import { hapticLight } from '../lib/haptics'
 
 interface InputAmountProps {
   asset?: AssetOption
@@ -85,7 +85,6 @@ export default function InputAmount({
       : fiatSymbol
         ? `${fiatSymbol}${otherValue}`
         : `${otherValue} ${config.fiat}`
-  const fontStyle = { color: 'var(--neutral-500)', fontSize: '13px' }
   const bottomLeft =
     minimumSats && satsValue !== undefined && satsValue < minimumSats
       ? `Min: ${prettyNumber(minimumSats)} ${minimumSats === 1 ? 'SAT' : 'SATS'}`
@@ -109,23 +108,24 @@ export default function InputAmount({
           disabled={disabled}
           readOnly={readOnly}
           onChange={handleAmountChange}
-          value={value ? Number(value) : ''}
+          value={value ?? ''}
           onKeyUp={(ev) => ev.key === 'Enter' && onEnter && onEnter()}
         />
         <TextSecondary>{rightLabel}</TextSecondary>
       </label>
       {onMax && !disabled && !readOnly ? (
-        <Focusable onEnter={onMax} fit>
-          <p
-            role='button'
-            onClick={onMax}
-            aria-label='Set maximum amount'
-            data-testid='input-amount-max'
-            style={{ ...fontStyle, color: 'var(--purpletext)', cursor: 'pointer' }}
-          >
-            Max
-          </p>
-        </Focusable>
+        <button
+          type='button'
+          className='pill-base'
+          onClick={() => {
+            hapticLight()
+            onMax()
+          }}
+          aria-label='Set maximum amount'
+          data-testid='input-amount-max'
+        >
+          Max
+        </button>
       ) : null}
     </InputContainer>
   )

--- a/src/components/InputContainer.tsx
+++ b/src/components/InputContainer.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react'
 import ErrorMessage from './Error'
 import FlexRow from './FlexRow'
 import FlexCol from './FlexCol'
-import Shadow from './Shadow'
 import Text from './Text'
 
 interface InputContainerProps {
@@ -43,12 +42,12 @@ export default function InputContainer({
   )
 
   return (
-    <FlexCol>
+    <FlexCol className='input-container'>
       <FlexCol gap='0.5rem'>
         {label || right ? <TopLabel /> : null}
-        <Shadow>
+        <div className='input-shell'>
           <FlexRow between>{children}</FlexRow>
-        </Shadow>
+        </div>
         {bottomLeft || bottomRight ? <BottomLabel /> : null}
       </FlexCol>
       <ErrorMessage error={Boolean(error)} text={error ?? ''} />

--- a/src/index.css
+++ b/src/index.css
@@ -1121,6 +1121,8 @@ button.reminder-button {
   background-color: transparent;
   caret-color: var(--black);
   color: var(--black);
+  outline: none;
+  min-width: 0;
 }
 
 input:focus::placeholder {
@@ -1133,26 +1135,299 @@ input:focus::placeholder {
 }
 
 .label {
-  position: relative;
   align-items: center;
   display: flex;
   gap: 0.25rem;
   flex: 1;
-  &.has-buttons {
-    & > div {
-      right: 0;
-      top: 50%;
-      gap: 4px;
-      display: flex;
-      position: absolute;
-      transform: translateY(-50%);
-    }
-    & > input {
-      width: 100%;
-      padding-right: 36px;
-      box-sizing: border-box;
-    }
+}
+
+.input-container {
+  gap: 0.375rem !important;
+}
+
+.input-shell {
+  width: 100%;
+  min-height: 3.5rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--fg) 3.5%, var(--bg));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent),
+    inset 0 1px 2px color-mix(in srgb, var(--fg) 4%, transparent);
+  padding: 0.75rem;
+  transition:
+    background-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.input-shell:focus-within {
+  background: color-mix(in srgb, var(--purple-100) 18%, var(--bg));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--purple-700) 24%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--purple-700) 8%, transparent);
+}
+
+.input-shell .input {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.input-shell .label {
+  gap: 0.625rem;
+}
+
+html.palette-dark .input-shell {
+  background: var(--neutral-50) !important;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--fg) 6%, transparent),
+    inset 0 1px 2px color-mix(in srgb, var(--bg) 28%, transparent);
+}
+
+html.palette-dark .input-shell:focus-within {
+  background: color-mix(in oklab, var(--purple-700) 18%, var(--neutral-50)) !important;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--purple-200) 22%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--purple-500) 14%, transparent);
+}
+
+.send-form {
+  width: 100%;
+  height: 100%;
+}
+
+.send-form .content-shell {
+  padding-top: 0.75rem;
+}
+
+.send-form-stack {
+  padding-bottom: 1.5rem;
+}
+
+.send-form .input-container > div:first-child > div:first-child p,
+.send-asset-field > p {
+  color: color-mix(in srgb, var(--fg) 52%, transparent) !important;
+  font-size: 0.8125rem !important;
+  line-height: 1.125rem !important;
+}
+
+.send-form .input {
+  color: var(--fg);
+  font-weight: 400;
+}
+
+.send-form .input::placeholder {
+  color: color-mix(in srgb, var(--fg) 36%, transparent);
+}
+
+.send-form .input-shell p {
+  color: color-mix(in srgb, var(--fg) 54%, transparent) !important;
+}
+
+.send-form .input-shell [role='button'] {
+  color: color-mix(in srgb, var(--purple-700) 80%, var(--fg)) !important;
+  font-weight: 500;
+}
+
+.send-asset-trigger,
+.send-asset-option {
+  width: 100%;
+  border: 0;
+  appearance: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.send-asset-trigger {
+  min-height: 4.25rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--fg) 3.5%, var(--bg));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent),
+    inset 0 1px 2px color-mix(in srgb, var(--fg) 4%, transparent);
+  color: var(--fg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  transition:
+    background-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.send-asset-trigger:active {
+  transform: scale(0.99);
+}
+
+.send-asset-trigger[aria-expanded='true'] {
+  background: color-mix(in srgb, var(--purple-100) 18%, var(--bg));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--purple-700) 24%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--purple-700) 8%, transparent);
+}
+
+.send-asset-trigger__main,
+.send-asset-option__main {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.send-asset-trigger__copy,
+.send-asset-option__main > span {
+  min-width: 0;
+  display: grid;
+  gap: 0.125rem;
+}
+
+.send-asset-trigger__name,
+.send-asset-option__name {
+  color: var(--fg);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+}
+
+.send-asset-trigger__balance,
+.send-asset-option__meta,
+.send-asset-option__amount {
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: 0.8125rem;
+  line-height: 1.125rem;
+}
+
+.send-asset-trigger__chevron {
+  color: color-mix(in srgb, var(--fg) 42%, transparent);
+  font-size: 0.6875rem;
+  line-height: 1;
+}
+
+.send-asset-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.send-asset-icon svg,
+.send-asset-icon img {
+  width: 100%;
+  height: 100%;
+}
+
+.send-asset-icon--fallback {
+  background: color-mix(in srgb, var(--purple-100) 58%, var(--bg));
+  color: color-mix(in srgb, var(--purple-700) 86%, var(--fg));
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.send-asset-menu {
+  width: var(--anchor-width);
+  max-width: min(var(--available-width), calc(100vw - 2rem));
+  min-width: min(var(--anchor-width), calc(100vw - 2rem));
+  max-height: min(18rem, 40vh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-radius: 0.875rem;
+  background: var(--bg);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 6%, transparent),
+    0 10px 20px -16px color-mix(in srgb, var(--fg) 28%, transparent);
+  padding: 0.25rem;
+  transform-origin: var(--transform-origin);
+  will-change: opacity, transform;
+}
+
+.send-asset-menu[data-open] {
+  animation: send-asset-menu-in 180ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.send-asset-menu[data-closed] {
+  animation: send-asset-menu-out 120ms cubic-bezier(0.4, 0, 1, 1);
+}
+
+.send-asset-option {
+  min-height: 3.75rem;
+  border-radius: 0.625rem;
+  background: transparent;
+  color: var(--fg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.625rem;
+  transition:
+    background-color 160ms ease,
+    transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.send-asset-option:active {
+  transform: scale(0.99);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .send-asset-option:hover {
+    background: color-mix(in srgb, var(--fg) 4%, transparent);
   }
+}
+
+@keyframes send-asset-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-0.375rem) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes send-asset-menu-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-0.25rem) scale(0.985);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .send-asset-menu[data-open],
+  .send-asset-menu[data-closed] {
+    animation-duration: 0.01ms;
+  }
+}
+
+html.palette-dark .send-asset-trigger {
+  background: var(--neutral-50) !important;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--fg) 6%, transparent),
+    inset 0 1px 2px color-mix(in srgb, var(--bg) 28%, transparent);
+}
+
+html.palette-dark .send-asset-trigger[aria-expanded='true'] {
+  background: color-mix(in oklab, var(--purple-700) 18%, var(--neutral-50)) !important;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--purple-200) 22%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--purple-500) 14%, transparent);
+}
+
+html.palette-dark .send-asset-menu {
+  background: var(--neutral-50) !important;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 6%, transparent),
+    0 10px 20px -16px color-mix(in srgb, var(--bg) 72%, transparent);
 }
 
 .page {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,9 +24,52 @@ import ErrorBoundary from './components/ErrorBoundary'
 import { DevModeProvider } from './providers/devMode'
 
 const DEV_SERVICE_WORKER_RESET_KEY = 'arkade-dev-service-worker-reset-attempted'
+const DEV_WALLET_STORAGE_RESET_KEY_PREFIX = 'arkade-dev-wallet-storage-reset'
+
+function getDevWalletStorageResetKey() {
+  const credential = import.meta.env.VITE_DEV_MNEMONIC || import.meta.env.VITE_DEV_NSEC || 'manual'
+  let hash = 5381
+
+  for (let i = 0; i < credential.length; i++) {
+    hash = (hash * 33) ^ credential.charCodeAt(i)
+  }
+
+  return `${DEV_WALLET_STORAGE_RESET_KEY_PREFIX}:${hash >>> 0}`
+}
+
+function reloadAfterUnregisteringServiceWorkers() {
+  navigator.serviceWorker
+    ?.getRegistrations()
+    .then((registrations) => Promise.all(registrations.map((registration) => registration.unregister())))
+    .finally(() => window.location.reload())
+}
+
+function resetDevWalletStorage() {
+  if (!import.meta.env.DEV || import.meta.env.VITE_DEV_RESET_WALLET_ON_BOOT !== 'true') return false
+
+  try {
+    const storageResetKey = getDevWalletStorageResetKey()
+    if (localStorage.getItem(storageResetKey)) return false
+    localStorage.setItem(storageResetKey, 'true')
+
+    localStorage.removeItem('wallet')
+    localStorage.removeItem('encrypted_private_key')
+    localStorage.removeItem('encrypted_mnemonic')
+  } catch {
+    // Keep booting even if dev browser storage is unavailable.
+  }
+
+  if ('serviceWorker' in navigator) {
+    reloadAfterUnregisteringServiceWorkers()
+    return true
+  }
+
+  window.location.reload()
+  return true
+}
 
 function resetControlledDevServiceWorker() {
-  if (!import.meta.env.DEV || !import.meta.env.VITE_DEV_NSEC) return false
+  if (!import.meta.env.DEV || !(import.meta.env.VITE_DEV_MNEMONIC || import.meta.env.VITE_DEV_NSEC)) return false
   if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) return false
 
   try {
@@ -36,10 +79,7 @@ function resetControlledDevServiceWorker() {
     // Prefer one reload over leaving a stale dev service worker controlling boot.
   }
 
-  navigator.serviceWorker
-    .getRegistrations()
-    .then((registrations) => Promise.all(registrations.map((registration) => registration.unregister())))
-    .finally(() => window.location.reload())
+  reloadAfterUnregisteringServiceWorkers()
 
   return true
 }
@@ -71,8 +111,8 @@ if (shouldInitializeSentry(sentryDsn)) {
 // Pre-register service worker so activation happens in parallel with page
 // bootstrap (ASP fetch, auth check, etc.). On cold starts this saves the
 // full activation wait from the critical path; on warm starts it's a no-op.
-const devServiceWorkerResetting = resetControlledDevServiceWorker()
-if ('serviceWorker' in navigator && !devServiceWorkerResetting) {
+const devBootResetting = resetDevWalletStorage() || resetControlledDevServiceWorker()
+if ('serviceWorker' in navigator && !devBootResetting) {
   navigator.serviceWorker.register('/wallet-service-worker.mjs').catch(() => {})
 
   // check if there's a service worker controlling the page

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -202,13 +202,16 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
 
   // wallet is read synchronously in useState initializer above
 
+  const devMnemonic = import.meta.env.VITE_DEV_MNEMONIC as string | undefined
   const devNsec = import.meta.env.VITE_DEV_NSEC as string | undefined
-  const isDevAutoInit = import.meta.env.DEV && Boolean(devNsec) && import.meta.env.VITE_DEV_AUTO_INIT !== 'false'
+  const devAutoInitCredential = devMnemonic || devNsec
+  const isDevAutoInit =
+    import.meta.env.DEV && Boolean(devAutoInitCredential) && import.meta.env.VITE_DEV_AUTO_INIT !== 'false'
   const [devAutoInitFailed, setDevAutoInitFailed] = useState(false)
 
-  // dev-only: auto-initialize wallet from VITE_DEV_NSEC, bypassing onboarding and unlock
+  // dev-only: auto-initialize wallet from VITE_DEV_MNEMONIC or VITE_DEV_NSEC, bypassing onboarding and unlock
   useEffect(() => {
-    if (!isDevAutoInit || !devNsec || devAutoInitFailed) return
+    if (!isDevAutoInit || !devAutoInitCredential || devAutoInitFailed) return
     if (initialized) return
     if (!aspInfo.url) return
 
@@ -234,8 +237,12 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
             .then((reg) => reg?.unregister())
             .finally(() => window.location.reload())
         }, DEV_AUTO_INIT_TIMEOUT_MS)
-        const privateKey = nsecToPrivateKey(devNsec)
-        await initWallet({ privateKey })
+        if (devMnemonic) {
+          await initWallet({ mnemonic: devMnemonic })
+        } else if (devNsec) {
+          const privateKey = nsecToPrivateKey(devNsec)
+          await initWallet({ privateKey })
+        }
         if (cancelled) return
         clearTimeout(watchdog)
         try {
@@ -258,7 +265,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       clearTimeout(watchdog)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [aspInfo.url, initialized, devAutoInitFailed])
+  }, [aspInfo.url, initialized, devAutoInitFailed, isDevAutoInit, devAutoInitCredential, devMnemonic, devNsec])
 
   useEffect(() => {
     // skip auth check when dev auto-init will handle it

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -49,6 +49,14 @@ import SheetModal from '../../../components/SheetModal'
 import { AnimatePresence, motion } from 'framer-motion'
 import { overlaySlideUp, overlayStyle } from '../../../lib/animations'
 import { useReducedMotion } from '../../../hooks/useReducedMotion'
+import TokenLogo, { TokenLogoTicker } from '../../../components/TokenLogo'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../../../components/ui/dropdown-menu'
+import { hapticLight } from '../../../lib/haptics'
 
 // TODO: Replace when SDK is accurate
 type BrantaPayment = Partial<
@@ -60,6 +68,34 @@ type BrantaPayment = Partial<
 const brantaClient = new V2BrantaClient({
   baseUrl: BrantaServerBaseUrl.Production,
 })
+
+function AssetIcon({ asset }: { asset: AssetOption | null }) {
+  const ticker = asset?.ticker?.toUpperCase()
+  const tokenTicker =
+    ticker === 'USD' || ticker === 'USDT' || ticker === 'USDC' || ticker === 'CHF' || ticker === 'BRL'
+      ? (ticker as TokenLogoTicker)
+      : asset
+        ? null
+        : 'BTC'
+
+  if (tokenTicker) {
+    return (
+      <span className='send-asset-icon' aria-hidden='true'>
+        <TokenLogo ticker={tokenTicker} />
+      </span>
+    )
+  }
+
+  if (asset?.icon) {
+    return <img className='send-asset-icon' src={asset.icon} alt='' />
+  }
+
+  return (
+    <span className='send-asset-icon send-asset-icon--fallback' aria-hidden='true'>
+      {asset?.ticker?.[0] ?? 'A'}
+    </span>
+  )
+}
 
 export default function SendForm() {
   const { aspInfo } = useContext(AspContext)
@@ -696,26 +732,10 @@ export default function SendForm() {
       satoshis < 1 ||
       processing
 
-  const selectedAssetLabel = selectedAsset ? `${selectedAsset.name} (${selectedAsset.ticker})` : 'Bitcoin (BTC)'
-
-  const btcIcon = (
-    <div
-      style={{
-        width: 24,
-        height: 24,
-        borderRadius: '50%',
-        background: '#f7931a',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: 'white',
-        fontSize: '14px',
-        fontWeight: 'bold',
-      }}
-    >
-      ₿
-    </div>
-  )
+  const selectedAssetLabel = selectedAsset ? `${selectedAsset.name} (${selectedAsset.ticker})` : 'Bitcoin'
+  const selectedAssetBalance = selectedAsset
+    ? `${prettyAssetAmount(selectedAsset.balance, selectedAsset.decimals)} ${selectedAsset.ticker} available`
+    : `${useFiat ? prettyFiatAmount(toFiat(liquidBalance), config.fiat) : prettyAmount(liquidBalance)} available`
 
   const overlayOpen = scan || (keys && !amountIsReadOnly)
   const sendOverlayStyle = { ...overlayStyle, position: 'fixed' as const, zIndex: 20 }
@@ -788,11 +808,15 @@ export default function SendForm() {
   return (
     <>
       {/* @ts-expect-error inert is valid HTML but React types lag behind */}
-      <div inert={overlayOpen || undefined} style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div
+        inert={overlayOpen || undefined}
+        className='send-form'
+        style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+      >
         <Header text='Send' back />
         <Content>
           <Padded>
-            <FlexCol gap='2rem'>
+            <FlexCol gap='1.25rem' className='send-form-stack'>
               <ErrorMessage error={Boolean(error)} text={error} />
               <InputAddress
                 name='send-address'
@@ -833,106 +857,78 @@ export default function SendForm() {
                 </Shadow>
               ) : null}
               {assetOptions.length > 0 ? (
-                <FlexCol gap='0.25rem'>
+                <FlexCol gap='0.5rem' className='send-asset-field'>
                   <Text smaller color='neutral-500'>
                     Asset
                   </Text>
-                  <Shadow border onClick={() => setShowAssetSelector(!showAssetSelector)} testId='asset-selector'>
-                    <FlexRow between padding='0.5rem'>
-                      <FlexRow>
-                        {selectedAsset ? (
-                          selectedAsset.icon ? (
-                            <img
-                              src={selectedAsset.icon}
-                              alt=''
-                              width={24}
-                              height={24}
-                              style={{ borderRadius: '50%' }}
-                            />
-                          ) : (
-                            <div
-                              style={{
-                                width: 24,
-                                height: 24,
-                                borderRadius: '50%',
-                                background: 'var(--neutral-200)',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                              }}
-                            >
-                              <Text smaller>{selectedAsset.ticker?.[0] ?? 'A'}</Text>
-                            </div>
-                          )
-                        ) : (
-                          btcIcon
-                        )}
-                        <Text>{selectedAssetLabel}</Text>
-                      </FlexRow>
-                      <Text color='neutral-500' smaller>
+                  <DropdownMenu
+                    open={showAssetSelector}
+                    onOpenChange={(open) => {
+                      if (open) hapticLight()
+                      setShowAssetSelector(open)
+                    }}
+                    modal={false}
+                  >
+                    <DropdownMenuTrigger
+                      aria-expanded={showAssetSelector}
+                      className='send-asset-trigger'
+                      data-testid='asset-selector'
+                    >
+                      <span className='send-asset-trigger__main'>
+                        <AssetIcon asset={selectedAsset} />
+                        <span className='send-asset-trigger__copy'>
+                          <span className='send-asset-trigger__name'>{selectedAssetLabel}</span>
+                          <span className='send-asset-trigger__balance'>{selectedAssetBalance}</span>
+                        </span>
+                      </span>
+                      <span className='send-asset-trigger__chevron' aria-hidden='true'>
                         {showAssetSelector ? '▲' : '▼'}
-                      </Text>
-                    </FlexRow>
-                  </Shadow>
-                  {showAssetSelector ? (
-                    <div style={{ maxHeight: '40vh', overflowY: 'auto', width: '100%' }}>
+                      </span>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className='send-asset-menu' align='start' side='bottom' sideOffset={8}>
                       <FlexCol gap='0.25rem'>
                         {selectedAsset ? (
-                          <Shadow onClick={() => handleSelectAsset(null)}>
-                            <FlexRow between padding='0.5rem'>
-                              <FlexRow>
-                                {btcIcon}
-                                <Text>Bitcoin (BTC)</Text>
-                              </FlexRow>
-                            </FlexRow>
-                          </Shadow>
+                          <DropdownMenuItem className='send-asset-option' onClick={() => handleSelectAsset(null)}>
+                            <span className='send-asset-option__main'>
+                              <AssetIcon asset={null} />
+                              <span>
+                                <span className='send-asset-option__name'>Bitcoin</span>
+                                <span className='send-asset-option__meta'>
+                                  {useFiat
+                                    ? prettyFiatAmount(toFiat(liquidBalance), config.fiat)
+                                    : prettyAmount(liquidBalance)}{' '}
+                                  available
+                                </span>
+                              </span>
+                            </span>
+                          </DropdownMenuItem>
                         ) : null}
                         {assetOptions
                           .filter((asset) => asset.assetId !== selectedAsset?.assetId)
                           .map((asset) => (
-                            <Shadow
+                            <DropdownMenuItem
                               key={asset.assetId}
+                              className='send-asset-option'
                               onClick={() => handleSelectAsset(asset)}
-                              testId={`asset-${asset.ticker.toLowerCase()}-option`}
+                              data-testid={`asset-${asset.ticker.toLowerCase()}-option`}
                             >
-                              <FlexRow between padding='0.5rem'>
-                                <FlexRow>
-                                  {asset.icon ? (
-                                    <img
-                                      src={asset.icon}
-                                      alt=''
-                                      width={24}
-                                      height={24}
-                                      style={{ borderRadius: '50%' }}
-                                    />
-                                  ) : (
-                                    <div
-                                      style={{
-                                        width: 24,
-                                        height: 24,
-                                        borderRadius: '50%',
-                                        background: 'var(--neutral-200)',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'center',
-                                      }}
-                                    >
-                                      <Text smaller>{asset.ticker?.[0] ?? 'A'}</Text>
-                                    </div>
-                                  )}
-                                  <Text>
+                              <span className='send-asset-option__main'>
+                                <AssetIcon asset={asset} />
+                                <span>
+                                  <span className='send-asset-option__name'>
                                     {asset.name} ({asset.ticker})
-                                  </Text>
-                                </FlexRow>
-                                <Text color='neutral-500' smaller>
-                                  {prettyAssetAmount(asset.balance, asset.decimals)} {asset.ticker}
-                                </Text>
-                              </FlexRow>
-                            </Shadow>
+                                  </span>
+                                  <span className='send-asset-option__meta'>Tap to send this asset</span>
+                                </span>
+                              </span>
+                              <span className='send-asset-option__amount'>
+                                {prettyAssetAmount(asset.balance, asset.decimals)} {asset.ticker}
+                              </span>
+                            </DropdownMenuItem>
                           ))}
                       </FlexCol>
-                    </div>
-                  ) : null}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </FlexCol>
               ) : null}
               <FlexCol gap='0.5rem'>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,7 +5,9 @@ interface ImportMetaEnv {
   readonly BASE_URL: string
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_ARK_SERVER?: string
+  readonly VITE_DEV_MNEMONIC?: string
   readonly VITE_DEV_NSEC?: string
+  readonly VITE_DEV_RESET_WALLET_ON_BOOT?: string
   readonly VITE_BOLTZ_URL?: string
   readonly VITE_DELEGATOR_URL?: string
   // Add other env variables as needed


### PR DESCRIPTION
## Summary
- Aligns the send form fields with the draft redesign prototype by moving shared form fields from the gray `Shadow` wrapper to the draft `input-shell` surface.
- Ports the draft-style send asset selector: token icons, selected asset label/balance, dropdown menu surface, option rows, and menu motion.
- Updates amount and button interactions for the send flow, including a pill-style Max control with haptic feedback and safer disabled/loading button handling.
- Adds dev mnemonic auto-init support and a dev-only wallet storage reset path so local mnemonic seeds do not fall back to stale nsec wallet state.

## Affected files and components
- `src/screens/Wallet/Send/Form.tsx` - send form layout, asset selector, selector menu, haptics.
- `src/components/InputContainer.tsx` - shared input shell structure.
- `src/components/InputAmount.tsx` - Max pill control and controlled amount value preservation.
- `src/components/Button.tsx` - disabled/loading click and haptic guard.
- `src/index.css` - send form field, asset selector, dropdown, and dark-mode styling.
- `src/App.tsx`, `src/index.tsx`, `src/providers/wallet.tsx`, `src/vite-env.d.ts` - dev mnemonic auto-init support.

## Testing
- `bun run lint`
- `bun run test:unit src/test/screens/wallet/send.test.tsx`
- `bun run build`
- Local visual verification on `wt-send-flow-changes-20260521.arkade.localhost` for send form field shells, neutral pill labels, and bottom CTA.

## Notes
- This PR is stacked on #627 and intentionally avoids copying the full prototype send implementation where it would replace newer PR-627 send logic.
- The local seed itself is not committed; only mnemonic-based dev auto-init support is included.
