### PR TITLE
fix(send): show recipient validation inline

### DIFF
--- a/src/components/InputAddress.tsx
+++ b/src/components/InputAddress.tsx
@@ -11,6 +11,8 @@ import { isBip21 } from '../lib/bip21'
 import InputWithScanner from './InputWithScanner'
 
 interface InputAddressProps {
+  error?: string
+  errorVariant?: 'banner' | 'inline'
   focus?: boolean
   label?: string
   name?: string
@@ -25,6 +27,8 @@ interface InputAddressProps {
 }
 
 export default function InputAddress({
+  error,
+  errorVariant,
   focus,
   label,
   name,
@@ -54,6 +58,8 @@ export default function InputAddress({
 
   return (
     <InputWithScanner
+      error={error}
+      errorVariant={errorVariant}
       focus={focus}
       label={label}
       name={name}

--- a/src/components/InputContainer.tsx
+++ b/src/components/InputContainer.tsx
@@ -8,6 +8,7 @@ import Text from './Text'
 interface InputContainerProps {
   children: ReactNode
   error?: string
+  errorVariant?: 'banner' | 'inline'
   label?: string
   right?: JSX.Element
   bottomLeft?: string
@@ -17,6 +18,7 @@ interface InputContainerProps {
 export default function InputContainer({
   children,
   error,
+  errorVariant = 'banner',
   label,
   right,
   bottomLeft,
@@ -42,16 +44,27 @@ export default function InputContainer({
     </FlexRow>
   )
 
+  const hasError = Boolean(error)
+  const inlineError = errorVariant === 'inline' && hasError
+
   return (
-    <FlexCol>
+    <FlexCol gap={inlineError ? '0.375rem' : undefined}>
       <FlexCol gap='0.5rem'>
         {label || right ? <TopLabel /> : null}
-        <Shadow>
+        <Shadow dangerBorder={inlineError}>
           <FlexRow between>{children}</FlexRow>
         </Shadow>
         {bottomLeft || bottomRight ? <BottomLabel /> : null}
       </FlexCol>
-      <ErrorMessage error={Boolean(error)} text={error ?? ''} />
+      {inlineError ? (
+        <div className='field-error' role='alert'>
+          <Text color='danger' small wrap>
+            {error}
+          </Text>
+        </div>
+      ) : (
+        <ErrorMessage error={hasError} text={error ?? ''} />
+      )}
     </FlexCol>
   )
 }

--- a/src/components/InputWithScanner.tsx
+++ b/src/components/InputWithScanner.tsx
@@ -7,6 +7,7 @@ import FlexRow from './FlexRow'
 
 interface InputWithScannerProps {
   error?: string
+  errorVariant?: 'banner' | 'inline'
   focus?: boolean
   label?: string
   name?: string
@@ -22,6 +23,7 @@ interface InputWithScannerProps {
 
 export default function InputWithScanner({
   error,
+  errorVariant,
   focus,
   label,
   name,
@@ -70,7 +72,7 @@ export default function InputWithScanner({
   const hasValue = Boolean(value && value.length > 0)
 
   return (
-    <InputContainer label={label} error={error}>
+    <InputContainer label={label} error={error} errorVariant={errorVariant}>
       <label className='label has-buttons'>
         <input
           ref={input}

--- a/src/components/Shadow.tsx
+++ b/src/components/Shadow.tsx
@@ -4,6 +4,7 @@ interface ShadowProps {
   border?: boolean
   borderPurple?: boolean
   children: ReactNode
+  dangerBorder?: boolean
   darkPurple?: boolean
   fat?: boolean
   flex?: boolean
@@ -21,6 +22,7 @@ export default function Shadow({
   border,
   borderPurple,
   children,
+  dangerBorder,
   darkPurple,
   fat,
   flex,
@@ -45,12 +47,18 @@ export default function Shadow({
             : inverted
               ? 'var(--magenta)'
               : 'var(--neutral-100)',
-    border: border ? `1px solid var(--${borderPurple ? 'purple' : 'neutral-100'})` : undefined,
+    border: dangerBorder
+      ? '1px solid var(--danger)'
+      : border
+        ? `1px solid var(--${borderPurple ? 'purple' : 'neutral-100'})`
+        : undefined,
     borderRadius: squared ? undefined : '0.5rem',
+    boxShadow: dangerBorder ? '0 0 0 1px color-mix(in srgb, var(--danger) 20%, transparent)' : undefined,
     color: purple || darkPurple ? 'white' : '',
     cursor: onClick ? 'pointer' : undefined,
     overflow: 'hidden',
     padding: slim ? '0.25rem' : fat ? '1rem' : '0.5rem',
+    transition: dangerBorder ? 'border-color 150ms ease, box-shadow 150ms ease' : undefined,
     width: flex ? undefined : '100%',
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -353,6 +353,27 @@ input:focus::placeholder {
   color: transparent; /* Hide placeholder on focus */
 }
 
+.field-error {
+  animation: field-error-enter 180ms cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+
+@keyframes field-error-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field-error {
+    animation: none;
+  }
+}
+
 .palette-dark button.reminder-button.action-sheet-button {
   background-color: var(--neutral-200);
   color: var(--fg);

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -98,6 +98,7 @@ export default function SendForm() {
   const [proceed, setProceed] = useState(false)
   const [processing, setProcessing] = useState(false)
   const [recipient, setRecipient] = useState('')
+  const [recipientError, setRecipientError] = useState('')
   const [receivingAddresses, setReceivingAddresses] = useState<Addresses>()
   const [scan, setScan] = useState(false)
   const [rawScanData, setRawScanData] = useState('')
@@ -122,7 +123,13 @@ export default function SendForm() {
     setError(str === '' ? (aspInfo.unreachable ? 'Ark server unreachable' : '') : str)
   }
 
+  const setRecipientValidationError = (message: string) => {
+    setError('')
+    setRecipientError(message)
+  }
+
   const setState = (info: SendInfo) => {
+    setRecipientError('')
     setScan(false)
     setSendInfo(info)
     if (info.satoshis) {
@@ -203,6 +210,7 @@ export default function SendForm() {
   // selects an asset and the address is not compatible with it)
   useEffect(() => {
     smartSetError('')
+    setRecipientError('')
 
     const parseRecipient = async () => {
       setNudgeBoltz(false)
@@ -218,7 +226,7 @@ export default function SendForm() {
       }
       if (isBip21(lowerCaseData)) {
         const { address, arkAddress, invoice, lnUrl, satoshis, assetId, assetAmount } = decodeBip21(recipient.trim())
-        if (!address && !arkAddress && !invoice && !lnUrl) return setError('Unable to parse bip21')
+        if (!address && !arkAddress && !invoice && !lnUrl) return setRecipientValidationError('Unable to parse bip21')
         if (assetId) {
           let found = assetOptions.find((a) => a.assetId === assetId)
           if (!found) {
@@ -258,21 +266,21 @@ export default function SendForm() {
       }
       if (isLightningInvoice(lowerCaseData)) {
         if (isAssetSend) {
-          return setError('Assets can only be sent to Arkade addresses')
+          return setRecipientValidationError('Assets can only be sent to Arkade addresses')
         }
         if (!connected) {
-          setError('Lightning swaps not enabled')
+          setRecipientValidationError('Lightning swaps not enabled')
           return setNudgeBoltz(true)
         }
         const satoshis = getInvoiceSatoshis(lowerCaseData)
-        if (!satoshis) return setError('Invoice must have amount defined')
+        if (!satoshis) return setRecipientValidationError('Invoice must have amount defined')
         setState({ ...base, invoice: lowerCaseData, satoshis })
         setAmountIsReadOnly(true)
         return
       }
       if (isBTCAddress(recipient)) {
         if (isAssetSend) {
-          return setError('Assets can only be sent to Arkade addresses')
+          return setRecipientValidationError('Assets can only be sent to Arkade addresses')
         }
         return setState({ ...base, address: recipient })
       }
@@ -288,7 +296,7 @@ export default function SendForm() {
       if (isValidLnUrl(lowerCaseData)) {
         return setState({ ...base, lnUrl: lowerCaseData })
       }
-      setError('Invalid recipient address')
+      setRecipientValidationError('Invalid recipient address')
     }
 
     parseRecipient()
@@ -372,7 +380,7 @@ export default function SendForm() {
     if (sendInfo.lnUrl && sendInfo.invoice) return
     checkLnUrlConditions(sendInfo.lnUrl)
       .then((conditions) => {
-        if (!conditions) return setError('Unable to fetch LNURL conditions')
+        if (!conditions) return setRecipientValidationError('Unable to fetch LNURL conditions')
         const min = Math.floor(conditions.minSendable / 1000) // from millisatoshis to satoshis
         const max = Math.floor(conditions.maxSendable / 1000) // from millisatoshis to satoshis
         if (min === max) setSendInfo({ ...sendInfo, satoshis: min }) // set amount automatically
@@ -380,7 +388,7 @@ export default function SendForm() {
       })
       .catch((e) => {
         consoleError(e, 'Error checking LNURL conditions')
-        setError(extractError(e))
+        setRecipientValidationError(extractError(e))
       })
   }, [sendInfo.arkAddress, sendInfo.lnUrl])
 
@@ -396,11 +404,11 @@ export default function SendForm() {
     const { address, arkAddress, invoice, lnUrl } = sendInfo
     // check server limits for onchain transactions
     if (address && !arkAddress && !invoice && !lnUrl && !utxoTxsAllowed()) {
-      return setError('Sending onchain not allowed')
+      return setRecipientValidationError('Sending onchain not allowed')
     }
     // check server limits for offchain transactions
     if (!address && (arkAddress || invoice || lnUrl) && !vtxoTxsAllowed()) {
-      return setError('Sending offchain not allowed')
+      return setRecipientValidationError('Sending offchain not allowed')
     }
     // check swap limits for lightning transactions
     if (!address && !arkAddress && invoice) {
@@ -417,7 +425,7 @@ export default function SendForm() {
       const { serverPubKey: expectedServerPubKey } = decodeArkAddress(offchainAddr)
       if (serverPubKey !== expectedServerPubKey) {
         // if there's no other way to pay, show error
-        if (!address && !invoice) return setError('Ark server key mismatch')
+        if (!address && !invoice) return setRecipientValidationError('Ark server key mismatch')
         // remove ark address from possibilities to send and continue
         // we will try to pay to lightning or mainnet instead
         setSendInfo({ ...sendInfo, arkAddress: '' })
@@ -426,7 +434,7 @@ export default function SendForm() {
     // check if is trying to self send
     if (address === boardingAddr || arkAddress === offchainAddr) {
       setTryingToSelfSend(true) // nudge user to rollover
-      return setError('Cannot send to yourself')
+      return setRecipientValidationError('Cannot send to yourself')
     } else {
       setTryingToSelfSend(false)
     }
@@ -552,7 +560,7 @@ export default function SendForm() {
     setSelectedAsset(asset)
     if (asset) {
       if (isBTCAddress(recipient)) {
-        return setError('Assets can only be sent to Arkade addresses')
+        return setRecipientValidationError('Assets can only be sent to Arkade addresses')
       }
       setState({
         ...sendInfo,
@@ -586,6 +594,7 @@ export default function SendForm() {
   // typing only updates state; parsing waits for blur, paste or clear
   const handleRecipientInput = (data: string, parseNow = false) => {
     smartSetError('')
+    setRecipientError('')
     setRawScanData('')
     resetDerivedState(data)
     if (parseNow || !data) requestParse()
@@ -603,7 +612,9 @@ export default function SendForm() {
           // Fetch Ark address instead of Lightning invoice
           const arkResponse = await fetchArkAddress(sendInfo.lnUrl)
           if (!isArkAddress(arkResponse.address)) {
-            handleError('Invalid Arkade address received from LNURL')
+            consoleError('Invalid Arkade address received from LNURL', 'error sending payment')
+            setProcessing(false)
+            setRecipientValidationError('Invalid Arkade address received from LNURL')
             return
           }
           setState({ ...sendInfo, arkAddress: arkResponse.address, invoice: undefined })
@@ -694,6 +705,7 @@ export default function SendForm() {
       aspInfo.unreachable ||
       tryingToSelfSend ||
       Boolean(error) ||
+      Boolean(recipientError) ||
       processing
     : !((address || arkAddress || lnUrl || invoice) && satoshis && satoshis > 0) ||
       (lnUrlResponse?.maxSendable && satoshis > lnUrlResponse.maxSendable) ||
@@ -704,6 +716,7 @@ export default function SendForm() {
       aspInfo.unreachable ||
       tryingToSelfSend ||
       Boolean(error) ||
+      Boolean(recipientError) ||
       satoshis < 1 ||
       processing
 
@@ -804,9 +817,11 @@ export default function SendForm() {
         <Header text='Send' back />
         <Content>
           <Padded>
-            <FlexCol gap='2rem'>
+            <FlexCol gap='1.5rem'>
               <ErrorMessage error={Boolean(error)} text={error} />
               <InputAddress
+                error={recipientError}
+                errorVariant='inline'
                 name='send-address'
                 focus={focus === 'recipient'}
                 label='Recipient address'

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, act, fireEvent, cleanup } from '@testing-library/react'
+import { useState } from 'react'
+import { render, screen, act, fireEvent, cleanup, waitFor } from '@testing-library/react'
 import { FlowContext } from '../../../providers/flow'
 import { LimitsContext } from '../../../providers/limits'
 import {
@@ -25,6 +26,7 @@ import { FiatContext } from '../../../providers/fiat'
 import { SwapsContext } from '../../../providers/swaps'
 import { OptionsContext } from '../../../providers/options'
 import { FeesContext } from '../../../providers/fees'
+import fixtures from '../../fixtures.json'
 
 // Mock lnurl module so we can spy on isValidLnUrl
 vi.mock('../../../lib/lnurl', async (importOriginal) => {
@@ -41,7 +43,60 @@ vi.mock('../../../lib/lnurl', async (importOriginal) => {
   }
 })
 
-function renderSendForm(svcWallet: unknown = mockSvcWallet) {
+function renderSendForm(
+  svcWallet: unknown = mockSvcWallet,
+  overrides: {
+    config?: Record<string, any>
+    wallet?: Record<string, any>
+  } = {},
+) {
+  function SendFormWithState() {
+    const [sendInfo, setSendInfo] = useState(mockFlowContextValue.sendInfo)
+
+    const config = {
+      ...mockConfigContextValue.config,
+      ...overrides.config,
+      apps: {
+        ...mockConfigContextValue.config.apps,
+        ...overrides.config?.apps,
+      },
+    }
+
+    const wallet = {
+      ...mockWalletContextValue,
+      ...overrides.wallet,
+      svcWallet: svcWallet as any,
+    }
+
+    return (
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <AspContext.Provider value={mockAspContextValue}>
+          <ConfigContext.Provider value={{ ...mockConfigContextValue, config } as any}>
+            <FiatContext.Provider value={mockFiatContextValue as any}>
+              <SwapsContext.Provider value={mockSwapsContextValue as any}>
+                <OptionsContext.Provider value={mockOptionsContextValue as any}>
+                  <FlowContext.Provider value={{ ...mockFlowContextValue, sendInfo, setSendInfo } as any}>
+                    <WalletContext.Provider value={wallet as any}>
+                      <LimitsContext.Provider value={mockLimitsContextValue}>
+                        <FeesContext.Provider value={mockFeesContextValue as any}>
+                          <SendForm />
+                        </FeesContext.Provider>
+                      </LimitsContext.Provider>
+                    </WalletContext.Provider>
+                  </FlowContext.Provider>
+                </OptionsContext.Provider>
+              </SwapsContext.Provider>
+            </FiatContext.Provider>
+          </ConfigContext.Provider>
+        </AspContext.Provider>
+      </NavigationContext.Provider>
+    )
+  }
+
+  return render(<SendFormWithState />)
+}
+
+function renderLoadingSendForm() {
   return render(
     <NavigationContext.Provider value={mockNavigationContextValue}>
       <AspContext.Provider value={mockAspContextValue}>
@@ -50,7 +105,7 @@ function renderSendForm(svcWallet: unknown = mockSvcWallet) {
             <SwapsContext.Provider value={mockSwapsContextValue as any}>
               <OptionsContext.Provider value={mockOptionsContextValue as any}>
                 <FlowContext.Provider value={mockFlowContextValue as any}>
-                  <WalletContext.Provider value={{ ...mockWalletContextValue, svcWallet: svcWallet as any }}>
+                  <WalletContext.Provider value={mockWalletContextValue}>
                     <LimitsContext.Provider value={mockLimitsContextValue}>
                       <FeesContext.Provider value={mockFeesContextValue as any}>
                         <SendForm />
@@ -69,27 +124,7 @@ function renderSendForm(svcWallet: unknown = mockSvcWallet) {
 
 describe('Send screen', () => {
   it('renders the loading send screen correctly', async () => {
-    render(
-      <NavigationContext.Provider value={mockNavigationContextValue}>
-        <AspContext.Provider value={mockAspContextValue}>
-          <ConfigContext.Provider value={mockConfigContextValue as any}>
-            <FiatContext.Provider value={mockFiatContextValue as any}>
-              <SwapsContext.Provider value={mockSwapsContextValue as any}>
-                <OptionsContext.Provider value={mockOptionsContextValue as any}>
-                  <FlowContext.Provider value={mockFlowContextValue as any}>
-                    <WalletContext.Provider value={mockWalletContextValue}>
-                      <LimitsContext.Provider value={mockLimitsContextValue}>
-                        <SendForm />
-                      </LimitsContext.Provider>
-                    </WalletContext.Provider>
-                  </FlowContext.Provider>
-                </OptionsContext.Provider>
-              </SwapsContext.Provider>
-            </FiatContext.Provider>
-          </ConfigContext.Provider>
-        </AspContext.Provider>
-      </NavigationContext.Provider>,
-    )
+    renderLoadingSendForm()
     // should be loading because svcWallet is undefined
     expect(screen.getByTestId('loading-logo')).toBeInTheDocument()
   })
@@ -143,6 +178,60 @@ describe('Send form recipient validation timing', () => {
     fireEvent.blur(input)
     expect(mockIsValidLnUrl).toHaveBeenCalledTimes(1)
     expect(mockIsValidLnUrl).toHaveBeenCalledWith('user@example.com')
+  }, 10000)
+
+  it('shows invalid recipients inline instead of in the global error banner', async () => {
+    renderSendForm(mockSvcWalletWithAddresses)
+
+    const input = document.querySelector('input[name="send-address"]') as HTMLInputElement
+    expect(input).not.toBeNull()
+
+    fireEvent.change(input, { target: { value: 'tiero94@tet' } })
+    expect(screen.queryByText('Invalid recipient address')).not.toBeInTheDocument()
+
+    fireEvent.blur(input)
+
+    expect(screen.getByText('Invalid recipient address')).toBeInTheDocument()
+    expect(screen.queryByTestId('error-message')).not.toBeInTheDocument()
+  }, 10000)
+
+  it('keeps continue disabled when recipient compatibility errors are inline', async () => {
+    vi.useRealTimers()
+
+    const assetId = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd'
+    const svcWallet = {
+      ...mockSvcWalletWithAddresses,
+      assetManager: {
+        getAssetDetails: vi.fn().mockResolvedValue({
+          metadata: { name: 'Test token', ticker: 'TST', decimals: 8 },
+        }),
+      },
+    }
+
+    renderSendForm(svcWallet, {
+      config: { apps: { assets: { enabled: true } } },
+      wallet: {
+        assetBalances: [{ assetId, amount: BigInt(100_000_000) }],
+        setCacheEntry: (_assetId: string, details: unknown) => details,
+      },
+    })
+
+    const recipientInput = document.querySelector('input[name="send-address"]') as HTMLInputElement
+    const amountInput = document.querySelector('input[name="send-amount"]') as HTMLInputElement
+
+    fireEvent.change(recipientInput, { target: { value: fixtures.lib.address.btc[0] } })
+    fireEvent.blur(recipientInput)
+    fireEvent.change(amountInput, { target: { value: '1' } })
+
+    const continueButton = await screen.findByRole('button', { name: 'Continue' })
+    await waitFor(() => expect(continueButton).not.toBeDisabled())
+
+    fireEvent.click(await screen.findByTestId('asset-selector'))
+    fireEvent.click(await screen.findByTestId('asset-tst-option'))
+
+    expect(screen.getByText('Assets can only be sent to Arkade addresses')).toBeInTheDocument()
+    expect(screen.queryByTestId('error-message')).not.toBeInTheDocument()
+    expect(continueButton).toBeDisabled()
   }, 10000)
 
   it('native paste validates immediately, without waiting for blur', async () => {


### PR DESCRIPTION
## Summary
- Moves recipient-owned send validation failures out of the global toast/banner and into the recipient address field.
- Adds inline error support to the shared scanner/address input path, including a red field border and reduced-motion-safe entry animation.
- Keeps amount, fee, server, and send execution errors on the existing global error path so non-recipient failures still surface at the form level.

## Why
This follows up on #666. The debounce/blur validation fix worked, but invalid recipient feedback showed as a large global error banner. This makes recipient-address failures feel attached to the field the user needs to fix.

## Affected files
- `src/screens/Wallet/Send/Form.tsx`
- `src/components/InputAddress.tsx`
- `src/components/InputWithScanner.tsx`
- `src/components/InputContainer.tsx`
- `src/components/Shadow.tsx`
- `src/index.css`
- `src/test/screens/wallet/send.test.tsx`

## Testing
- `bunx prettier --write src/components/Shadow.tsx src/screens/Wallet/Send/Form.tsx src/test/screens/wallet/send.test.tsx src/components/InputContainer.tsx src/index.css src/components/InputAddress.tsx src/components/InputWithScanner.tsx`
- `bunx eslint src/screens/Wallet/Send/Form.tsx src/test/screens/wallet/send.test.tsx src/components/InputContainer.tsx src/components/InputAddress.tsx src/components/InputWithScanner.tsx src/components/Shadow.tsx`
- `bunx vitest run src/test/screens/wallet/send.test.tsx`
- `bunx vitest run src/test/lib/format.test.ts src/test/screens/wallet/send.test.tsx`
- `bunx vite build -c vite.worker.config.ts`

## Notes
- A broad non-e2e vitest run initially hit a time-sensitive format test expecting 30 seconds and observing 31 seconds; rerunning the affected format tests passed.
- Local browser verification showed invalid `tiero94@tet` with the inline recipient error and no global banner.