### PR TITLE
fix(assets): handle scientific notation in prettyAssetNumber

### DIFF
--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -45,6 +45,7 @@ export const prettyAssetAmountHide = (value: bigint, suffix: string): string => 
 export const prettyAssetNumber = (num?: string | number, maximumFractionDigits = MAX_DECIMALS): string => {
   if (num === undefined || num === null) return '0'
   if (typeof num === 'number') num = num.toString()
+  if (/e/i.test(num)) num = new Decimal(num).toFixed()
   let [integer, fraction = ''] = num.split('.')
   integer = integer.replace(/[^0-9-]+/g, '') // remove non-digit and non-negative sign characters
   const negative = integer === '-0'

--- a/src/test/lib/asset.test.ts
+++ b/src/test/lib/asset.test.ts
@@ -191,6 +191,7 @@ describe('asset utilities', () => {
     it('formats very small number', () => {
       expect(prettyAssetNumber('0.00000001')).toBe('0.00000001')
       expect(prettyAssetNumber('-0.00000001')).toBe('-0.00000001')
+      expect(prettyAssetNumber('-8e-8')).toBe('-0.00000008')
     })
 
     it('formats number with grouping', () => {
@@ -279,6 +280,12 @@ describe('asset utilities', () => {
 
     it('handles negative values when tidy=true', () => {
       expect(prettyAssetAmount(BigInt(-987_654_321), 0, true)).toBe('-987M')
+    })
+
+    it('handles tiny negative fractional amounts when tidy=true', () => {
+      // centsToUnits → Number() produces -8e-8; prettyAssetNumber must convert it before regex-stripping 'e'
+      expect(prettyAssetAmount(BigInt(-8), 8, true)).toBe('-0.00000008')
+      expect(prettyAssetAmount(BigInt(-1), 8, true)).toBe('-0.00000001')
     })
 
     it('does not add suffix when tidy=true but amount is under 1K', () => {


### PR DESCRIPTION
Numbers like -8e-8 passed as JS floats would have the 'e' stripped by the formatting regex, producing '-8-8' which BigInt rejects. Convert to fixed-point via Decimal.toFixed() before splitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper rendering of very small numbers in scientific notation format, now correctly normalized to decimal representation.

* **Tests**
  * Extended test coverage to verify correct formatting of tiny negative values and amounts in scientific notation without formatting artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->