### PR TITLE
feat(wallet): add bitcoin detail page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "framer-motion": "^12.34.3",
         "input-otp": "^1.4.2",
         "light-bolt11-decoder": "^3.2.0",
+        "liveline": "^0.0.7",
         "lucide-react": "^0.575.0",
         "nostr-tools": "^2.12.0",
         "qr": "^0.5.2",
@@ -1203,6 +1204,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "liveline": ["liveline@0.0.7", "", { "peerDependencies": { "react": ">=18" } }, "sha512-S1Weo1kmefiOCNaW/WFXErqJXlV8A/ldIkIthaOeT57I2ZhqhKLKQDJ1wfabtMSK9vJeU8PeMNHd8Sr8TLByWQ=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "framer-motion": "^12.34.3",
     "input-otp": "^1.4.2",
     "light-bolt11-decoder": "^3.2.0",
+    "liveline": "^0.0.7",
     "lucide-react": "^0.575.0",
     "nostr-tools": "^2.12.0",
     "qr": "^0.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       light-bolt11-decoder:
         specifier: ^3.2.0
         version: 3.2.0
+      liveline:
+        specifier: ^0.0.7
+        version: 0.0.7(react@18.3.1)
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@18.3.1)
@@ -3002,6 +3005,12 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  liveline@0.0.7:
+    resolution: {integrity: sha512-S1Weo1kmefiOCNaW/WFXErqJXlV8A/ldIkIthaOeT57I2ZhqhKLKQDJ1wfabtMSK9vJeU8PeMNHd8Sr8TLByWQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=18'
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -7098,6 +7107,10 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@1.2.4: {}
+
+  liveline@0.0.7(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   locate-path@6.0.0:
     dependencies:

--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -33,7 +33,7 @@ export default function AssetCard({
   fiatText,
   onClick,
 }: AssetCardProps) {
-  const assetName = ticker && ticker !== 'BTC' ? ticker : name || truncatedAssetId(assetId) || 'Asset'
+  const assetName = name || truncatedAssetId(assetId) || 'Asset'
   const tokenTick = ticker ?? 'TKN'
   const rawBalance =
     typeof balance === 'bigint'

--- a/src/components/SwapComingSoonSheet.tsx
+++ b/src/components/SwapComingSoonSheet.tsx
@@ -1,0 +1,22 @@
+import Button from './Button'
+import SheetModal from './SheetModal'
+import SwapIcon from '../icons/Swap'
+
+export default function SwapComingSoonSheet({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  return (
+    <SheetModal isOpen={isOpen} onClose={onClose}>
+      <div className='swap-coming-soon' data-testid='swap-coming-soon-sheet'>
+        <div className='swap-coming-soon__icon' aria-hidden='true'>
+          <SwapIcon />
+        </div>
+        <div className='swap-coming-soon__copy'>
+          <h2 className='swap-coming-soon__title'>Swaps are coming soon</h2>
+          <p className='swap-coming-soon__description'>
+            We are polishing the swap experience before turning it on here.
+          </p>
+        </div>
+        <Button label='Got it' onClick={onClose} />
+      </div>
+    </SheetModal>
+  )
+}

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -109,7 +109,7 @@ const TransactionLine = ({
           const icon = meta?.icon
           const decimals = meta?.decimals ?? 8
           const accountTicker = accountTickerForAssetTicker(ticker)
-          const label = accountTicker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`
+          const label = accountTicker ?? ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`
           return (
             <FlexRow key={a.assetId} gap='0.375rem' end>
               <TransactionAssetAvatar icon={icon} ticker={accountTicker ?? ticker} assetId={a.assetId} />

--- a/src/index.css
+++ b/src/index.css
@@ -1872,3 +1872,379 @@ html.palette-dark .settings-row--danger .settings-row__label,
 html.palette-dark .settings-row--danger .settings-row__chevron {
   color: color-mix(in srgb, var(--red-400) 82%, var(--fg));
 }
+
+.asset-detail-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.375rem;
+  padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
+  contain: content;
+  --asset-detail-label-size: 0.8125rem;
+  --asset-detail-control-size: 0.8125rem;
+  --asset-detail-section-size: 1rem;
+  --asset-detail-support-weight: 500;
+}
+
+.asset-detail-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 0.75rem 0 0.25rem;
+}
+
+.asset-detail-identity {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.875rem;
+}
+
+.asset-detail-logo {
+  display: inline-flex;
+  width: 3.75rem;
+  height: 3.75rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--neutral-50) 72%, var(--bg));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent),
+    0 1px 2px -1px color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+.asset-detail-logo svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.asset-detail-name {
+  margin: 0;
+  color: var(--fg);
+  font-family: var(--font-heading);
+  font-size: 1.625rem;
+  font-weight: 500;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.asset-detail-price-row {
+  display: flex;
+  width: 100%;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.asset-detail-price {
+  color: var(--fg);
+  font-family: var(--font-heading);
+  font-size: clamp(2.375rem, 10.5vw, 2.875rem);
+  font-weight: 500;
+  line-height: 0.95;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.asset-detail-delta {
+  display: inline-flex;
+  min-height: 2rem;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 999px;
+  padding: 0 0.625rem;
+  font-size: var(--asset-detail-control-size);
+  font-weight: var(--asset-detail-support-weight);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, currentColor 8%, transparent),
+    0 1px 2px -1px color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+.asset-detail-delta__arrow {
+  display: inline-flex;
+  width: 0.875rem;
+  height: 0.875rem;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--asset-detail-control-size);
+  line-height: 1;
+  transform-origin: center;
+}
+
+.asset-detail-delta--up {
+  background: color-mix(in srgb, var(--green-500) 9%, var(--bg));
+  color: var(--green-600);
+}
+
+.asset-detail-delta--down {
+  background: color-mix(in srgb, var(--neutral-50) 88%, var(--bg));
+  color: color-mix(in srgb, var(--fg) 54%, transparent);
+}
+
+.asset-detail-actions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.625rem;
+}
+
+.asset-detail-action {
+  display: flex;
+  min-height: 4.75rem;
+  min-width: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 0;
+  border-radius: 1.125rem;
+  background: color-mix(in srgb, var(--purple-100) 48%, var(--bg));
+  color: var(--purple-700);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--purple-700) 5%, transparent);
+  font: inherit;
+  touch-action: manipulation;
+  transition:
+    background-color 180ms ease,
+    opacity 180ms ease,
+    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.asset-detail-action:active {
+  transform: scale(0.97);
+}
+
+.asset-detail-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.asset-detail-action > span {
+  display: inline-flex;
+  width: 1.375rem;
+  height: 1.375rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.asset-detail-action svg {
+  display: block;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.asset-detail-action small {
+  color: color-mix(in srgb, var(--fg) 68%, transparent);
+  font-size: var(--asset-detail-label-size);
+  font-weight: var(--asset-detail-support-weight);
+  line-height: 1;
+}
+
+.asset-detail-chart-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0 -1rem;
+}
+
+.asset-detail-chart {
+  position: relative;
+  height: 17rem;
+  overflow: visible;
+  background: transparent;
+}
+
+.asset-detail-chart canvas {
+  display: block;
+}
+
+.asset-detail-chart-fallback {
+  width: 100%;
+  height: 100%;
+  background:
+    linear-gradient(
+      135deg,
+      transparent 0%,
+      transparent 42%,
+      color-mix(in srgb, var(--purple-700) 24%, transparent) 43%,
+      color-mix(in srgb, var(--purple-700) 24%, transparent) 44%,
+      transparent 45%,
+      transparent 100%
+    ),
+    var(--neutral-50);
+}
+
+.asset-detail-range-tabs {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.25rem;
+}
+
+.asset-detail-range-tab {
+  min-width: 2.75rem;
+  min-height: 2.5rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: color-mix(in srgb, var(--fg) 38%, transparent);
+  font: inherit;
+  font-size: var(--asset-detail-control-size);
+  font-weight: var(--asset-detail-support-weight);
+  line-height: 1;
+  touch-action: manipulation;
+  transition:
+    background-color 180ms ease,
+    color 180ms ease,
+    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.asset-detail-range-tab[aria-selected='true'] {
+  background: color-mix(in srgb, var(--neutral-100) 74%, var(--bg));
+  color: var(--fg);
+}
+
+.asset-detail-range-tab:active {
+  transform: scale(0.96);
+}
+
+.asset-detail-holdings {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+  border-top: 1px solid color-mix(in srgb, var(--fg) 6%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--fg) 6%, transparent);
+}
+
+.asset-detail-holding {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 1rem 0.875rem 1.125rem;
+  text-align: center;
+}
+
+.asset-detail-holding + .asset-detail-holding {
+  border-left: 1px solid color-mix(in srgb, var(--fg) 6%, transparent);
+}
+
+.asset-detail-holding > span {
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: var(--asset-detail-label-size);
+  font-weight: var(--asset-detail-support-weight);
+  line-height: 1.1;
+}
+
+.asset-detail-holding strong {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  color: var(--fg);
+  font-size: clamp(1.375rem, 5.4vw, 1.625rem);
+  font-weight: 500;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.asset-detail-holding strong .privacy-amount__value {
+  display: inline-flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+.asset-detail-holding-amount {
+  color: var(--fg);
+  font: inherit;
+}
+
+.asset-detail-holding-unit {
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+  font-size: var(--asset-detail-label-size);
+  font-weight: var(--asset-detail-support-weight);
+  line-height: 1;
+}
+
+.asset-detail-holding-logo {
+  display: inline-grid;
+  width: 1.375rem;
+  height: 1.375rem;
+  flex: 0 0 auto;
+  place-items: center;
+  transform: translateY(-0.01em);
+}
+
+.asset-detail-holding-logo svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.asset-detail-activity {
+  padding: 0.25rem 0 0;
+}
+
+.asset-detail-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.25rem 0.625rem;
+}
+
+.asset-detail-section-header strong {
+  color: var(--fg);
+  font-family: inherit;
+  font-size: var(--asset-detail-section-size);
+  font-weight: var(--asset-detail-support-weight);
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.asset-detail-activity .activity-list--compact {
+  margin: 0;
+}
+
+.palette-dark .asset-detail-action {
+  background: color-mix(in srgb, var(--purple-500) 16%, var(--neutral-50));
+  color: color-mix(in srgb, var(--purple-100) 92%, var(--fg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--purple-200) 7%, transparent);
+}
+
+.palette-dark .asset-detail-action small {
+  color: color-mix(in srgb, var(--fg) 72%, transparent);
+}
+
+.palette-dark .asset-detail-delta--up {
+  background: color-mix(in srgb, var(--green-500) 15%, var(--bg));
+  color: color-mix(in srgb, var(--green-100) 86%, var(--green-500));
+}
+
+.palette-dark .asset-detail-delta--down {
+  background: color-mix(in srgb, var(--neutral-50) 28%, var(--bg));
+  color: color-mix(in srgb, var(--fg) 66%, transparent);
+}
+
+.palette-dark .asset-detail-range-tab[aria-selected='true'] {
+  background: color-mix(in srgb, var(--fg) 12%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .asset-detail-action,
+  .asset-detail-range-tab {
+    transition-duration: 0.01ms;
+  }
+
+  .asset-detail-action:active,
+  .asset-detail-range-tab:active {
+    transform: none;
+  }
+}

--- a/src/lib/marketData.ts
+++ b/src/lib/marketData.ts
@@ -1,0 +1,49 @@
+import { LivelinePoint } from 'liveline'
+import { Fiats } from './types'
+
+const host = 'https://fetch-json.bordalix.workers.dev' // TODO: move to final worker URL
+
+interface HistoricalMarketDataResponse {
+  when: number
+  from: string
+  data: LivelinePoint[]
+}
+
+const CHART_WINDOWS = [
+  { label: 'oneHour', secs: 3_600 },
+  { label: 'oneDay', secs: 86_400 },
+  { label: 'oneWeek', secs: 604_800 },
+  { label: 'oneMonth', secs: 2_592_000 },
+  { label: 'oneYear', secs: 31_536_000 },
+  { label: 'all', secs: -1 },
+]
+
+const secsToPeriod = (secs: number): string => {
+  const window = CHART_WINDOWS.find((w) => w.secs === secs)
+  return window ? window.label : 'oneDay'
+}
+
+export const fetchHistoricalMarketData = async (secs: number, fiat: Fiats): Promise<LivelinePoint[]> => {
+  const period = secsToPeriod(secs)
+  const params = new URLSearchParams({ period, fiat })
+  const resp = await fetch(`${host}?${params.toString()}`)
+  const data = await resp.json()
+  return isValidHistoricalMarketDataResponse(data) ? data.data : []
+}
+
+const isValidHistoricalMarketDataResponse = (data: unknown): data is HistoricalMarketDataResponse => {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    typeof (data as HistoricalMarketDataResponse).when === 'number' &&
+    typeof (data as HistoricalMarketDataResponse).from === 'string' &&
+    Array.isArray((data as HistoricalMarketDataResponse).data) &&
+    (data as HistoricalMarketDataResponse).data.every(
+      (point) =>
+        point !== null &&
+        typeof point === 'object' &&
+        typeof point.time === 'number' &&
+        typeof point.value === 'number',
+    )
+  )
+}

--- a/src/lib/marketData.ts
+++ b/src/lib/marketData.ts
@@ -9,7 +9,7 @@ interface HistoricalMarketDataResponse {
   data: LivelinePoint[]
 }
 
-const CHART_WINDOWS = [
+const PERIOD_WINDOWS = [
   { label: 'oneHour', secs: 3_600 },
   { label: 'oneDay', secs: 86_400 },
   { label: 'oneWeek', secs: 604_800 },
@@ -19,14 +19,19 @@ const CHART_WINDOWS = [
 ]
 
 const secsToPeriod = (secs: number): string => {
-  const window = CHART_WINDOWS.find((w) => w.secs === secs)
+  const window = PERIOD_WINDOWS.find((w) => w.secs === secs)
   return window ? window.label : 'oneDay'
 }
 
-export const fetchHistoricalMarketData = async (secs: number, fiat: Fiats): Promise<LivelinePoint[]> => {
+export const fetchHistoricalMarketData = async (
+  secs: number,
+  fiat: Fiats,
+  signal?: AbortSignal,
+): Promise<LivelinePoint[]> => {
   const period = secsToPeriod(secs)
   const params = new URLSearchParams({ period, fiat })
-  const resp = await fetch(`${host}?${params.toString()}`)
+  const resp = await fetch(`${host}?${params.toString()}`, { signal })
+  if (!resp.ok) throw new Error(`Market data fetch failed: ${resp.status}`)
   const data = await resp.json()
   return isValidHistoricalMarketDataResponse(data) ? data.data : []
 }

--- a/src/providers/navigation.tsx
+++ b/src/providers/navigation.tsx
@@ -17,6 +17,7 @@ import Unlock from '../screens/Wallet/Unlock'
 import Activity from '../screens/Wallet/Activity'
 import Vtxos from '../screens/Settings/Vtxos'
 import Wallet from '../screens/Wallet/Index'
+import BitcoinDetail from '../screens/Wallet/BitcoinDetail'
 import Settings from '../screens/Settings/Index'
 
 import Apps from '../screens/Apps/Index'
@@ -42,6 +43,7 @@ export type NavigationDirection = 'forward' | 'back' | 'none'
 
 export enum Pages {
   Activity,
+  BitcoinDetail,
   AppBoltz,
   AppBoltzSettings,
   AppBoltzSwap,
@@ -90,6 +92,7 @@ export enum Tabs {
 
 const pageTab = {
   [Pages.Activity]: Tabs.Wallet,
+  [Pages.BitcoinDetail]: Tabs.Wallet,
   [Pages.AppBoltz]: Tabs.Apps,
   [Pages.AppBoltzSettings]: Tabs.Apps,
   [Pages.AppBoltzSwap]: Tabs.Apps,
@@ -151,6 +154,8 @@ export const pageComponent = (page: Pages): JSX.Element => {
   switch (page) {
     case Pages.Activity:
       return <Activity />
+    case Pages.BitcoinDetail:
+      return <BitcoinDetail />
     case Pages.AppBoltz:
       return <AppBoltz />
     case Pages.AppBoltzSettings:

--- a/src/screens/Wallet/AssetsSection.tsx
+++ b/src/screens/Wallet/AssetsSection.tsx
@@ -3,11 +3,13 @@ import AssetCard from '../../components/AssetCard'
 import { usePortfolioFiat } from '../../hooks/usePortfolioFiat'
 import { ConfigContext } from '../../providers/config'
 import { FiatContext } from '../../providers/fiat'
+import { NavigationContext, Pages } from '../../providers/navigation'
 import { prettyFiatAmount } from '../../lib/format'
 
 export default function AssetsSection() {
   const { config } = useContext(ConfigContext)
   const { fiatDecimals } = useContext(FiatContext)
+  const { navigate } = useContext(NavigationContext)
   const { rows } = usePortfolioFiat()
 
   const fiatLabel = (amount: number) => {
@@ -34,6 +36,7 @@ export default function AssetsSection() {
             decimals={row.decimals}
             balance={row.balance}
             fiatText={row.hasFiatPrice ? fiatLabel(row.fiatAmount) : undefined}
+            onClick={row.assetId === 'btc' ? () => navigate(Pages.BitcoinDetail) : undefined}
           />
         ))}
       </div>

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -1,0 +1,610 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import { Liveline, type HoverPoint, type LivelinePoint } from 'liveline'
+import { ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import Content from '../../components/Content'
+import Header from '../../components/Header'
+import Padded from '../../components/Padded'
+import { PrivacyAmount, maskedFiat } from '../../components/PrivacyAmount'
+import SwapComingSoonSheet from '../../components/SwapComingSoonSheet'
+import TokenLogo from '../../components/TokenLogo'
+import TransactionsList from '../../components/TransactionsList'
+import ReceiveIcon from '../../icons/Receive'
+import ScanIcon from '../../icons/Scan'
+import SendIcon from '../../icons/Send'
+import SwapIcon from '../../icons/Swap'
+import { walletLoadInChild, walletLoadInContainer } from '../../lib/animations'
+import { formatAssetAmount, prettyFiatAmount, prettyNumber } from '../../lib/format'
+import { hapticLight, hapticSubtle } from '../../lib/haptics'
+import { consoleError } from '../../lib/logs'
+import { Fiats, Themes } from '../../lib/types'
+import { useReducedMotion } from '../../hooks/useReducedMotion'
+import { ConfigContext } from '../../providers/config'
+import { FiatContext } from '../../providers/fiat'
+import { FlowContext, emptyRecvInfo, emptySendInfo } from '../../providers/flow'
+import { NavigationContext, Pages } from '../../providers/navigation'
+import { WalletContext } from '../../providers/wallet'
+
+const CHART_WINDOWS = [
+  { label: '1H', secs: 3_600 },
+  { label: '1D', secs: 86_400 },
+  { label: '1W', secs: 604_800 },
+  { label: '1M', secs: 2_592_000 },
+  { label: '1Y', secs: 31_536_000 },
+  { label: 'All', secs: -1 },
+]
+
+const ALL_CHART_START_TIME = Math.floor(Date.UTC(2015, 0, 1) / 1000)
+const COINBASE_CANDLE_CHUNK_DAYS = 300
+const MIN_CHART_WINDOW_SECS = 30
+
+export default function BitcoinDetail() {
+  const { config } = useContext(ConfigContext)
+  const { convertFiat, fiatDecimals, toFiat } = useContext(FiatContext)
+  const { setRecvInfo, setSendInfo } = useContext(FlowContext)
+  const { navigate } = useContext(NavigationContext)
+  const { balance } = useContext(WalletContext)
+  const prefersReduced = useReducedMotion()
+
+  const [chartWindow, setChartWindow] = useState(CHART_WINDOWS[0].secs)
+  const [chartInteracting, setChartInteracting] = useState(false)
+  const [swapSheetOpen, setSwapSheetOpen] = useState(false)
+  const chartHapticState = useRef({ lastPointTime: 0, lastTriggerTime: 0 })
+
+  const fallbackUnitPrice = toFiat(100_000_000)
+  const liveChartData = useBitcoinMarketChartData(config.fiat, chartWindow, convertFiat)
+  const unitPrice = liveChartData.at(-1)?.value ?? fallbackUnitPrice
+  const fiatValue = (balance / 100_000_000) * unitPrice
+  const formattedFiat = prettyFiatAmount(fiatValue, config.fiat, {
+    maximumFractionDigits: fiatDecimals(),
+    minimumFractionDigits: fiatDecimals(),
+  })
+  const chartColor = useTokenColor('--orange-500')
+  const chartTheme = useResolvedChartTheme(config.theme)
+  const chartData = useMemo(
+    () => (liveChartData.length ? liveChartData : buildFlatChartData(unitPrice, chartWindow)),
+    [chartWindow, liveChartData, unitPrice],
+  )
+  const chartDisplayData = useMemo(
+    () => smoothChartData(chartData, chartWindow, chartInteracting),
+    [chartData, chartInteracting, chartWindow],
+  )
+  const chartDelta = calculateDelta(chartData)
+  const livelineWindow = useMemo(
+    () => getLivelineWindowSecs(chartDisplayData, chartWindow),
+    [chartDisplayData, chartWindow],
+  )
+  const canRenderChart = typeof ResizeObserver !== 'undefined'
+
+  const handleSend = () => {
+    hapticLight()
+    setSendInfo(emptySendInfo)
+    navigate(Pages.SendForm)
+  }
+
+  const handleReceive = () => {
+    hapticLight()
+    setRecvInfo(emptyRecvInfo)
+    navigate(Pages.ReceiveQRCode)
+  }
+
+  const handleScan = () => {
+    hapticLight()
+    setSendInfo({ ...emptySendInfo, scan: true })
+    navigate(Pages.SendForm)
+  }
+
+  const handleSwap = () => {
+    hapticLight()
+    setSwapSheetOpen(true)
+  }
+
+  const handleChartPress = useCallback(() => {
+    if (prefersReduced) return
+    hapticSubtle()
+  }, [prefersReduced])
+
+  const setChartScrubbing = useCallback((value: boolean) => {
+    setChartInteracting((current) => (current === value ? current : value))
+  }, [])
+
+  const handleChartHover = useCallback(
+    (point: HoverPoint | null) => {
+      if (!point || prefersReduced) return
+
+      const pointTime = Math.round(point.time)
+      const now = performance.now()
+      const state = chartHapticState.current
+
+      if (!pointTime || pointTime === state.lastPointTime) return
+      if (now - state.lastTriggerTime < 120) return
+
+      chartHapticState.current = {
+        lastPointTime: pointTime,
+        lastTriggerTime: now,
+      }
+      hapticSubtle()
+    },
+    [prefersReduced],
+  )
+
+  return (
+    <>
+      <Header text='' back />
+      <Content>
+        <Padded>
+          <motion.div
+            className='asset-detail-page'
+            variants={prefersReduced ? undefined : walletLoadInContainer}
+            initial={prefersReduced ? false : 'initial'}
+            animate='animate'
+          >
+            <motion.section className='asset-detail-hero' variants={prefersReduced ? undefined : walletLoadInChild}>
+              <motion.div className='asset-detail-identity' variants={prefersReduced ? undefined : walletLoadInChild}>
+                <span className='asset-detail-logo' aria-hidden='true'>
+                  <TokenLogo ticker='BTC' />
+                </span>
+                <div>
+                  <h1 className='asset-detail-name'>bitcoin</h1>
+                </div>
+              </motion.div>
+
+              <motion.div
+                className='asset-detail-price-row'
+                layout
+                variants={prefersReduced ? undefined : walletLoadInChild}
+              >
+                <AnimatePresence mode='popLayout' initial={false}>
+                  <motion.div
+                    key={`${unitPrice}-${config.fiat}`}
+                    className='asset-detail-price'
+                    initial={prefersReduced ? false : { opacity: 0, y: 8, filter: 'blur(2px)' }}
+                    animate={prefersReduced ? undefined : { opacity: 1, y: 0, filter: 'blur(0px)' }}
+                    exit={prefersReduced ? undefined : { opacity: 0, y: -8, filter: 'blur(2px)' }}
+                    transition={{ duration: 0.22, ease: [0.23, 1, 0.32, 1] }}
+                  >
+                    {prettyFiatAmount(unitPrice, config.fiat)}
+                  </motion.div>
+                </AnimatePresence>
+                <DeltaBadge value={chartDelta} />
+              </motion.div>
+            </motion.section>
+
+            <motion.div className='asset-detail-actions' variants={prefersReduced ? undefined : walletLoadInChild}>
+              <AssetAction icon={<ReceiveIcon />} label='Receive' onClick={handleReceive} />
+              <AssetAction icon={<SendIcon />} label='Send' onClick={handleSend} disabled={balance === 0} />
+              <AssetAction icon={<SwapIcon />} label='Swap' onClick={handleSwap} />
+              <AssetAction icon={<ScanIcon />} label='Scan' onClick={handleScan} />
+            </motion.div>
+
+            <motion.section
+              className='asset-detail-chart-section'
+              variants={prefersReduced ? undefined : walletLoadInChild}
+            >
+              <div
+                className='asset-detail-chart'
+                onPointerDown={() => {
+                  setChartScrubbing(true)
+                  handleChartPress()
+                }}
+                onPointerEnter={() => setChartScrubbing(true)}
+                onPointerLeave={() => setChartScrubbing(false)}
+                onPointerUp={() => setChartScrubbing(false)}
+                onPointerCancel={() => setChartScrubbing(false)}
+              >
+                {canRenderChart ? (
+                  <Liveline
+                    data={chartDisplayData}
+                    value={chartDisplayData.at(-1)?.value ?? unitPrice}
+                    color={chartColor}
+                    theme={chartTheme}
+                    window={livelineWindow}
+                    badge={false}
+                    badgeTail
+                    badgeVariant='minimal'
+                    formatValue={(value) => prettyFiatAmount(value, config.fiat)}
+                    grid={false}
+                    pulse={!prefersReduced}
+                    scrub={!prefersReduced}
+                    momentum={false}
+                    fill
+                    showValue={false}
+                    valueMomentumColor={false}
+                    degen={false}
+                    exaggerate={false}
+                    lineWidth={4}
+                    padding={{ top: 8, right: 32, bottom: 8, left: 12 }}
+                    lerpSpeed={prefersReduced ? 1 : 0.1}
+                    onHover={(point) => {
+                      setChartScrubbing(Boolean(point))
+                      handleChartHover(point)
+                    }}
+                    cursor='default'
+                  />
+                ) : (
+                  <div className='asset-detail-chart-fallback' aria-hidden='true' />
+                )}
+              </div>
+              <div className='asset-detail-range-tabs' role='tablist' aria-label='Price chart range'>
+                {CHART_WINDOWS.map((option) => (
+                  <motion.button
+                    key={option.label}
+                    type='button'
+                    role='tab'
+                    aria-selected={chartWindow === option.secs}
+                    className='asset-detail-range-tab'
+                    onClick={() => {
+                      hapticSubtle()
+                      setChartWindow(option.secs)
+                    }}
+                    whileTap={prefersReduced ? undefined : { scale: 0.96 }}
+                    transition={{ duration: 0.14 }}
+                  >
+                    {option.label}
+                  </motion.button>
+                ))}
+              </div>
+            </motion.section>
+
+            <motion.section className='asset-detail-holdings' variants={prefersReduced ? undefined : walletLoadInChild}>
+              <div className='asset-detail-holding'>
+                <span>Balance</span>
+                <strong>
+                  <span className='asset-detail-holding-logo'>
+                    <TokenLogo ticker='BTC' />
+                  </span>
+                  <PrivacyAmount masked='•••• BTC'>
+                    <span className='asset-detail-holding-amount'>{formatAssetAmount(BigInt(balance), 8)}</span>
+                    <span className='asset-detail-holding-unit'>BTC</span>
+                  </PrivacyAmount>
+                </strong>
+              </div>
+              <div className='asset-detail-holding'>
+                <span>Value</span>
+                <strong>
+                  <PrivacyAmount masked={maskedFiat()}>{formattedFiat}</PrivacyAmount>
+                </strong>
+              </div>
+            </motion.section>
+
+            <motion.section className='asset-detail-activity' variants={prefersReduced ? undefined : walletLoadInChild}>
+              <div className='asset-detail-section-header'>
+                <strong>Recent activity</strong>
+              </div>
+              <TransactionsList mode='static' assetIdFilter='btc' limit={5} />
+            </motion.section>
+          </motion.div>
+        </Padded>
+      </Content>
+      <SwapComingSoonSheet isOpen={swapSheetOpen} onClose={() => setSwapSheetOpen(false)} />
+    </>
+  )
+}
+
+function AssetAction({
+  disabled,
+  icon,
+  label,
+  onClick,
+}: {
+  disabled?: boolean
+  icon: ReactNode
+  label: string
+  onClick: () => void
+}) {
+  const prefersReduced = useReducedMotion()
+  const props = {
+    type: 'button' as const,
+    className: 'asset-detail-action',
+    disabled,
+    onClick,
+  }
+
+  if (prefersReduced) {
+    return (
+      <button {...props}>
+        <span>{icon}</span>
+        <small>{label}</small>
+      </button>
+    )
+  }
+
+  return (
+    <motion.button {...props} whileTap={{ scale: disabled ? 1 : 0.97 }} transition={{ duration: 0.16 }}>
+      <span>{icon}</span>
+      <small>{label}</small>
+    </motion.button>
+  )
+}
+
+function DeltaBadge({ value }: { value: number }) {
+  const prefersReduced = useReducedMotion()
+  const isUp = value >= 0
+  const directionKey = isUp ? 'up' : 'down'
+  const arrowRotation = isUp ? 0 : 180
+
+  return (
+    <motion.span
+      key={directionKey}
+      className={`asset-detail-delta ${isUp ? 'asset-detail-delta--up' : 'asset-detail-delta--down'}`}
+      initial={prefersReduced ? false : { opacity: 0, y: 8, scale: 0.96 }}
+      animate={prefersReduced ? undefined : { opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: 0.22, ease: [0.23, 1, 0.32, 1] }}
+    >
+      <motion.span
+        key={`${directionKey}-arrow`}
+        className='asset-detail-delta__arrow'
+        initial={prefersReduced ? false : { rotate: isUp ? 180 : 0, scale: 0.9 }}
+        animate={prefersReduced ? undefined : { rotate: arrowRotation, scale: 1 }}
+        transition={{ duration: 0.26, ease: [0.86, 0, 0.07, 1] }}
+      >
+        ↑
+      </motion.span>
+      <span>
+        {isUp ? '+' : ''}
+        {prettyNumber(value, 2)}%
+      </span>
+    </motion.span>
+  )
+}
+
+function useTokenColor(token: string): string {
+  const [color, setColor] = useState(`var(${token})`)
+
+  useEffect(() => {
+    const root = getComputedStyle(document.documentElement)
+    const next = root.getPropertyValue(token).trim()
+    if (next) setColor(next)
+  }, [token])
+
+  return color
+}
+
+function useResolvedChartTheme(theme: Themes): 'light' | 'dark' {
+  const [resolved, setResolved] = useState<'light' | 'dark'>('light')
+
+  useEffect(() => {
+    const query = window.matchMedia('(prefers-color-scheme: dark)')
+    const update = () => {
+      setResolved(theme === Themes.Dark || (theme === Themes.Auto && query.matches) ? 'dark' : 'light')
+    }
+    update()
+    query.addEventListener('change', update)
+    return () => query.removeEventListener('change', update)
+  }, [theme])
+
+  return resolved
+}
+
+function useBitcoinMarketChartData(
+  fiat: Fiats,
+  windowSecs: number,
+  convertFiat: (amount: number, from: Fiats) => number,
+): LivelinePoint[] {
+  const [data, setData] = useState<LivelinePoint[]>([])
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    fetchBitcoinMarketChart(fiat, windowSecs, convertFiat, controller.signal)
+      .then((json) => {
+        if (controller.signal.aborted) return
+        const prices = Array.isArray(json.prices) ? json.prices : []
+        const points = prices
+          .map(([timeMs, value]) => ({ time: Math.round(timeMs / 1000), value }))
+          .filter((point) => Number.isFinite(point.time) && Number.isFinite(point.value) && point.value > 0)
+
+        if (isAllChartWindow(windowSecs)) {
+          setData(points)
+          return
+        }
+
+        const cutoff = Math.floor(Date.now() / 1000) - windowSecs
+        const windowedPoints = points.filter((point) => point.time >= cutoff)
+        setData(windowedPoints.length >= 2 ? windowedPoints : points)
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return
+        consoleError(err, 'error fetching bitcoin market chart')
+        setData([])
+      })
+
+    return () => controller.abort()
+  }, [fiat, windowSecs, convertFiat])
+
+  return data
+}
+
+async function fetchBitcoinMarketChart(
+  fiat: Fiats,
+  windowSecs: number,
+  convertFiat: (amount: number, from: Fiats) => number,
+  signal: AbortSignal,
+): Promise<{ prices?: [number, number][] }> {
+  if (isAllChartWindow(windowSecs)) {
+    const prices = await fetchCoinbaseBitcoinAllChart(fiat, convertFiat, signal)
+    if (prices.length >= 2) return { prices }
+  }
+
+  return fetchCoinGeckoBitcoinChart(fiat, windowSecs, signal)
+}
+
+async function fetchCoinbaseBitcoinAllChart(
+  fiat: Fiats,
+  convertFiat: (amount: number, from: Fiats) => number,
+  signal: AbortSignal,
+): Promise<[number, number][]> {
+  const now = Math.floor(Date.now() / 1000)
+  const chunkSecs = COINBASE_CANDLE_CHUNK_DAYS * 86_400
+  const requests: Promise<[number, number][]>[] = []
+
+  for (let start = ALL_CHART_START_TIME; start < now; start += chunkSecs) {
+    const end = Math.min(start + chunkSecs, now)
+    requests.push(fetchCoinbaseBitcoinCandles(start, end, fiat, convertFiat, signal))
+  }
+
+  const chunks = await Promise.all(requests)
+  return chunks
+    .flat()
+    .sort(([a], [b]) => a - b)
+    .filter((point, index, points) => index === 0 || point[0] !== points[index - 1][0])
+}
+
+async function fetchCoinbaseBitcoinCandles(
+  start: number,
+  end: number,
+  fiat: Fiats,
+  convertFiat: (amount: number, from: Fiats) => number,
+  signal: AbortSignal,
+): Promise<[number, number][]> {
+  const params = new URLSearchParams({
+    granularity: '86400',
+    start: new Date(start * 1000).toISOString(),
+    end: new Date(end * 1000).toISOString(),
+  })
+  const response = await fetch(`https://api.exchange.coinbase.com/products/BTC-USD/candles?${params.toString()}`, {
+    signal,
+  })
+
+  if (!response.ok) throw new Error(`Coinbase bitcoin chart failed: ${response.status}`)
+  const candles = (await response.json()) as [number, number, number, number, number, number][]
+
+  return candles
+    .map(
+      ([time, , , , close]) =>
+        [time * 1000, fiat === Fiats.USD ? close : convertFiat(close, Fiats.USD)] as [number, number],
+    )
+    .filter(([, value]) => Number.isFinite(value) && value > 0)
+}
+
+async function fetchCoinGeckoBitcoinChart(
+  fiat: Fiats,
+  windowSecs: number,
+  signal: AbortSignal,
+): Promise<{ prices?: [number, number][] }> {
+  const requests = coinGeckoDaysForWindow(windowSecs)
+
+  for (const days of requests) {
+    const params = new URLSearchParams({
+      vs_currency: fiat.toLowerCase(),
+      days,
+      precision: 'full',
+    })
+    const response = await fetch(`https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?${params.toString()}`, {
+      signal,
+    })
+
+    if (response.ok) return response.json() as Promise<{ prices?: [number, number][] }>
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError')
+  }
+
+  throw new Error('CoinGecko bitcoin chart failed')
+}
+
+function buildFlatChartData(latestValue: number, windowSecs: number): LivelinePoint[] {
+  const now = Math.floor(Date.now() / 1000)
+  const fallbackWindowSecs = isAllChartWindow(windowSecs) ? 86_400 : windowSecs
+  return [
+    { time: now - fallbackWindowSecs, value: latestValue },
+    { time: now, value: latestValue },
+  ]
+}
+
+function smoothChartData(data: LivelinePoint[], windowSecs: number, isInteracting: boolean): LivelinePoint[] {
+  if (isInteracting || data.length < 8 || (!isAllChartWindow(windowSecs) && windowSecs <= 3_600)) return data
+
+  const targetPoints = chartTargetPointCount(windowSecs)
+  const bucketed = bucketAveragePoints(data, targetPoints)
+  const radius = chartSmoothingRadius(windowSecs)
+  if (radius <= 0) return bucketed
+
+  return bucketed.map((point, index) => {
+    if (index === 0 || index === bucketed.length - 1) return point
+
+    const start = Math.max(0, index - radius)
+    const end = Math.min(bucketed.length - 1, index + radius)
+    let totalWeight = 0
+    let totalValue = 0
+
+    for (let cursor = start; cursor <= end; cursor += 1) {
+      const distance = Math.abs(cursor - index)
+      const weight = radius + 1 - distance
+      totalWeight += weight
+      totalValue += bucketed[cursor].value * weight
+    }
+
+    return {
+      time: point.time,
+      value: totalValue / totalWeight,
+    }
+  })
+}
+
+function bucketAveragePoints(data: LivelinePoint[], targetPoints: number): LivelinePoint[] {
+  if (data.length <= targetPoints) return data
+
+  const bucketSize = Math.ceil(data.length / targetPoints)
+  const points: LivelinePoint[] = [data[0]]
+
+  for (let index = 1; index < data.length - 1; index += bucketSize) {
+    const bucket = data.slice(index, index + bucketSize)
+    if (!bucket.length) continue
+
+    const time = bucket[Math.floor(bucket.length / 2)].time
+    const value = bucket.reduce((sum, point) => sum + point.value, 0) / bucket.length
+    points.push({ time, value })
+  }
+
+  const last = data.at(-1)
+  if (last && points.at(-1)?.time !== last.time) points.push(last)
+
+  return points
+}
+
+function chartTargetPointCount(windowSecs: number): number {
+  if (isAllChartWindow(windowSecs)) return 120
+  if (windowSecs >= 31_536_000) return 116
+  if (windowSecs >= 2_592_000) return 96
+  if (windowSecs >= 86_400) return 72
+  return 84
+}
+
+function chartSmoothingRadius(windowSecs: number): number {
+  if (isAllChartWindow(windowSecs)) return 5
+  if (windowSecs >= 31_536_000) return 4
+  if (windowSecs >= 2_592_000) return 3
+  if (windowSecs >= 86_400) return 2
+  return 2
+}
+
+function getLivelineWindowSecs(data: LivelinePoint[], windowSecs: number): number {
+  if (!isAllChartWindow(windowSecs)) return windowSecs
+
+  const first = data[0]
+  const last = data.at(-1)
+  if (!first || !last) return 86_400
+
+  const now = Math.floor(Date.now() / 1000)
+  const rightEdge = Math.max(now, last.time)
+  return Math.max(MIN_CHART_WINDOW_SECS, rightEdge - first.time)
+}
+
+function calculateDelta(data: LivelinePoint[]): number {
+  const first = data[0]?.value ?? 0
+  const last = data.at(-1)?.value ?? first
+  if (!first) return 0
+  return ((last - first) / first) * 100
+}
+
+function coinGeckoDaysForWindow(windowSecs: number): string[] {
+  if (isAllChartWindow(windowSecs)) return ['365']
+  if (windowSecs <= 3_600) return ['1']
+  if (windowSecs <= 86_400) return ['1']
+  if (windowSecs <= 604_800) return ['7']
+  if (windowSecs <= 2_592_000) return ['30']
+  if (windowSecs <= 31_536_000) return ['365']
+  return ['365']
+}
+
+function isAllChartWindow(windowSecs: number): boolean {
+  return windowSecs < 0
+}

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -23,6 +23,7 @@ import { FiatContext } from '../../providers/fiat'
 import { FlowContext, emptyRecvInfo, emptySendInfo } from '../../providers/flow'
 import { NavigationContext, Pages } from '../../providers/navigation'
 import { WalletContext } from '../../providers/wallet'
+import { fetchHistoricalMarketData } from '../../lib/marketData'
 
 const CHART_WINDOWS = [
   { label: '1H', secs: 3_600 },
@@ -33,8 +34,6 @@ const CHART_WINDOWS = [
   { label: 'All', secs: -1 },
 ]
 
-const ALL_CHART_START_TIME = Math.floor(Date.UTC(2015, 0, 1) / 1000)
-const COINBASE_CANDLE_CHUNK_DAYS = 300
 const MIN_CHART_WINDOW_SECS = 30
 const bitcoinChartCache = new Map<string, LivelinePoint[]>()
 
@@ -391,25 +390,12 @@ function useBitcoinMarketChartData(fiat: Fiats, windowSecs: number): LivelinePoi
       return () => controller.abort()
     }
 
-    fetchBitcoinMarketChart(fiat, windowSecs, controller.signal)
-      .then((json) => {
+    fetchHistoricalMarketData(windowSecs, fiat)
+      .then((points) => {
         if (controller.signal.aborted) return
-        const prices = Array.isArray(json.prices) ? json.prices : []
-        const points = prices
-          .map(([timeMs, value]) => ({ time: Math.round(timeMs / 1000), value }))
-          .filter((point) => Number.isFinite(point.time) && Number.isFinite(point.value) && point.value > 0)
-
-        if (isAllChartWindow(windowSecs)) {
-          bitcoinChartCache.set(cacheKey, points)
-          setData(points)
-          return
-        }
-
-        const cutoff = Math.floor(Date.now() / 1000) - windowSecs
-        const windowedPoints = points.filter((point) => point.time >= cutoff)
-        const nextData = windowedPoints.length >= 2 ? windowedPoints : points
-        bitcoinChartCache.set(cacheKey, nextData)
-        setData(nextData)
+        console.log('point', points)
+        bitcoinChartCache.set(cacheKey, points)
+        setData(points)
       })
       .catch((err) => {
         if (controller.signal.aborted) return
@@ -421,81 +407,6 @@ function useBitcoinMarketChartData(fiat: Fiats, windowSecs: number): LivelinePoi
   }, [fiat, windowSecs])
 
   return data
-}
-
-async function fetchBitcoinMarketChart(
-  fiat: Fiats,
-  windowSecs: number,
-  signal: AbortSignal,
-): Promise<{ prices?: [number, number][] }> {
-  if (isAllChartWindow(windowSecs) && fiat === Fiats.USD) {
-    const prices = await fetchCoinbaseBitcoinAllChart(signal)
-    if (prices.length >= 2) return { prices }
-  }
-
-  return fetchCoinGeckoBitcoinChart(fiat, windowSecs, signal)
-}
-
-async function fetchCoinbaseBitcoinAllChart(signal: AbortSignal): Promise<[number, number][]> {
-  const now = Math.floor(Date.now() / 1000)
-  const chunkSecs = COINBASE_CANDLE_CHUNK_DAYS * 86_400
-  const chunks: [number, number][][] = []
-
-  for (let start = ALL_CHART_START_TIME; start < now; start += chunkSecs) {
-    const end = Math.min(start + chunkSecs, now)
-    chunks.push(await fetchCoinbaseBitcoinCandles(start, end, signal))
-  }
-
-  return chunks
-    .flat()
-    .sort(([a], [b]) => a - b)
-    .filter((point, index, points) => index === 0 || point[0] !== points[index - 1][0])
-}
-
-async function fetchCoinbaseBitcoinCandles(
-  start: number,
-  end: number,
-  signal: AbortSignal,
-): Promise<[number, number][]> {
-  const params = new URLSearchParams({
-    granularity: '86400',
-    start: new Date(start * 1000).toISOString(),
-    end: new Date(end * 1000).toISOString(),
-  })
-  const response = await fetch(`https://api.exchange.coinbase.com/products/BTC-USD/candles?${params.toString()}`, {
-    signal,
-  })
-
-  if (!response.ok) throw new Error(`Coinbase bitcoin chart failed: ${response.status}`)
-  const candles = (await response.json()) as [number, number, number, number, number, number][]
-
-  return candles
-    .map(([time, , , , close]) => [time * 1000, close] as [number, number])
-    .filter(([, value]) => Number.isFinite(value) && value > 0)
-}
-
-async function fetchCoinGeckoBitcoinChart(
-  fiat: Fiats,
-  windowSecs: number,
-  signal: AbortSignal,
-): Promise<{ prices?: [number, number][] }> {
-  const requests = coinGeckoDaysForWindow(windowSecs)
-
-  for (const days of requests) {
-    const params = new URLSearchParams({
-      vs_currency: fiat.toLowerCase(),
-      days,
-      precision: 'full',
-    })
-    const response = await fetch(`https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?${params.toString()}`, {
-      signal,
-    })
-
-    if (response.ok) return response.json() as Promise<{ prices?: [number, number][] }>
-    if (signal.aborted) throw new DOMException('Aborted', 'AbortError')
-  }
-
-  throw new Error('CoinGecko bitcoin chart failed')
 }
 
 function buildFlatChartData(latestValue: number, windowSecs: number): LivelinePoint[] {
@@ -595,16 +506,6 @@ function calculateDelta(data: LivelinePoint[]): number {
 
 function bitcoinChartCacheKey(fiat: Fiats, windowSecs: number): string {
   return `${fiat}:${windowSecs}`
-}
-
-function coinGeckoDaysForWindow(windowSecs: number): string[] {
-  if (isAllChartWindow(windowSecs)) return ['max']
-  if (windowSecs <= 3_600) return ['1']
-  if (windowSecs <= 86_400) return ['1']
-  if (windowSecs <= 604_800) return ['7']
-  if (windowSecs <= 2_592_000) return ['30']
-  if (windowSecs <= 31_536_000) return ['365']
-  return ['365']
 }
 
 function isAllChartWindow(windowSecs: number): boolean {

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -36,10 +36,11 @@ const CHART_WINDOWS = [
 const ALL_CHART_START_TIME = Math.floor(Date.UTC(2015, 0, 1) / 1000)
 const COINBASE_CANDLE_CHUNK_DAYS = 300
 const MIN_CHART_WINDOW_SECS = 30
+const bitcoinChartCache = new Map<string, LivelinePoint[]>()
 
 export default function BitcoinDetail() {
   const { config } = useContext(ConfigContext)
-  const { convertFiat, fiatDecimals, toFiat } = useContext(FiatContext)
+  const { fiatDecimals, toFiat } = useContext(FiatContext)
   const { setRecvInfo, setSendInfo } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
   const { balance } = useContext(WalletContext)
@@ -51,15 +52,16 @@ export default function BitcoinDetail() {
   const chartHapticState = useRef({ lastPointTime: 0, lastTriggerTime: 0 })
 
   const fallbackUnitPrice = toFiat(100_000_000)
-  const liveChartData = useBitcoinMarketChartData(config.fiat, chartWindow, convertFiat)
+  const liveChartData = useBitcoinMarketChartData(config.fiat, chartWindow)
   const unitPrice = liveChartData.at(-1)?.value ?? fallbackUnitPrice
   const fiatValue = (balance / 100_000_000) * unitPrice
   const formattedFiat = prettyFiatAmount(fiatValue, config.fiat, {
     maximumFractionDigits: fiatDecimals(),
     minimumFractionDigits: fiatDecimals(),
   })
-  const chartColor = useTokenColor('--orange-500')
+  const chartColor = useTokenColor('--orange-500', config.theme)
   const chartTheme = useResolvedChartTheme(config.theme)
+  const safeBalance = Number.isFinite(balance) ? Math.max(0, Math.floor(balance)) : 0
   const chartData = useMemo(
     () => (liveChartData.length ? liveChartData : buildFlatChartData(unitPrice, chartWindow)),
     [chartWindow, liveChartData, unitPrice],
@@ -253,7 +255,7 @@ export default function BitcoinDetail() {
                     <TokenLogo ticker='BTC' />
                   </span>
                   <PrivacyAmount masked='•••• BTC'>
-                    <span className='asset-detail-holding-amount'>{formatAssetAmount(BigInt(balance), 8)}</span>
+                    <span className='asset-detail-holding-amount'>{formatAssetAmount(BigInt(safeBalance), 8)}</span>
                     <span className='asset-detail-holding-unit'>BTC</span>
                   </PrivacyAmount>
                 </strong>
@@ -347,14 +349,14 @@ function DeltaBadge({ value }: { value: number }) {
   )
 }
 
-function useTokenColor(token: string): string {
+function useTokenColor(token: string, theme: Themes): string {
   const [color, setColor] = useState(`var(${token})`)
 
   useEffect(() => {
     const root = getComputedStyle(document.documentElement)
     const next = root.getPropertyValue(token).trim()
     if (next) setColor(next)
-  }, [token])
+  }, [theme, token])
 
   return color
 }
@@ -375,17 +377,20 @@ function useResolvedChartTheme(theme: Themes): 'light' | 'dark' {
   return resolved
 }
 
-function useBitcoinMarketChartData(
-  fiat: Fiats,
-  windowSecs: number,
-  convertFiat: (amount: number, from: Fiats) => number,
-): LivelinePoint[] {
+function useBitcoinMarketChartData(fiat: Fiats, windowSecs: number): LivelinePoint[] {
   const [data, setData] = useState<LivelinePoint[]>([])
 
   useEffect(() => {
     const controller = new AbortController()
+    const cacheKey = bitcoinChartCacheKey(fiat, windowSecs)
+    const cached = bitcoinChartCache.get(cacheKey)
 
-    fetchBitcoinMarketChart(fiat, windowSecs, convertFiat, controller.signal)
+    if (cached) {
+      setData(cached)
+      return () => controller.abort()
+    }
+
+    fetchBitcoinMarketChart(fiat, windowSecs, controller.signal)
       .then((json) => {
         if (controller.signal.aborted) return
         const prices = Array.isArray(json.prices) ? json.prices : []
@@ -394,13 +399,16 @@ function useBitcoinMarketChartData(
           .filter((point) => Number.isFinite(point.time) && Number.isFinite(point.value) && point.value > 0)
 
         if (isAllChartWindow(windowSecs)) {
+          bitcoinChartCache.set(cacheKey, points)
           setData(points)
           return
         }
 
         const cutoff = Math.floor(Date.now() / 1000) - windowSecs
         const windowedPoints = points.filter((point) => point.time >= cutoff)
-        setData(windowedPoints.length >= 2 ? windowedPoints : points)
+        const nextData = windowedPoints.length >= 2 ? windowedPoints : points
+        bitcoinChartCache.set(cacheKey, nextData)
+        setData(nextData)
       })
       .catch((err) => {
         if (controller.signal.aborted) return
@@ -409,7 +417,7 @@ function useBitcoinMarketChartData(
       })
 
     return () => controller.abort()
-  }, [fiat, windowSecs, convertFiat])
+  }, [fiat, windowSecs])
 
   return data
 }
@@ -417,32 +425,26 @@ function useBitcoinMarketChartData(
 async function fetchBitcoinMarketChart(
   fiat: Fiats,
   windowSecs: number,
-  convertFiat: (amount: number, from: Fiats) => number,
   signal: AbortSignal,
 ): Promise<{ prices?: [number, number][] }> {
-  if (isAllChartWindow(windowSecs)) {
-    const prices = await fetchCoinbaseBitcoinAllChart(fiat, convertFiat, signal)
+  if (isAllChartWindow(windowSecs) && fiat === Fiats.USD) {
+    const prices = await fetchCoinbaseBitcoinAllChart(signal)
     if (prices.length >= 2) return { prices }
   }
 
   return fetchCoinGeckoBitcoinChart(fiat, windowSecs, signal)
 }
 
-async function fetchCoinbaseBitcoinAllChart(
-  fiat: Fiats,
-  convertFiat: (amount: number, from: Fiats) => number,
-  signal: AbortSignal,
-): Promise<[number, number][]> {
+async function fetchCoinbaseBitcoinAllChart(signal: AbortSignal): Promise<[number, number][]> {
   const now = Math.floor(Date.now() / 1000)
   const chunkSecs = COINBASE_CANDLE_CHUNK_DAYS * 86_400
-  const requests: Promise<[number, number][]>[] = []
+  const chunks: [number, number][][] = []
 
   for (let start = ALL_CHART_START_TIME; start < now; start += chunkSecs) {
     const end = Math.min(start + chunkSecs, now)
-    requests.push(fetchCoinbaseBitcoinCandles(start, end, fiat, convertFiat, signal))
+    chunks.push(await fetchCoinbaseBitcoinCandles(start, end, signal))
   }
 
-  const chunks = await Promise.all(requests)
   return chunks
     .flat()
     .sort(([a], [b]) => a - b)
@@ -452,8 +454,6 @@ async function fetchCoinbaseBitcoinAllChart(
 async function fetchCoinbaseBitcoinCandles(
   start: number,
   end: number,
-  fiat: Fiats,
-  convertFiat: (amount: number, from: Fiats) => number,
   signal: AbortSignal,
 ): Promise<[number, number][]> {
   const params = new URLSearchParams({
@@ -469,10 +469,7 @@ async function fetchCoinbaseBitcoinCandles(
   const candles = (await response.json()) as [number, number, number, number, number, number][]
 
   return candles
-    .map(
-      ([time, , , , close]) =>
-        [time * 1000, fiat === Fiats.USD ? close : convertFiat(close, Fiats.USD)] as [number, number],
-    )
+    .map(([time, , , , close]) => [time * 1000, close] as [number, number])
     .filter(([, value]) => Number.isFinite(value) && value > 0)
 }
 
@@ -595,8 +592,12 @@ function calculateDelta(data: LivelinePoint[]): number {
   return ((last - first) / first) * 100
 }
 
+function bitcoinChartCacheKey(fiat: Fiats, windowSecs: number): string {
+  return `${fiat}:${windowSecs}`
+}
+
 function coinGeckoDaysForWindow(windowSecs: number): string[] {
-  if (isAllChartWindow(windowSecs)) return ['365']
+  if (isAllChartWindow(windowSecs)) return ['max']
   if (windowSecs <= 3_600) return ['1']
   if (windowSecs <= 86_400) return ['1']
   if (windowSecs <= 604_800) return ['7']

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -45,7 +45,7 @@ export default function BitcoinDetail() {
   const { balance } = useContext(WalletContext)
   const prefersReduced = useReducedMotion()
 
-  const [chartWindow, setChartWindow] = useState(CHART_WINDOWS[0].secs)
+  const [chartWindow, setChartWindow] = useState(CHART_WINDOWS[2].secs)
   const [chartInteracting, setChartInteracting] = useState(false)
   const [swapSheetOpen, setSwapSheetOpen] = useState(false)
   const chartHapticState = useRef({ lastPointTime: 0, lastTriggerTime: 0 })

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -393,7 +393,6 @@ function useBitcoinMarketChartData(fiat: Fiats, windowSecs: number): LivelinePoi
     fetchHistoricalMarketData(windowSecs, fiat)
       .then((points) => {
         if (controller.signal.aborted) return
-        console.log('point', points)
         bitcoinChartCache.set(cacheKey, points)
         setData(points)
       })

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -205,6 +205,7 @@ export default function BitcoinDetail() {
                     badgeVariant='minimal'
                     formatValue={(value) => prettyFiatAmount(value, config.fiat)}
                     grid={false}
+                    paused={chartInteracting}
                     pulse={!prefersReduced}
                     scrub={!prefersReduced}
                     momentum={false}

--- a/src/screens/Wallet/HomeQuickActions.tsx
+++ b/src/screens/Wallet/HomeQuickActions.tsx
@@ -4,8 +4,7 @@ import ReceiveIcon from '../../icons/Receive'
 import ScanIcon from '../../icons/Scan'
 import SendIcon from '../../icons/Send'
 import SwapIcon from '../../icons/Swap'
-import Button from '../../components/Button'
-import SheetModal from '../../components/SheetModal'
+import SwapComingSoonSheet from '../../components/SwapComingSoonSheet'
 import { emptyRecvInfo, emptySendInfo, FlowContext } from '../../providers/flow'
 import { NavigationContext, Pages } from '../../providers/navigation'
 import { homeActionStaggerChild, homeActionStaggerContainer } from '../../lib/animations'
@@ -115,24 +114,5 @@ export default function HomeQuickActions() {
       </motion.div>
       <SwapComingSoonSheet isOpen={swapSheetOpen} onClose={() => setSwapSheetOpen(false)} />
     </>
-  )
-}
-
-function SwapComingSoonSheet({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
-  return (
-    <SheetModal isOpen={isOpen} onClose={onClose}>
-      <div className='swap-coming-soon' data-testid='swap-coming-soon-sheet'>
-        <div className='swap-coming-soon__icon' aria-hidden='true'>
-          <SwapIcon />
-        </div>
-        <div className='swap-coming-soon__copy'>
-          <h2 className='swap-coming-soon__title'>Swaps are coming soon</h2>
-          <p className='swap-coming-soon__description'>
-            We are polishing the swap experience before turning it on here.
-          </p>
-        </div>
-        <Button label='Got it' onClick={onClose} />
-      </div>
-    </SheetModal>
   )
 }

--- a/src/test/e2e/send.test.ts
+++ b/src/test/e2e/send.test.ts
@@ -1,4 +1,3 @@
-import { wait } from '@testing-library/user-event/dist/cjs/utils/index.js'
 import { prettyNumber } from '../../lib/format'
 import {
   test,
@@ -303,7 +302,7 @@ test('should send usds (some and max) to onchain address with chain swap', async
 
   const balanceText = await page.getByTestId('main-balance').textContent()
   const balance = Number((balanceText ?? '').replace(/[^\d.-]/g, '') || '0')
-  expect(balance).toBe(usdsReceived - totalSent)
+  expect(balance.toFixed(2)).toBe((usdsReceived - totalSent).toFixed(2))
 
   // go to send page
   await page.getByText('Send').click()
@@ -324,7 +323,7 @@ test('should send usds (some and max) to onchain address with chain swap', async
 
   await page.getByText('Tap to Sign').click()
   await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
-  await expect(page.getByText(`${balance.toFixed(2)} sent successfully`)).toBeVisible()
+  await expect(page.getByText(`$${balance.toFixed(2)} sent successfully`)).toBeVisible()
 
   // main page
   await page.getByText('Sounds good').click()

--- a/src/test/e2e/send.test.ts
+++ b/src/test/e2e/send.test.ts
@@ -1,3 +1,4 @@
+import { wait } from '@testing-library/user-event/dist/cjs/utils/index.js'
 import { prettyNumber } from '../../lib/format'
 import {
   test,
@@ -95,7 +96,7 @@ test('should send usds (some and max) to ark address', async ({ page, isMobile }
 
   // main page
   await page.getByText('Sounds good').click()
-  await page.waitForSelector('text=$2.00', { timeout: 4000 })
+  await page.waitForSelector('text=$2.00', { timeout: 10000 })
   await expect(page.getByText('Sent')).toBeVisible()
 
   // go to send page
@@ -121,7 +122,7 @@ test('should send usds (some and max) to ark address', async ({ page, isMobile }
 
   // main page
   await page.getByText('Sounds good').click()
-  await page.waitForSelector(`text=- $${usdsRemaining}`, { timeout: 10000 })
+  await page.waitForSelector(`text=$${usdsRemaining}`, { timeout: 10000 })
 })
 
 test('should send assets (some and max) to ark address', async ({ page, isMobile }) => {
@@ -230,6 +231,10 @@ test('should send sats (some and max) to onchain address with chain swap', async
 
   // details page
   await expect(page.getByTestId('Amount')).toContainText('2,000 SATS')
+  const fees = await page.getByTestId('Network fees').textContent()
+  expect(fees).not.toBeNull()
+  const feesNumber = parseInt(fees!.replace(/[^0-9]/g, ''), 10)
+  expect(feesNumber).toBeGreaterThan(0)
 
   await page.getByText('Tap to Sign').click()
   await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
@@ -238,8 +243,7 @@ test('should send sats (some and max) to onchain address with chain swap', async
   await page.getByText('Sounds good').click()
   await page.waitForSelector('text=Sent', { timeout: 10000 })
 
-  const balanceText = await page.getByTestId('main-balance').textContent()
-  const balance = parseInt(balanceText?.replace(/[^0-9]/g, '') || '0', 10)
+  const balance = 5000 - feesNumber - 2000
   expect(balance).toBeLessThan(3000) // balance should be less than 3000 sats
 
   // go to send page
@@ -280,21 +284,26 @@ test('should send usds (some and max) to onchain address with chain swap', async
   await prePay(page, someOnchainAddress, isMobile, usdsToSend)
 
   // details page
-  await expect(page.getByTestId('Amount')).toContainText('$2.00')
+  await expect(page.getByTestId('Amount')).toContainText(`$${usdsToSend.toFixed(2)}`)
+  const fees = await page.getByTestId('Network fees').textContent()
+  expect(fees).not.toBeNull()
+  const feesNumber = parseFloat(fees!.replace(/[^0-9.]/g, ''))
+  expect(feesNumber).toBeGreaterThan(0)
+  const totalSent = usdsToSend + feesNumber
 
   await page.getByText('Tap to Sign').click()
   await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
   await page.waitForSelector('text=Payment sent!', { timeout: 30000 })
-  await expect(page.getByText(/\$[\d\,\.]+ sent successfully/)).toBeVisible()
+  await expect(page.getByText(`$${totalSent.toFixed(2)} sent successfully`)).toBeVisible()
 
   // main page
   await page.getByText('Sounds good').click()
-  await expect(page.getByText(/\- \$[\d\,\.]+/)).toBeVisible()
+  await expect(page.getByText(`$${totalSent.toFixed(2)}`)).toBeVisible()
   await expect(page.getByText('Sent')).toBeVisible()
 
   const balanceText = await page.getByTestId('main-balance').textContent()
   const balance = Number((balanceText ?? '').replace(/[^\d.-]/g, '') || '0')
-  expect(balance).toBeLessThan(usdsReceived)
+  expect(balance).toBe(usdsReceived - totalSent)
 
   // go to send page
   await page.getByText('Send').click()
@@ -315,11 +324,11 @@ test('should send usds (some and max) to onchain address with chain swap', async
 
   await page.getByText('Tap to Sign').click()
   await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
-  await expect(page.getByText(/\$[\d\,\.]+ sent successfully/)).toBeVisible()
+  await expect(page.getByText(`${balance.toFixed(2)} sent successfully`)).toBeVisible()
 
   // main page
   await page.getByText('Sounds good').click()
-  await expect(page.getByText(`- $${balance.toFixed(2)}`)).toBeVisible()
+  await page.waitForSelector('text=$0.00', { timeout: 10000 })
 })
 
 // wallet balance is 5000 sats,
@@ -343,19 +352,25 @@ test('should send sats (some and max) to onchain address with collaborative exit
 
   // details page
   await expect(page.getByTestId('Amount')).toContainText('700 SATS')
+  const fees = await page.getByTestId('Network fees').textContent()
+  expect(fees).not.toBeNull()
+  const feesNumber = parseInt(fees!.replace(/[^0-9]/g, ''), 10)
+  expect(feesNumber).toBeGreaterThan(0)
+  const totalSent = 700 + feesNumber
 
   await page.getByText('Tap to Sign').click()
   await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
-  await page.waitForSelector('text=sent successfully', { timeout: 20000 })
+  await page.waitForSelector('text=Payment sent!', { timeout: 30000 })
+  await expect(page.getByText(`${totalSent} SATS sent successfully`)).toBeVisible()
 
   // main page
   await page.getByText('Sounds good').click()
   await expect(page.getByText('Received')).toBeVisible()
   await expect(page.getByText('1,800 SATS')).toBeVisible()
   await page.waitForSelector('text=Sent', { timeout: 10000 })
+  await expect(page.getByText(`${totalSent} SATS`)).toBeVisible()
 
-  const balanceText = await page.getByTestId('main-balance').textContent()
-  const balance = parseInt(balanceText?.replace(/[^0-9]/g, '') || '0', 10)
+  const balance = 1800 - totalSent
 
   // go to send page
   await page.getByText('Send').click()
@@ -372,15 +387,15 @@ test('should send sats (some and max) to onchain address with collaborative exit
   await page.getByText('Continue').click()
 
   // details page
-  await expect(page.getByTestId('Total')).toContainText(`${prettyNumber(balance)} SATS`)
+  await expect(page.getByTestId('Total')).toContainText(`${balance} SATS`)
 
   await page.getByText('Tap to Sign').click()
   await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
-  await page.waitForSelector(`text=${prettyNumber(balance)} SATS sent successfully`, { timeout: 20000 })
+  await page.waitForSelector(`text=${balance} SATS sent successfully`, { timeout: 20000 })
 
   // main page
   await page.getByText('Sounds good').click()
-  await page.waitForSelector(`text=- ${prettyNumber(balance)} SATS`, { timeout: 10000 })
+  await page.waitForSelector(`text=- ${balance} SATS`, { timeout: 10000 })
 
   // clear fees
   execSync('docker exec -t arkd arkd fees clear')

--- a/src/test/screens/wallet/bitcoin-detail.test.tsx
+++ b/src/test/screens/wallet/bitcoin-detail.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import BitcoinDetail from '../../../screens/Wallet/BitcoinDetail'
+import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import { FlowContext } from '../../../providers/flow'
+import { NavigationContext } from '../../../providers/navigation'
+import { WalletContext } from '../../../providers/wallet'
+import {
+  mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockNavigationContextValue,
+  mockWalletContextValue,
+} from '../mocks'
+
+vi.mock('liveline', () => ({
+  Liveline: ({ paused }: { paused?: boolean }) => <div data-testid='liveline-chart' data-paused={String(paused)} />,
+}))
+
+describe('Bitcoin detail screen', () => {
+  it('pauses the liveline chart while the pointer is hovering it', async () => {
+    const ResizeObserverMock = vi.fn(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }))
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          prices: [
+            [Date.now() - 3_600_000, 77_000],
+            [Date.now(), 78_000],
+          ],
+        }),
+      }),
+    )
+
+    const { container } = render(
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <FlowContext.Provider value={mockFlowContextValue}>
+            <NavigationContext.Provider value={mockNavigationContextValue}>
+              <WalletContext.Provider value={mockWalletContextValue}>
+                <BitcoinDetail />
+              </WalletContext.Provider>
+            </NavigationContext.Provider>
+          </FlowContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    expect(screen.getByTestId('liveline-chart')).toHaveAttribute('data-paused', 'false')
+
+    const chart = container.querySelector('.asset-detail-chart')
+    expect(chart).not.toBeNull()
+
+    fireEvent.pointerEnter(chart!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('liveline-chart')).toHaveAttribute('data-paused', 'true')
+    })
+
+    fireEvent.pointerLeave(chart!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('liveline-chart')).toHaveAttribute('data-paused', 'false')
+    })
+  })
+})

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import Wallet from '../../../screens/Wallet/Index'
+import { NavigationContext, Pages } from '../../../providers/navigation'
+import { mockNavigationContextValue } from '../mocks'
 
 describe('Wallet screen', () => {
   it('renders the wallet screen with the correct elements', async () => {
@@ -18,5 +20,19 @@ describe('Wallet screen', () => {
     expect(screen.getByText('Bitcoin')).toBeInTheDocument()
     expect(screen.queryByText('Recent activity')).not.toBeInTheDocument()
     expect(screen.queryByText('No transactions yet')).not.toBeInTheDocument()
+  })
+
+  it('opens the bitcoin detail page from the bitcoin asset row', async () => {
+    const user = userEvent.setup()
+    const navigate = vi.fn()
+
+    render(
+      <NavigationContext.Provider value={{ ...mockNavigationContextValue, navigate }}>
+        <Wallet />
+      </NavigationContext.Provider>,
+    )
+
+    await user.click(screen.getByTestId('asset-row-BTC'))
+    expect(navigate).toHaveBeenCalledWith(Pages.BitcoinDetail)
   })
 })


### PR DESCRIPTION
## Summary
- Add a bitcoin-only wallet detail page opened from the bitcoin asset row on the redesigned home screen.
- Bring over the draft PR's Liveline-based price chart treatment with current bitcoin price, percentage movement badge, range tabs, holdings balance/value, and bitcoin-filtered recent activity.
- Share the existing Vaul-backed swap coming-soon drawer between the home quick action and the bitcoin detail Swap action.

## Affected files and components
- `src/screens/Wallet/BitcoinDetail.tsx` adds the bitcoin detail screen and chart/price data handling.
- `src/screens/Wallet/AssetsSection.tsx` routes the bitcoin row into the detail page.
- `src/components/SwapComingSoonSheet.tsx` centralizes the PR 627 swap coming-soon drawer.
- `src/providers/navigation.tsx` registers the bitcoin detail route under the wallet tab.
- `src/index.css` adds the detail page styles ported from the draft approach.
- `package.json`, `bun.lock`, and `pnpm-lock.yaml` add `liveline`.

## Testing
- `bunx vitest run src/test/screens/wallet/index.test.tsx`
- `bun run lint`
- `bun run build`
- Playwright smoke check against `wt-bitcoin-detail-page-20260521.arkade.localhost`: clicked the bitcoin row, confirmed the detail page rendered with a chart canvas and Receive/Send/Swap/Scan actions, and verified Swap opens the coming-soon drawer.
