### PR TITLE
contracts view: copy encoded params, empty state, active/inactive sections

### DIFF
--- a/src/screens/Settings/Contracts.tsx
+++ b/src/screens/Settings/Contracts.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { Contract, encodeArkContract } from '@arkade-os/sdk'
 import Header from './Header'
 import Content from '../../components/Content'
@@ -45,6 +45,14 @@ function CopyRow({ label, value }: { label: string; value: string }) {
 }
 
 function ContractCard({ contract }: { contract: Contract }) {
+  const encoded = useMemo(() => {
+    try {
+      return encodeArkContract(contract)
+    } catch {
+      return ''
+    }
+  }, [contract])
+
   return (
     <Shadow border>
       <FlexCol gap='0.5rem'>
@@ -60,14 +68,14 @@ function ContractCard({ contract }: { contract: Contract }) {
               {contract.state}
             </Text>
             <Text tiny color='neutral-500'>
-              {prettyAgo(contract.createdAt)}
+              {contract.createdAt ? prettyAgo(contract.createdAt) : 'Unknown'}
             </Text>
           </FlexCol>
         </FlexRow>
         <hr className='dashed' />
         <CopyRow label='address' value={contract.address} />
         <CopyRow label='script' value={contract.script} />
-        <CopyRow label='parameters' value={encodeArkContract(contract)} />
+        {encoded ? <CopyRow label='parameters' value={encoded} /> : null}
       </FlexCol>
     </Shadow>
   )
@@ -81,7 +89,7 @@ function Section({ title, contracts }: { title: string; contracts: Contract[] })
         {title}
       </Text>
       {contracts.map((c) => (
-        <ContractCard key={c.script} contract={c} />
+        <ContractCard key={c.address} contract={c} />
       ))}
     </FlexCol>
   )

--- a/src/screens/Settings/Contracts.tsx
+++ b/src/screens/Settings/Contracts.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef, useState } from 'react'
-import type { Contract } from '@arkade-os/sdk'
+import { Contract, ContractManager, encodeArkContract } from '@arkade-os/sdk'
 import Header from './Header'
 import Content from '../../components/Content'
 import Padded from '../../components/Padded'
@@ -65,6 +65,7 @@ function ContractCard({ contract }: { contract: Contract }) {
         <hr className='dashed' />
         <CopyRow label='address' value={contract.address} />
         <CopyRow label='script' value={contract.script} />
+        <CopyRow label='parameters' value={encodeArkContract(contract)} />
       </FlexCol>
     </div>
   )

--- a/src/screens/Settings/Contracts.tsx
+++ b/src/screens/Settings/Contracts.tsx
@@ -11,19 +11,11 @@ import LoadingLogo from '../../components/LoadingLogo'
 import CopyIcon from '../../icons/Copy'
 import CheckMarkIcon from '../../icons/CheckMark'
 import { WalletContext } from '../../providers/wallet'
-import { prettyLongText } from '../../lib/format'
+import { prettyAgo, prettyLongText } from '../../lib/format'
 import { copyToClipboard } from '../../lib/clipboard'
 import { hapticSubtle } from '../../lib/haptics'
 import { useToast } from '../../components/Toast'
 import { consoleError } from '../../lib/logs'
-
-const cardStyle: React.CSSProperties = {
-  backgroundColor: 'var(--neutral-100)',
-  border: '1px solid var(--neutral-200)',
-  borderRadius: '0.25rem',
-  padding: '10px',
-  width: '100%',
-}
 
 function CopyRow({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false)
@@ -54,20 +46,44 @@ function CopyRow({ label, value }: { label: string; value: string }) {
 
 function ContractCard({ contract }: { contract: Contract }) {
   return (
-    <div style={cardStyle}>
+    <Shadow border>
       <FlexCol gap='0.5rem'>
         <FlexRow between>
-          <Text>{contract.type}</Text>
-          <Text tiny color={contract.state === 'active' ? 'green' : 'neutral-500'}>
-            {contract.state}
-          </Text>
+          <FlexCol gap='0'>
+            {contract.label ? <Text small>{contract.label}</Text> : null}
+            <Text tiny color='neutral-500'>
+              {contract.type}
+            </Text>
+          </FlexCol>
+          <FlexCol gap='0' end>
+            <Text tiny color={contract.state === 'active' ? 'green' : 'neutral-500'}>
+              {contract.state}
+            </Text>
+            <Text tiny color='neutral-500'>
+              {prettyAgo(contract.createdAt)}
+            </Text>
+          </FlexCol>
         </FlexRow>
         <hr className='dashed' />
         <CopyRow label='address' value={contract.address} />
         <CopyRow label='script' value={contract.script} />
         <CopyRow label='parameters' value={encodeArkContract(contract)} />
       </FlexCol>
-    </div>
+    </Shadow>
+  )
+}
+
+function Section({ title, contracts }: { title: string; contracts: Contract[] }) {
+  if (contracts.length === 0) return null
+  return (
+    <FlexCol gap='0.5rem'>
+      <Text capitalize color='neutral-500' smaller>
+        {title}
+      </Text>
+      {contracts.map((c) => (
+        <ContractCard key={c.script} contract={c} />
+      ))}
+    </FlexCol>
   )
 }
 
@@ -94,17 +110,23 @@ export default function Contracts() {
 
   if (!svcWallet || loading) return <LoadingLogo text='Loading...' />
 
+  const active = contracts.filter((c) => c.state === 'active')
+  const inactive = contracts.filter((c) => c.state !== 'active')
+
   return (
     <>
       <Header text='Contracts' back />
       <Content noRefresh>
         <Padded>
           <FlexCol className='scroll-fade'>
-            <FlexCol gap='0.5rem'>
-              {contracts.map((c) => (
-                <ContractCard key={c.script} contract={c} />
-              ))}
-            </FlexCol>
+            {contracts.length === 0 ? (
+              <TextSecondary>No contracts found.</TextSecondary>
+            ) : (
+              <FlexCol gap='2rem'>
+                <Section title='Active' contracts={active} />
+                <Section title='Inactive' contracts={inactive} />
+              </FlexCol>
+            )}
           </FlexCol>
         </Padded>
       </Content>

--- a/src/screens/Settings/Contracts.tsx
+++ b/src/screens/Settings/Contracts.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef, useState } from 'react'
-import { Contract, ContractManager, encodeArkContract } from '@arkade-os/sdk'
+import { Contract, encodeArkContract } from '@arkade-os/sdk'
 import Header from './Header'
 import Content from '../../components/Content'
 import Padded from '../../components/Padded'

--- a/src/test/screens/settings/contracts.test.tsx
+++ b/src/test/screens/settings/contracts.test.tsx
@@ -11,12 +11,16 @@ const mockContracts: Contract[] = [
     state: 'inactive',
     address: 'ark1qinactive000000000000000000000000',
     script: 'abcdef1234567890inactive',
+    params: {},
+    createdAt: 1717000000000,
   },
   {
     type: 'default',
     state: 'active',
     address: 'ark1qactive0000000000000000000000000',
     script: 'abcdef1234567890active00',
+    params: {},
+    createdAt: 1717000000000,
   },
 ]
 
@@ -33,6 +37,20 @@ describe('Contracts screen', () => {
     renderContracts(undefined)
     // Loading logo renders — no crash, no contract content
     expect(screen.queryByText('Contracts')).not.toBeInTheDocument()
+  })
+
+  it('renders empty state when there are no contracts', async () => {
+    const svcWalletWithContracts = {
+      ...mockSvcWallet,
+      getContractManager: () =>
+        Promise.resolve({
+          getContracts: () => Promise.resolve([]),
+        }),
+    }
+    renderContracts(svcWalletWithContracts as any)
+
+    await screen.findByText('Contracts')
+    expect(screen.getByText('No contracts found.')).toBeInTheDocument()
   })
 
   it('renders contract cards with type and state', async () => {


### PR DESCRIPTION
## Summary

- Add `encodeArkContract` call to render the URI-like `arkcontract=…` string and let users copy it
- Replace inline `cardStyle` div with `Shadow border` (consistent with the rest of the codebase)
- Show `contract.label` (when set) and `createdAt` as relative time on each card
- Split list into **Active** / **Inactive** labeled sections
- Add empty state when no contracts are found

## Screenshot

<img width="688" height="857" alt="Screenshot from 2026-06-03 10-12-00" src="https://github.com/user-attachments/assets/fd3be50d-c245-4eeb-ba8d-693ceb8b8d6d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Contracts are now organized into "Active" and "Inactive" sections for easier viewing
  * Contract parameters are now displayed for each contract entry
  * Enhanced contract card layout with improved visual formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->