### PR TITLE
don't check lnUrl conditions if ark address is present

### DIFF
--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -12,7 +12,7 @@ export default function ErrorMessage({ error, text }: ErrorProps) {
   return (
     <Shadow red>
       <Padded>
-        <Text bold centered color='white' small wrap>
+        <Text bold centered color='white' small wrap testId='error-message'>
           {text}
         </Text>
       </Padded>

--- a/src/lib/bip21.ts
+++ b/src/lib/bip21.ts
@@ -81,12 +81,12 @@ export const decodeBip21 = (uri: string): Bip21Decoded => {
 }
 
 export const encodeBip21 = (address: string, arkAddress: string, invoice: string, sats: number, lnurl?: string) => {
-  return (
-    `bitcoin:${address}` +
-    `?ark=${arkAddress}` +
-    (invoice ? `&lightning=${invoice}` : lnurl ? `&lightning=${lnurl}` : '') +
-    (sats ? `&amount=${prettyNumber(fromSatoshis(sats))}` : '')
-  )
+  const bip21 =
+    `bitcoin:${address}?` +
+    (arkAddress ? `ark=${arkAddress}&` : '') +
+    (invoice ? `lightning=${invoice}&` : lnurl ? `lightning=${lnurl}&` : '') +
+    (sats ? `amount=${prettyNumber(fromSatoshis(sats))}` : '')
+  return bip21.endsWith('&') || bip21.endsWith('?') ? bip21.slice(0, -1) : bip21
 }
 
 export const encodeBip21Asset = (arkAddress: string, assetId: string, cents: bigint, decimals?: number) => {

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -376,7 +376,7 @@ export default function SendForm() {
         consoleError(e, 'Error checking LNURL conditions')
         setError(extractError(e))
       })
-  }, [sendInfo.lnUrl])
+  }, [sendInfo.arkAddress, sendInfo.lnUrl])
 
   // check if user wants to send all funds
   useEffect(() => {

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -362,6 +362,7 @@ export default function SendForm() {
   // check lnurl conditions
   useEffect(() => {
     if (!sendInfo.lnUrl) return
+    if (sendInfo.arkAddress) return
     if (sendInfo.lnUrl && sendInfo.invoice) return
     checkLnUrlConditions(sendInfo.lnUrl)
       .then((conditions) => {

--- a/src/test/e2e/bip21.test.ts
+++ b/src/test/e2e/bip21.test.ts
@@ -1,19 +1,7 @@
-import { test, expect, createWallet, readClipboard, handleKeyboardInput } from './utils'
+import { test, expect, readClipboard, handleKeyboardInput, createWalletAndGetBIP21 } from './utils'
 import { decodeInvoice } from '../../lib/bolt11'
-import { Page } from '@playwright/test'
 import { decodeBip21, isBip21 } from '../../lib/bip21'
 import { sleep } from '../../lib/sleep'
-
-const createWalletAndGetBIP21 = async (page: Page): Promise<string> => {
-  await createWallet(page)
-  await page.getByTestId('tab-wallet').click()
-  await page.getByText('Receive', { exact: true }).click()
-  await sleep(1000) // wait for the receive page to load
-  await page.getByText('Copy').click()
-  await page.getByTestId('bip21-address-copy').click()
-  const bip21 = await readClipboard(page)
-  return bip21
-}
 
 test('should generate valid BIP21 out of the box', async ({ page }) => {
   // create wallet

--- a/src/test/e2e/form.test.ts
+++ b/src/test/e2e/form.test.ts
@@ -1,0 +1,97 @@
+import { decodeBip21, encodeBip21 } from '../../lib/bip21'
+import { sleep } from '../../lib/sleep'
+import {
+  test,
+  expect,
+  prePay,
+  fundWallet,
+  resetWallet,
+  createWallet,
+  getInvoiceFromLND,
+  createWalletAndGetBIP21,
+  handleKeyboardInput,
+} from './utils'
+
+const someArkAddress =
+  'tark1qr340xg400jtxat9hdd0ungyu6s05zjtdf85uj9smyzxshf98nda' +
+  'h6u2nredqtn0cr4p4zqz53gsmhju4l9t7x47kzleesa9dprx7e56xhzlen'
+
+const someOnchainAddress = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+
+const someLnUrl =
+  'LNURL1DP68GUP69UHKCMMRV9KXSMMNWSARJVPEXQHKCMN4WFKZ7D3JXY6NGWFEVYMN2D3JX33KZVF5VD3RJDEK8P3KXEFJVYMNXVNXSG08CU'
+
+const someInvoice =
+  'lnbcrt21u1p5tqtaypp56yzglgfgwsm5pd49996jqvtmpf8fqdk7cq2znnjw5c2j5t8ua38q' +
+  'dql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp586s5vpsdxt05rm7hr6ycwq5ff' +
+  'mnx2gngv820seugky6j6z2wxqwq9qxpqysgqepuxr82pvlp8lgj7nqu8yp2f5q32323jxddx' +
+  '9qgtjhfhsyzvftgkwx8qv4772fzz46pwyw5ex3u7lf7na8a8403ur3gyeu22gv29rpspefzz2y'
+
+test('should prioritize Arkade addresses over others', async ({ page, isMobile }) => {
+  // create wallet
+  await createWallet(page)
+  await fundWallet(page, 5000)
+
+  const bip21 = encodeBip21(someOnchainAddress, someArkAddress, someInvoice, 0, someLnUrl)
+
+  // send page
+  await prePay(page, bip21, isMobile, 2000)
+
+  // details page
+  await expect(page.getByTestId('Direction')).toContainText('Paying inside Arkade')
+  await expect(page.getByTestId('Network fees')).toContainText('0 SATS')
+  await expect(page.getByTestId('Amount')).toContainText('2,000 SATS')
+  await expect(page.getByTestId('Total')).toContainText('2,000 SATS')
+})
+
+test('should prioritize lightning invoice if no ark address present', async ({ page }) => {
+  // create wallet
+  await createWallet(page)
+  await fundWallet(page, 5000)
+
+  // get invoice
+  const invoice = await getInvoiceFromLND(2100)
+  const bip21 = encodeBip21(someOnchainAddress, '', invoice, 2100, someLnUrl)
+
+  // send page
+  await prePay(page, bip21)
+
+  // details page
+  await expect(page.getByTestId('Direction')).toContainText('Swapping to Lightning')
+  await expect(page.getByTestId('Network fees')).toContainText('1 SAT')
+  await expect(page.getByTestId('Amount')).toContainText('2,100 SATS')
+  await expect(page.getByTestId('Total')).toContainText('2,101 SATS')
+})
+
+test('should prioritize lnurl if no invoice or ark address are present', async ({ page, isMobile }) => {
+  const bip21 = await createWalletAndGetBIP21(page)
+  const { lnUrl } = decodeBip21(bip21)
+  expect(lnUrl).toBeDefined()
+  const bip21WithLnUrl = encodeBip21(someOnchainAddress, '', '', 0, lnUrl)
+
+  await resetWallet(page)
+  await sleep(1000)
+
+  // create wallet
+  await createWallet(page)
+  await fundWallet(page, 5000)
+
+  // send page
+  // go to send page
+  await page.getByTestId('tab-wallet').click()
+  await page.getByText('Send').click()
+
+  // fill address
+  await page.locator('input[name="send-address"]').fill(bip21WithLnUrl)
+
+  // fill amount
+  if (isMobile) {
+    await page.locator('input[name="send-amount"]').click()
+    await handleKeyboardInput(page, 2100)
+  } else {
+    await page.locator('input[name="send-amount"]').fill('2100')
+  }
+
+  // lnurl error because the wallet that used this lnurl is no longer running
+  await expect(page.getByTestId('error-message')).toContainText('This LNURL is no longer active')
+})

--- a/src/test/e2e/nostr.test.ts
+++ b/src/test/e2e/nostr.test.ts
@@ -6,6 +6,7 @@ import {
   receiveLightning,
   resetAndRestoreWallet,
   waitForPaymentReceived,
+  getInvoiceFromLND,
 } from './utils'
 import { exec } from 'child_process'
 import { promisify } from 'util'
@@ -107,13 +108,7 @@ test('should save swaps to nostr', async ({ page, isMobile }) => {
   await sleep(3000)
 
   // generate lightning invoice to pay
-  const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt 1000`)
-  const output = stdout.trim()
-  expect(output).toBeDefined()
-  expect(output).toBeTruthy()
-  const outputJSON = JSON.parse(output)
-  expect('payment_request' in outputJSON).toBeTruthy()
-  const sendInvoice = outputJSON.payment_request
+  const sendInvoice = await getInvoiceFromLND(1000)
   expect(sendInvoice).toBeDefined()
   expect(sendInvoice).toBeTruthy()
   expect(sendInvoice).toContain('lnbcrt')

--- a/src/test/e2e/restore.test.ts
+++ b/src/test/e2e/restore.test.ts
@@ -8,6 +8,7 @@ import {
   receiveLightning,
   resetAndRestoreWallet,
   waitForPaymentReceived,
+  getInvoiceFromLND,
 } from './utils'
 import { sleep } from '../../lib/sleep'
 
@@ -63,13 +64,7 @@ test('should restore swaps without nostr backup', async ({ page, isMobile }) => 
    */
 
   // create invoice with lnd
-  const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt 1000`)
-  const output = stdout.trim()
-  expect(output).toBeDefined()
-  expect(output).toBeTruthy()
-  const outputJSON = JSON.parse(output)
-  expect('payment_request' in outputJSON).toBeTruthy()
-  const paymentRequest = outputJSON.payment_request
+  const paymentRequest = await getInvoiceFromLND(1000)
   expect(paymentRequest).toBeDefined()
   expect(paymentRequest).toBeTruthy()
   expect(paymentRequest).toContain('lnbcrt')

--- a/src/test/e2e/swap.test.ts
+++ b/src/test/e2e/swap.test.ts
@@ -188,7 +188,7 @@ test('should refund failing swap', async ({ page }) => {
   expect(output).toBeTruthy()
   const outputJSON = JSON.parse(output)
   expect('payment_request' in outputJSON).toBeTruthy()
-  const invoice = await getInvoiceFromLND(1000)
+  const invoice = outputJSON.payment_request
   expect(invoice).toBeDefined()
   expect(invoice).toBeTruthy()
   expect(invoice).toContain('lnbcrt')

--- a/src/test/e2e/swap.test.ts
+++ b/src/test/e2e/swap.test.ts
@@ -1,5 +1,14 @@
 import { prettyLongText } from '../../lib/format'
-import { test, expect, createWallet, pay, receiveLightning, waitForPaymentReceived, fundWallet } from './utils'
+import {
+  test,
+  expect,
+  createWallet,
+  pay,
+  receiveLightning,
+  waitForPaymentReceived,
+  fundWallet,
+  getInvoiceFromLND,
+} from './utils'
 import { exec } from 'child_process'
 import { promisify } from 'util'
 
@@ -73,9 +82,7 @@ test('should receive funds from Lightning', async ({ page, isMobile }) => {
 test('should raise error when trying to pay invoice with little amount', async ({ page }) => {
   await createWallet(page)
 
-  const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt 21`)
-  const outputJSON = JSON.parse(stdout.trim())
-  const invoice = outputJSON.payment_request
+  const invoice = await getInvoiceFromLND(21)
   expect(invoice).toBeDefined()
   expect(invoice).toBeTruthy()
   expect(invoice).toContain('lnbcrt')
@@ -93,13 +100,7 @@ test('should send funds to Lightning', async ({ page }) => {
   await createWallet(page)
   await fundWallet(page, 5000)
 
-  const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt 1000`)
-  const output = stdout.trim()
-  expect(output).toBeDefined()
-  expect(output).toBeTruthy()
-  const outputJSON = JSON.parse(output)
-  expect('payment_request' in outputJSON).toBeTruthy()
-  const invoice = outputJSON.payment_request
+  const invoice = await getInvoiceFromLND(1000)
   expect(invoice).toBeDefined()
   expect(invoice).toBeTruthy()
   expect(invoice).toContain('lnbcrt')
@@ -187,7 +188,7 @@ test('should refund failing swap', async ({ page }) => {
   expect(output).toBeTruthy()
   const outputJSON = JSON.parse(output)
   expect('payment_request' in outputJSON).toBeTruthy()
-  const invoice = outputJSON.payment_request
+  const invoice = await getInvoiceFromLND(1000)
   expect(invoice).toBeDefined()
   expect(invoice).toBeTruthy()
   expect(invoice).toContain('lnbcrt')

--- a/src/test/e2e/utils.ts
+++ b/src/test/e2e/utils.ts
@@ -1,6 +1,10 @@
 import { test as base, type Page } from '@playwright/test'
 import { faucetOffchain } from './fundedWallet'
 import { sleep } from '../../lib/sleep'
+import { exec } from 'child_process'
+import { promisify } from 'util'
+
+const execAsync = promisify(exec)
 
 export const test = base.extend({
   page: async ({ page }, use) => {
@@ -129,6 +133,36 @@ export async function createWalletWithPassword(page: Page, password: string): Pr
   await page.getByTestId('tab-settings').click()
 }
 
+export async function createWalletAndGetBIP21(page: Page, isMobile?: boolean, sats?: number): Promise<string> {
+  await createWallet(page)
+  await page.getByTestId('tab-wallet').click()
+  await page.getByText('Receive', { exact: true }).click()
+
+  if (sats) {
+    await page.getByText('Edit amount').click()
+    if (isMobile) {
+      await handleKeyboardInput(page, sats)
+    } else {
+      await page.locator('input[name="receive-amount-sheet"]').fill(sats.toString())
+      await page.getByText('Set amount').click()
+    }
+  }
+
+  await page.waitForSelector('text=Copy', { state: 'visible' })
+  await page.getByText('Copy').click()
+  await page.getByTestId('bip21-address-copy').click()
+  const bip21 = await readClipboard(page)
+  return bip21
+}
+
+export async function getInvoiceFromLND(amount = 2100): Promise<string> {
+  const { stdout } = await execAsync(`docker exec lnd lncli --network=regtest addinvoice --amt ${amount}`)
+  const output = stdout.trim()
+  const outputJSON = JSON.parse(output)
+  const invoice = outputJSON.payment_request
+  return invoice
+}
+
 export async function prePay(page: Page, address: string, isMobile = false, sats = 0): Promise<void> {
   // go to send page
   await page.getByTestId('tab-wallet').click()
@@ -196,6 +230,13 @@ export async function receiveLightning(page: Page, isMobile: boolean, sats: numb
   return receive(page, 'invoice', isMobile, sats)
 }
 
+export async function resetWallet(page: Page): Promise<void> {
+  await navigateToSettings(page)
+  await page.getByText('Reset wallet').click()
+  await page.getByTestId('checkbox').click()
+  await page.getByRole('contentinfo').getByText('Reset wallet').click()
+}
+
 async function navigateToSettings(page: Page): Promise<void> {
   // If on a settings sub-page, go back until we reach the settings menu
   const backBtn = page.getByLabel('Go back')
@@ -227,13 +268,6 @@ async function getSecret(page: Page): Promise<string> {
   await page.getByText('Confirm').click()
   const secret = await page.getByTestId('private-key').innerText()
   return secret
-}
-
-async function resetWallet(page: Page): Promise<void> {
-  await navigateToSettings(page)
-  await page.getByText('Reset wallet').click()
-  await page.getByTestId('checkbox').click()
-  await page.getByRole('contentinfo').getByText('Reset wallet').click()
 }
 
 async function restoreWallet(page: Page, nsec: string): Promise<void> {

--- a/src/test/lib/bip21.test.ts
+++ b/src/test/lib/bip21.test.ts
@@ -25,6 +25,19 @@ describe('bip21 utilities', () => {
       expect(satoshis).toBeUndefined()
     })
 
+    it('should decode a valid bip21 without ark address', () => {
+      const bip21 =
+        'BITCOIN:bcrt1pq6gt72nxevsxk5fwl3h2sx56jeah6qfzh98mksxyakkg5l0q65gsa27khh?LIGHTNING=LNURL1DP68GURN8GHJ7MRWW4EXCTNPWF4KZER99EEKSTMVDE6HYMP0VG6N2VMXX4SKXC33XYEXVVTYXUMNXEFCXQCXYEP5X9JKZCMZXVESU28Y7U'
+      const { address, arkAddress, invoice, lnUrl, satoshis } = decodeBip21(bip21)
+      expect(address).toBe('bcrt1pq6gt72nxevsxk5fwl3h2sx56jeah6qfzh98mksxyakkg5l0q65gsa27khh')
+      expect(arkAddress).toBeUndefined()
+      expect(invoice).toBeUndefined()
+      expect(lnUrl).toBe(
+        'LNURL1DP68GURN8GHJ7MRWW4EXCTNPWF4KZER99EEKSTMVDE6HYMP0VG6N2VMXX4SKXC33XYEXVVTYXUMNXEFCXQCXYEP5X9JKZCMZXVESU28Y7U',
+      )
+      expect(satoshis).toBeUndefined()
+    })
+
     it('should throw an error for an invalid address', () => {
       expect(() => decodeBip21('invalidBip21')).toThrow('Invalid BIP21 URI')
     })
@@ -34,6 +47,12 @@ describe('bip21 utilities', () => {
     it('should encode a valid bip21 URI', () => {
       const { address, bip21, arkAddress, invoice, satoshis } = fixtures.lib.bip21
       expect(encodeBip21(address, arkAddress, invoice, satoshis)).toEqual(bip21)
+    })
+
+    it('should encode a valid bip21 URI without ark address', () => {
+      const { address, bip21, invoice, satoshis } = fixtures.lib.bip21
+      const bip21WithoutArk = bip21.replace(/([?&])ark=[^&]+(&|$)/i, '$1').replace(/&$/, '')
+      expect(encodeBip21(address!, '', invoice!, satoshis!)).toEqual(bip21WithoutArk)
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Send flow no longer runs unnecessary LNURL checks when using Ark addresses, avoiding erroneous error states.
* **Improvements**
  * BIP21 URI generation now normalizes separators and omits empty query segments for cleaner, more consistent payment URIs.
* **Tests**
  * Expanded end-to-end and unit test coverage and added shared helpers for generating invoices, BIP21 addresses, and reset flows to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->