### PR TITLE
fix(send): populate amount field for fixed-amount LNURL

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -352,7 +352,6 @@ export default function SendForm() {
     if (satoshis && satoshis < min) return setError(`Amount below LNURL min limit`)
     if (satoshis && satoshis > max) return setError(`Amount above LNURL max limit`)
     if (min === max) {
-      setAmount(min) // set fixed amount automatically
       setAmountIsReadOnly(true)
     } else {
       setAmountIsReadOnly(false)
@@ -369,7 +368,9 @@ export default function SendForm() {
         if (!conditions) return setError('Unable to fetch LNURL conditions')
         const min = Math.floor(conditions.minSendable / 1000) // from millisatoshis to satoshis
         const max = Math.floor(conditions.maxSendable / 1000) // from millisatoshis to satoshis
-        if (min === max) setSendInfo({ ...sendInfo, satoshis: min }) // set amount automatically
+        // when the LNURL resolves to a fixed amount, set it via setState so the
+        // amount input (bound to amountTextValue) reflects it instead of staying blank
+        if (min === max) setState({ ...sendInfo, satoshis: min })
         return setLnUrlResponse({ ...conditions, minSendable: min, maxSendable: max })
       })
       .catch((e) => {

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { FlowContext } from '../../../providers/flow'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import createFetchMock from 'vitest-fetch-mock'
+import { emptySendInfo, FlowContext } from '../../../providers/flow'
 import { LimitsContext } from '../../../providers/limits'
 import {
   mockAspContextValue,
@@ -78,5 +79,57 @@ describe('Send screen', () => {
     expect(screen.getByText('0 SATS available')).toBeInTheDocument()
     expect(screen.getByText('Recipient address')).toBeInTheDocument()
     expect(screen.getByText('Continue')).toBeInTheDocument()
+  })
+  it('fills the amount field when an LNURL resolves to a fixed amount', async () => {
+    // regression: a fixed-amount LNURL (minSendable === maxSendable) must
+    // populate the read-only amount input instead of leaving it blank
+    const fetchMocker = createFetchMock(vi)
+    fetchMocker.enableMocks()
+    fetchMocker.mockResponseOnce(
+      JSON.stringify({
+        callback: 'https://pay.staging.galoy.io/.well-known/lnurlp/testing',
+        minSendable: 21000, // millisatoshis -> 21 sats
+        maxSendable: 21000,
+        metadata: 'mock-metadata',
+      }),
+    )
+    const lnUrl = 'lnurl1dp68gurn8ghj7urp0yh8xarpva5kueewvaskcmme9e5k7tewwajkcmpdddhx7amw9akxuatjd3cz7ar9wd6xjmn8h9qlv7'
+    const flowValue = { ...mockFlowContextValue, sendInfo: { ...emptySendInfo, lnUrl, recipient: lnUrl } }
+    const walletValue = {
+      ...mockWalletContextValue,
+      balance: 1_000_000,
+      svcWallet: {
+        ...mockSvcWallet,
+        getAddress: () => 'tark1mockoffchain',
+        getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+        getBalance: () => Promise.resolve({ available: 1_000_000 }),
+      } as any,
+    }
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <AspContext.Provider value={mockAspContextValue}>
+          <ConfigContext.Provider value={mockConfigContextValue as any}>
+            <FiatContext.Provider value={mockFiatContextValue as any}>
+              <SwapsContext.Provider value={mockSwapsContextValue as any}>
+                <OptionsContext.Provider value={mockOptionsContextValue as any}>
+                  <FlowContext.Provider value={flowValue as any}>
+                    <WalletContext.Provider value={walletValue}>
+                      <LimitsContext.Provider value={mockLimitsContextValue}>
+                        <SendForm />
+                      </LimitsContext.Provider>
+                    </WalletContext.Provider>
+                  </FlowContext.Provider>
+                </OptionsContext.Provider>
+              </SwapsContext.Provider>
+            </FiatContext.Provider>
+          </ConfigContext.Provider>
+        </AspContext.Provider>
+      </NavigationContext.Provider>,
+    )
+    // amount input is bound to amountTextValue; before the fix it stayed empty
+    const amountInput = await waitFor(() => screen.getByDisplayValue('21'))
+    expect(amountInput).toHaveAttribute('name', 'send-amount')
+    expect(amountInput).toHaveAttribute('readonly')
+    fetchMocker.disableMocks()
   })
 })


### PR DESCRIPTION
## Problem

When an LNURL-pay endpoint resolves to a **fixed amount** (`minSendable === maxSendable`), the Send form locked the amount input but left it **blank**. The user saw an empty, read-only field and any attempt to continue produced an unpayable invoice.

## Cause

The fixed amount was applied via `setSendInfo` / `setAmount`, neither of which syncs `amountTextValue` — the state the amount `<input>` is actually bound to. So the value never reached the field.

## Fix

Route the auto-filled fixed amount through `setState({ ...sendInfo, satoshis: min })`, which updates `amountTextValue` and makes the locked field display the correct value. Removed the dead `setAmount(min)` call in the read-only branch.

## Test

Adds a regression test that mocks a fixed-amount LNURL response (`minSendable === maxSendable === 21000` msat → 21 sats) and asserts the amount input is **populated with `21`** and **read-only**.

- `pnpm test` — 268 passed / 4 skipped
- `pnpm lint`, `pnpm format:check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LNURL fixed-amount handling to ensure the send amount input properly syncs with and displays the fixed satoshi amount specified by the payment provider, maintaining consistency between the UI display and internal state, with the field marked as read-only when applicable.

* **Tests**
  * Added regression test to verify correct behavior and display of the send amount input when LNURL payments specify a fixed amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->