### PR TITLE
style(settings): polish contracts screen

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2333,6 +2333,329 @@ html.palette-dark .settings-row--danger .settings-row__chevron {
   color: color-mix(in srgb, var(--red-400) 82%, var(--fg));
 }
 
+/* ============================================================
+   Contracts
+   ============================================================ */
+
+.contract-summary {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.contract-summary__item {
+  display: grid;
+  min-width: 0;
+  gap: 0.1875rem;
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--neutral-50) 68%, var(--bg));
+  padding: 0.75rem;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent),
+    0 1px 2px -1px color-mix(in srgb, var(--fg) 7%, transparent);
+}
+
+.contract-summary__value {
+  color: var(--fg);
+  font-family: var(--font-heading);
+  font-size: var(--text-heading-sm-size);
+  font-weight: 500;
+  line-height: var(--text-heading-sm-line);
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.contract-summary__label {
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: var(--text-xs-size);
+  font-weight: 500;
+  line-height: var(--text-xs-line);
+}
+
+.contract-section-heading {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.contract-section-heading > span {
+  display: inline-flex;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--neutral-50) 76%, var(--bg));
+  color: color-mix(in srgb, var(--fg) 56%, transparent);
+  font-size: var(--text-xs-size);
+  font-weight: 500;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent);
+}
+
+.contract-card-frame {
+  width: 100%;
+  animation: contract-card-enter 220ms cubic-bezier(0.23, 1, 0.32, 1) both;
+  animation-delay: calc(var(--contract-card-index, 0) * 35ms);
+}
+
+.contract-card {
+  display: grid;
+  width: 100%;
+  gap: 0.875rem;
+  border-radius: var(--radius-xl);
+  background: var(--bg);
+  padding: 0.875rem;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent),
+    0 1px 2px -1px color-mix(in srgb, var(--fg) 7%, transparent),
+    0 2px 4px 0 color-mix(in srgb, var(--fg) 3%, transparent);
+}
+
+.contract-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.contract-card__identity,
+.contract-card__meta {
+  display: grid;
+  min-width: 0;
+  gap: 0.25rem;
+}
+
+.contract-card__title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--fg);
+  font-size: var(--text-base-size);
+  font-weight: 500;
+  line-height: var(--text-base-line);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.contract-card__subtitle,
+.contract-card__age {
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+  font-size: var(--text-xs-size);
+  font-weight: 400;
+  line-height: var(--text-xs-line);
+}
+
+.contract-card__meta {
+  flex: 0 0 auto;
+  justify-items: end;
+  text-align: right;
+}
+
+.contract-card__status {
+  display: inline-flex;
+  min-height: 1.5rem;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 0.5rem;
+  font-size: var(--text-xs-size);
+  font-weight: 500;
+  line-height: 1;
+}
+
+.contract-card__status--active {
+  background: color-mix(in srgb, var(--green-500) 11%, var(--bg));
+  color: var(--green-600);
+}
+
+.contract-card__status--inactive {
+  background: color-mix(in srgb, var(--neutral-50) 76%, var(--bg));
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+}
+
+.contract-card__stats {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.contract-card__stats > span {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--neutral-50) 66%, var(--bg));
+  padding: 0.625rem;
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: var(--text-xs-size);
+  line-height: var(--text-xs-line);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 4%, transparent);
+}
+
+.contract-card__stats strong {
+  color: var(--fg);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.contract-card__fields {
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+}
+
+.contract-copy-field {
+  display: flex;
+  width: 100%;
+  min-height: 3.75rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 0;
+  border-radius: var(--radius-md);
+  appearance: none;
+  background: color-mix(in srgb, var(--neutral-50) 74%, var(--bg));
+  color: var(--fg);
+  cursor: pointer;
+  font: inherit;
+  padding: 0.625rem;
+  text-align: left;
+  touch-action: manipulation;
+  transition:
+    background-color 160ms ease,
+    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.contract-copy-field:focus-visible {
+  background: var(--background-focused);
+}
+
+.contract-copy-field:active {
+  background: color-mix(in srgb, var(--fg) 3.5%, transparent);
+  transform: scale(0.99);
+}
+
+.contract-copy-field__text {
+  display: grid;
+  flex: 1 1 auto;
+  min-width: 0;
+  gap: 0.25rem;
+}
+
+.contract-copy-field__label {
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+  font-size: var(--text-xs-size);
+  font-weight: 500;
+  line-height: var(--text-xs-line);
+}
+
+.contract-copy-field__value {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--fg);
+  font-family: var(--font-family-mono);
+  font-size: var(--text-sm-size);
+  font-weight: 500;
+  line-height: var(--text-sm-line);
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.contract-copy-field__icon {
+  display: inline-flex;
+  width: 2.75rem;
+  height: 2.75rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  color: color-mix(in srgb, var(--fg) 64%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 6%, transparent);
+}
+
+.contract-copy-field__icon svg {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.contract-copy-field__icon--copied {
+  background: color-mix(in srgb, var(--green-500) 11%, var(--bg));
+  color: var(--green-600);
+  animation: contract-copy-confirm 220ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.contract-empty-state {
+  display: grid;
+  min-height: 8rem;
+  place-items: center;
+  border-radius: var(--radius-xl);
+  background: color-mix(in srgb, var(--neutral-50) 68%, var(--bg));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent),
+    0 1px 2px -1px color-mix(in srgb, var(--fg) 7%, transparent);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .contract-copy-field:hover {
+    background: color-mix(in srgb, var(--fg) 3%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent);
+  }
+}
+
+@keyframes contract-card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.375rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes contract-copy-confirm {
+  from {
+    transform: scale(0.94);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .contract-card-frame,
+  .contract-copy-field__icon--copied {
+    animation: none;
+  }
+
+  .contract-copy-field {
+    transition: none;
+  }
+}
+
+html.palette-dark .contract-card,
+html.palette-dark .contract-summary__item,
+html.palette-dark .contract-empty-state {
+  background: color-mix(in oklab, var(--fg) 4%, var(--bg));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent),
+    0 1px 2px -1px color-mix(in srgb, var(--bg) 42%, transparent),
+    0 4px 10px -8px color-mix(in srgb, var(--bg) 70%, transparent);
+}
+
+html.palette-dark .contract-copy-field,
+html.palette-dark .contract-card__stats > span {
+  background: color-mix(in srgb, var(--fg) 5%, var(--neutral-50));
+}
+
 .asset-detail-page {
   display: flex;
   flex-direction: column;

--- a/src/screens/Settings/Contracts.tsx
+++ b/src/screens/Settings/Contracts.tsx
@@ -1,11 +1,9 @@
-import { useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { CSSProperties, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { Contract, encodeArkContract } from '@arkade-os/sdk'
 import Header from './Header'
 import Content from '../../components/Content'
 import Padded from '../../components/Padded'
 import FlexCol from '../../components/FlexCol'
-import FlexRow from '../../components/FlexRow'
-import Shadow from '../../components/Shadow'
 import Text, { TextSecondary } from '../../components/Text'
 import LoadingLogo from '../../components/LoadingLogo'
 import CopyIcon from '../../icons/Copy'
@@ -16,8 +14,18 @@ import { copyToClipboard } from '../../lib/clipboard'
 import { hapticSubtle } from '../../lib/haptics'
 import { useToast } from '../../components/Toast'
 import { consoleError } from '../../lib/logs'
+import { cn } from '../../lib/utils'
 
-function CopyRow({ label, value }: { label: string; value: string }) {
+type ContractStat = {
+  label: string
+  value: number
+}
+
+function stateLabel(state: Contract['state']) {
+  return state === 'active' ? 'Active' : 'Inactive'
+}
+
+function CopyField({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout>>()
   const { toast } = useToast()
@@ -34,13 +42,31 @@ function CopyRow({ label, value }: { label: string; value: string }) {
   }
 
   return (
-    <FlexRow between onClick={handleCopy}>
-      <FlexCol gap='0'>
-        <TextSecondary>{label}</TextSecondary>
-        <Text small>{prettyLongText(value)}</Text>
-      </FlexCol>
-      <Shadow flex>{copied ? <CheckMarkIcon /> : <CopyIcon />}</Shadow>
-    </FlexRow>
+    <button type='button' className='contract-copy-field' onClick={handleCopy} aria-label={`Copy ${label}`}>
+      <span className='contract-copy-field__text'>
+        <span className='contract-copy-field__label'>{label}</span>
+        <span className='contract-copy-field__value'>{prettyLongText(value, 14)}</span>
+      </span>
+      <span
+        className={cn('contract-copy-field__icon', copied && 'contract-copy-field__icon--copied')}
+        aria-hidden='true'
+      >
+        {copied ? <CheckMarkIcon /> : <CopyIcon />}
+      </span>
+    </button>
+  )
+}
+
+function ContractSummary({ stats }: { stats: ContractStat[] }) {
+  return (
+    <section className='contract-summary' aria-label='Contract summary'>
+      {stats.map((stat) => (
+        <div className='contract-summary__item' key={stat.label}>
+          <span className='contract-summary__value'>{stat.value}</span>
+          <span className='contract-summary__label'>{stat.label}</span>
+        </div>
+      ))}
+    </section>
   )
 }
 
@@ -53,43 +79,64 @@ function ContractCard({ contract }: { contract: Contract }) {
     }
   }, [contract])
 
+  const title = contract.label || contract.type
+  const subtitle = contract.label ? contract.type : 'contract'
+  const paramsCount = Object.keys(contract.params).length
+  const createdAt = contract.createdAt ? prettyAgo(contract.createdAt) : 'Unknown'
+
   return (
-    <Shadow border>
-      <FlexCol gap='0.5rem'>
-        <FlexRow between>
-          <FlexCol gap='0'>
-            {contract.label ? <Text small>{contract.label}</Text> : null}
-            <Text tiny color='neutral-500'>
-              {contract.type}
-            </Text>
-          </FlexCol>
-          <FlexCol gap='0' end>
-            <Text tiny color={contract.state === 'active' ? 'green' : 'neutral-500'}>
-              {contract.state}
-            </Text>
-            <Text tiny color='neutral-500'>
-              {contract.createdAt ? prettyAgo(contract.createdAt) : 'Unknown'}
-            </Text>
-          </FlexCol>
-        </FlexRow>
-        <hr className='dashed' />
-        <CopyRow label='address' value={contract.address} />
-        <CopyRow label='script' value={contract.script} />
-        {encoded ? <CopyRow label='parameters' value={encoded} /> : null}
-      </FlexCol>
-    </Shadow>
+    <article className='contract-card'>
+      <header className='contract-card__header'>
+        <span className='contract-card__identity'>
+          <span className='contract-card__title'>{title}</span>
+          <span className='contract-card__subtitle'>{subtitle}</span>
+        </span>
+        <span className='contract-card__meta'>
+          <span className={cn('contract-card__status', `contract-card__status--${contract.state}`)}>
+            {stateLabel(contract.state)}
+          </span>
+          <span className='contract-card__age'>{createdAt}</span>
+        </span>
+      </header>
+
+      <div className='contract-card__stats' aria-label={`${title} details`}>
+        <span>
+          <span>Params</span>
+          <strong>{paramsCount}</strong>
+        </span>
+        <span>
+          <span>Script bytes</span>
+          <strong>{Math.floor(contract.script.length / 2)}</strong>
+        </span>
+      </div>
+
+      <div className='contract-card__fields'>
+        <CopyField label='Address' value={contract.address} />
+        <CopyField label='Script' value={contract.script} />
+        {encoded ? <CopyField label='Encoded contract' value={encoded} /> : null}
+      </div>
+    </article>
   )
 }
 
 function Section({ title, contracts }: { title: string; contracts: Contract[] }) {
   if (contracts.length === 0) return null
   return (
-    <FlexCol gap='0.5rem'>
-      <Text capitalize color='neutral-500' smaller>
-        {title}
-      </Text>
-      {contracts.map((c) => (
-        <ContractCard key={c.address} contract={c} />
+    <FlexCol gap='0.75rem'>
+      <div className='contract-section-heading'>
+        <Text capitalize color='neutral-500' smaller>
+          {title}
+        </Text>
+        <span>{contracts.length}</span>
+      </div>
+      {contracts.map((c, index) => (
+        <div
+          className='contract-card-frame'
+          style={{ '--contract-card-index': index } as CSSProperties}
+          key={c.address}
+        >
+          <ContractCard contract={c} />
+        </div>
       ))}
     </FlexCol>
   )
@@ -120,15 +167,28 @@ export default function Contracts() {
 
   const active = contracts.filter((c) => c.state === 'active')
   const inactive = contracts.filter((c) => c.state !== 'active')
+  const stats: ContractStat[] = [
+    { label: 'Total', value: contracts.length },
+    { label: 'Active', value: active.length },
+    { label: 'Inactive', value: inactive.length },
+  ]
 
   return (
     <>
       <Header text='Contracts' back />
       <Content noRefresh>
         <Padded>
-          <FlexCol className='scroll-fade'>
+          <FlexCol gap='1.25rem' className='scroll-fade'>
+            <FlexCol gap='0.75rem'>
+              <TextSecondary>
+                Contracts define addresses and scripts used by wallet flows, delegates, swaps, and default receiving.
+              </TextSecondary>
+              <ContractSummary stats={stats} />
+            </FlexCol>
             {contracts.length === 0 ? (
-              <TextSecondary>No contracts found.</TextSecondary>
+              <div className='contract-empty-state'>
+                <TextSecondary centered>No contracts found.</TextSecondary>
+              </div>
             ) : (
               <FlexCol gap='2rem'>
                 <Section title='Active' contracts={active} />

--- a/src/test/screens/settings/contracts.test.tsx
+++ b/src/test/screens/settings/contracts.test.tsx
@@ -66,8 +66,8 @@ describe('Contracts screen', () => {
     await screen.findByText('Contracts')
     expect(screen.getByText('default')).toBeInTheDocument()
     expect(screen.getByText('vhtlc')).toBeInTheDocument()
-    expect(screen.getByText('active')).toBeInTheDocument()
-    expect(screen.getByText('inactive')).toBeInTheDocument()
+    expect(screen.getAllByText('Active').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Inactive').length).toBeGreaterThan(0)
   })
 
   it('sorts active contracts before inactive ones', async () => {
@@ -81,8 +81,26 @@ describe('Contracts screen', () => {
     renderContracts(svcWalletWithContracts as any)
 
     await screen.findByText('Contracts')
-    const cards = screen.getAllByText(/^(active|inactive)$/)
-    expect(cards[0].textContent).toBe('active')
-    expect(cards[1].textContent).toBe('inactive')
+    const cards = screen
+      .getAllByText(/^(Active|Inactive)$/)
+      .filter((node) => node.className.includes('contract-card__status'))
+    expect(cards[0].textContent).toBe('Active')
+    expect(cards[1].textContent).toBe('Inactive')
+  })
+
+  it('renders the contracts summary and metadata', async () => {
+    const svcWalletWithContracts = {
+      ...mockSvcWallet,
+      getContractManager: () =>
+        Promise.resolve({
+          getContracts: () => Promise.resolve(mockContracts),
+        }),
+    }
+    renderContracts(svcWalletWithContracts as any)
+
+    await screen.findByText('Contracts')
+
+    expect(screen.getByLabelText('Contract summary')).toBeInTheDocument()
+    expect(screen.getAllByText('Script bytes').length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary

This PR gives the dev-mode contracts screen a more intentional UI treatment on top of PR 627.

- Adds a compact contracts summary for total, active, and inactive contracts.
- Reworks each contract into a full-width diagnostic card with clearer title/status metadata.
- Converts address, script, and encoded contract values into large copyable rows with mono text, haptic feedback, and copied-state feedback.
- Adds subtle card entrance motion, press feedback, and reduced-motion support.
- Keeps the screen dev-mode gated through the existing loading-logo tap flow.

@bordalix what do you think? Do you like this UI better for the contracts screen?

## Testing

- `bun run test -- src/test/screens/settings/contracts.test.tsx`
- `bun run lint`
- `bun run build`
- Playwright visual pass through the dev-mode path: loading logo taps -> settings -> advanced -> contracts, checked mobile and desktop widths.

## Affected files

- `src/screens/Settings/Contracts.tsx`
- `src/index.css`
- `src/test/screens/settings/contracts.test.tsx`
