### PR TITLE
Add Done button to change-password success screen

### DIFF
--- a/src/components/Success.tsx
+++ b/src/components/Success.tsx
@@ -1,5 +1,7 @@
 import { OnboardStaggerContainer, OnboardStaggerChild } from '../components/OnboardLoadIn'
 import SuccessIcon from '../icons/Success'
+import Button from './Button'
+import ButtonsOnBottom from './ButtonsOnBottom'
 import CenterScreen from './CenterScreen'
 import FlexCol from './FlexCol'
 import Text from './Text'
@@ -7,6 +9,14 @@ import Text from './Text'
 interface SuccessProps {
   headline?: string
   text?: string
+}
+
+export function SuccessDoneButton({ onClick }: { onClick: () => void }) {
+  return (
+    <ButtonsOnBottom>
+      <Button onClick={onClick} label='Done' />
+    </ButtonsOnBottom>
+  )
 }
 
 export default function Success({ headline, text }: SuccessProps) {

--- a/src/screens/Settings/Password.tsx
+++ b/src/screens/Settings/Password.tsx
@@ -4,19 +4,21 @@ import { consoleLog } from '../../lib/logs'
 import Button from '../../components/Button'
 import Padded from '../../components/Padded'
 import Content from '../../components/Content'
-import Success from '../../components/Success'
+import Success, { SuccessDoneButton } from '../../components/Success'
 import { defaultPassword } from '../../lib/constants'
 import { WalletContext } from '../../providers/wallet'
 import NewPassword from '../../components/NewPassword'
 import { useContext, useEffect, useState } from 'react'
 import NeedsPassword from '../../components/NeedsPassword'
 import ButtonsOnBottom from '../../components/ButtonsOnBottom'
+import { NavigationContext, Pages } from '../../providers/navigation'
 import { isBiometricsSupported, registerUser } from '../../lib/biometrics'
 import { getPrivateKey, isValidPassword, noUserDefinedPassword, setPrivateKey } from '../../lib/privateKey'
 import { hasMnemonic, getMnemonic, setMnemonic } from '../../lib/mnemonic'
 
 export default function Password() {
   const { updateWallet, wallet } = useContext(WalletContext)
+  const { navigate } = useContext(NavigationContext)
 
   const [authenticated, setAuthenticated] = useState(false)
   const [oldPassword, setOldPassword] = useState('')
@@ -98,7 +100,9 @@ export default function Password() {
           </Padded>
         )}
       </Content>
-      {successText ? null : (
+      {successText ? (
+        <SuccessDoneButton onClick={() => navigate(Pages.Wallet)} />
+      ) : (
         <ButtonsOnBottom>
           <Button onClick={handleContinue} label={label} disabled={newPassword === null || saving} loading={saving} />
           {wallet.lockedByBiometrics || !isBiometricsSupported() ? null : (


### PR DESCRIPTION
## Summary
- Adds a **Done** button on the success state of **Settings → Change password**, using the same bottom-button pattern as **Unlock wallet**.
- Tapping **Done** navigates back to Home (`Pages.Wallet`).
- Other success screens (send, receive, notes, init, mint) are unchanged.

## Context
Developed and tested locally with **Cursor** on branch `feat/success-done-button-home`.

## Test plan
- [x] Change password → success screen shows **Done** at the bottom
- [x] **Done** returns to wallet Home
- [x] Other success flows still use their original CTAs (`Sounds good`, `Go to wallet`, etc.)

Made with [Cursor](https://cursor.com)