### PR TITLE
fix(receive/send): clipboard correctness, amountless LNURL, BIP21 case handling

### DIFF
--- a/src/lib/bip21.ts
+++ b/src/lib/bip21.ts
@@ -45,30 +45,35 @@ export const decodeBip21 = (uri: string): Bip21Decoded => {
   if (queryString) {
     const params = new URLSearchParams(queryString)
 
-    if (params.has('ark') || params.has('ARK')) {
-      const arkAddress = params.get('ark') ?? params.get('ARK')!
-      if (isArkAddress(arkAddress)) result.arkAddress = arkAddress
+    // BIP21 query keys are case-insensitive — match them regardless of case
+    // (e.g. 'ark', 'ARK', 'Ark'), so QR codes and mixed-case URIs all parse.
+    const getParam = (name: string): string | null => {
+      for (const [key, value] of params) {
+        if (key.toLowerCase() === name) return value
+      }
+      return null
     }
 
-    if (params.has('assetid') || params.has('ASSETID')) {
-      const param = params.get('assetid') ?? params.get('ASSETID')!
-      if (param) result.assetId = param
-    }
+    const arkAddress = getParam('ark')
+    if (arkAddress && isArkAddress(arkAddress)) result.arkAddress = arkAddress
 
-    if (params.has('amount') || params.has('AMOUNT')) {
-      const param = params.get('amount') ?? params.get('AMOUNT')!
+    const assetId = getParam('assetid')
+    if (assetId) result.assetId = assetId
+
+    const amountParam = getParam('amount')
+    if (amountParam != null) {
       if (result.assetId != null) {
-        if (!param.match(/^\d+(\.\d+)?$/)) throw new Error('Invalid asset amount')
-        result.assetAmount = param
+        if (!amountParam.match(/^\d+(\.\d+)?$/)) throw new Error('Invalid asset amount')
+        result.assetAmount = amountParam
       } else {
-        const amount = Number(param)
+        const amount = Number(amountParam)
         if (isNaN(amount) || amount < 0 || !isFinite(amount)) throw new Error('Invalid amount')
         result.satoshis = toSatoshis(Number(amount))
       }
     }
 
-    if (params.has('lightning') || params.has('LIGHTNING')) {
-      const lightning = params.get('lightning') ?? params.get('LIGHTNING')!
+    const lightning = getParam('lightning')
+    if (lightning) {
       if (lightning.toLowerCase().startsWith('lnurl')) {
         result.lnUrl = lightning
       } else if (lightning.toLowerCase().startsWith('ln')) {
@@ -85,7 +90,8 @@ export const encodeBip21 = (address: string, arkAddress: string, invoice: string
     `bitcoin:${address}?` +
     (arkAddress ? `ark=${arkAddress}&` : '') +
     (invoice ? `lightning=${invoice}&` : lnurl ? `lightning=${lnurl}&` : '') +
-    (sats ? `amount=${prettyNumber(fromSatoshis(sats))}` : '')
+    // useGrouping=false: BIP21 amounts must be plain decimals, never '1,000'
+    (sats ? `amount=${prettyNumber(fromSatoshis(sats), 8, false)}` : '')
   return bip21.endsWith('&') || bip21.endsWith('?') ? bip21.slice(0, -1) : bip21
 }
 

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -44,6 +44,21 @@ import { EASE_OUT_QUINT } from '../../../lib/animations'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 
+/**
+ * Decide which value the QR should encode. Honours an explicit copy-sheet
+ * selection, but only while that value is still one we currently offer — once
+ * the selected address is regenerated or removed (e.g. a new invoice, an amount
+ * change), fall back to the unified BIP21 URI. This stops async rebuilds from
+ * silently reverting the user's pick and copying the wrong thing.
+ */
+export const resolveQrValue = (
+  selected: string,
+  options: { bip21: string; btc: string; ark: string; invoice: string; lnurl: string },
+): string => {
+  const candidates = [options.bip21, options.btc, options.ark, options.invoice, options.lnurl].filter(Boolean)
+  return selected && candidates.includes(selected) ? selected : options.bip21
+}
+
 export default function ReceiveQRCode() {
   const { useFiat } = useContext(ConfigContext)
   const { fromFiat } = useContext(FiatContext)
@@ -86,6 +101,7 @@ export default function ReceiveQRCode() {
   const [swapsTimedOut, setSwapsTimedOut] = useState(false)
   const [swapAddress, setSwapAddress] = useState('')
   const [qrCodeValue, setQrCodeValue] = useState('')
+  const [selectedValue, setSelectedValue] = useState('')
   const [bip21Uri, setBip21Uri] = useState('')
   const [invoice, setInvoice] = useState('')
 
@@ -113,6 +129,9 @@ export default function ReceiveQRCode() {
 
   const lnurlSession = useContext(LnurlContext)
   const isAmountlessLnurl = !satoshis && !isAssetReceive && !!lnurlServerUrl && lnurlSession.active
+  // LNURL is amountless by nature: only surface it when no amount is set. The
+  // session keeps running underneath — we just hide it from the QR + copy list.
+  const displayLnurl = isAmountlessLnurl ? lnurlSession.lnurl : ''
 
   const createBtcAddress = () => {
     return new Promise((resolve, reject) => {
@@ -151,7 +170,7 @@ export default function ReceiveQRCode() {
     const btc = utxoTxsAllowed() ? swapAddress || recvInfo.boardingAddr : ''
     const bip21 = isAssetReceive
       ? encodeBip21Asset(ark, assetId, assetAmount, assetMeta?.metadata?.decimals)
-      : encodeBip21(btc, ark, invoice, satoshis, lnurlSession.lnurl)
+      : encodeBip21(btc, ark, invoice, satoshis, displayLnurl)
 
     return { ark, btc, bip21 }
   }
@@ -221,18 +240,22 @@ export default function ReceiveQRCode() {
     if (!addressesLoaded && !showQrCode) return
 
     const { ark, btc, bip21 } = createBip21()
-    const hasLnurl = isAmountlessLnurl && lnurlSession.active
+    const hasLnurl = !!displayLnurl
 
     setNoPaymentMethods(!ark && !btc && !invoice && !hasLnurl && !isAssetReceive)
     setArkAddress(ark)
     setBtcAddress(btc)
     setBip21Uri(bip21)
-    setQrCodeValue(bip21)
+    // Preserve an explicit copy-sheet selection across rebuilds; only fall back
+    // to the unified URI when the selected value is no longer one we offer.
+    setQrCodeValue(resolveQrValue(selectedValue, { bip21, btc, ark, invoice, lnurl: displayLnurl }))
   }, [
     invoice,
     assetAmount,
     addressesLoaded,
     isAmountlessLnurl,
+    displayLnurl,
+    selectedValue,
     lnurlSession.lnurl,
     lnurlSession.active,
     recvInfo.offchainAddr,
@@ -486,12 +509,13 @@ export default function ReceiveQRCode() {
             bip21Uri={bip21Uri}
             btcAddress={btcAddress}
             arkAddress={arkAddress}
-            lnurl={lnurlSession.lnurl}
+            lnurl={displayLnurl}
             invoice={invoice}
             onCopy={handleCopy}
             onSelect={(v) => {
+              setSelectedValue(v)
               setQrCodeValue(v)
-              setShowCopySheet(false)
+              handleCopy(v)
             }}
             copied={copied}
           />
@@ -594,7 +618,7 @@ function AddressLine({
   return (
     <Focusable
       onEnter={() => {
-        onCopy(value)
+        // onSelect copies + switches the QR; avoid copying twice
         onSelect(value)
       }}
     >

--- a/src/test/lib/bip21.test.ts
+++ b/src/test/lib/bip21.test.ts
@@ -38,6 +38,23 @@ describe('bip21 utilities', () => {
       expect(satoshis).toBeUndefined()
     })
 
+    it('should decode mixed-case query parameter keys', () => {
+      const bip21 =
+        'bitcoin:?Ark=ARK1QQ4HFSSPRTCGNJZF8QLW2F78YVJAU5KLDFUGG29K34Y7J96Q2W4T4USH2JZ072D0ALD83VLWZRKDG24R40WRCM8XJW6AX7YPNJHTEZGU4A9R8D&Lightning=LNURL1DP68GURN8GHJ7MRWW4EXCTNPWF4KZER99EEKSTMVDE6HYMP0VG6N2VMXX4SKXC33XYEXVVTYXUMNXEFCXQCXYEP5X9JKZCMZXVESU28Y7U'
+      const { arkAddress, lnUrl } = decodeBip21(bip21)
+      expect(arkAddress).toBe(
+        'ARK1QQ4HFSSPRTCGNJZF8QLW2F78YVJAU5KLDFUGG29K34Y7J96Q2W4T4USH2JZ072D0ALD83VLWZRKDG24R40WRCM8XJW6AX7YPNJHTEZGU4A9R8D',
+      )
+      expect(lnUrl).toBe(
+        'LNURL1DP68GURN8GHJ7MRWW4EXCTNPWF4KZER99EEKSTMVDE6HYMP0VG6N2VMXX4SKXC33XYEXVVTYXUMNXEFCXQCXYEP5X9JKZCMZXVESU28Y7U',
+      )
+    })
+
+    it('should decode a mixed-case amount key', () => {
+      const { satoshis } = decodeBip21('bitcoin:bc1qexampleaddr?Amount=0.0005')
+      expect(satoshis).toBe(50_000)
+    })
+
     it('should throw an error for an invalid address', () => {
       expect(() => decodeBip21('invalidBip21')).toThrow('Invalid BIP21 URI')
     })
@@ -53,6 +70,13 @@ describe('bip21 utilities', () => {
       const { address, bip21, invoice, satoshis } = fixtures.lib.bip21
       const bip21WithoutArk = bip21.replace(/([?&])ark=[^&]+(&|$)/i, '$1').replace(/&$/, '')
       expect(encodeBip21(address!, '', invoice!, satoshis!)).toEqual(bip21WithoutArk)
+    })
+
+    it('should not group the amount with thousands separators', () => {
+      // 1000 BTC — large enough that Intl number formatting would insert a comma
+      const uri = encodeBip21('bc1qexampleaddr', '', '', 100_000_000_000)
+      expect(uri).not.toContain(',')
+      expect(uri).toContain('amount=1000')
     })
   })
 

--- a/src/test/screens/wallet/receive-qrcode.test.tsx
+++ b/src/test/screens/wallet/receive-qrcode.test.tsx
@@ -21,12 +21,19 @@ import { FiatContext } from '../../../providers/fiat'
 import { SwapsContext } from '../../../providers/swaps'
 import { NotificationsContext } from '../../../providers/notifications'
 import { ToastProvider } from '../../../components/Toast'
-import ReceiveQRCode from '../../../screens/Wallet/Receive/QrCode'
+import { LnurlContext } from '../../../providers/lnurl'
+import ReceiveQRCode, { resolveQrValue } from '../../../screens/Wallet/Receive/QrCode'
 
 // Mock qr module used by QrCode component
 vi.mock('qr', () => ({
   default: () => Array.from({ length: 21 }, () => new Uint8Array(21).fill(1)),
 }))
+
+// Provide a configured LNURL server URL so the amountless-LNURL path activates
+vi.mock('../../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/constants')>()
+  return { ...actual, lnurlServerUrl: 'https://lnurl.test' }
+})
 
 // Mock clipboard helper so we can assert it was called with the QR value
 const copyToClipboardMock = vi.fn((v) => Promise.resolve(v))
@@ -67,11 +74,14 @@ const mockNotificationsContextValue = {
   requestPermission: () => Promise.resolve(),
 }
 
+type LnurlValue = { lnurl: string; active: boolean; error: string | undefined }
+
 type RenderOverrides = {
   swaps?: Partial<typeof mockSwapsContextValue>
   flow?: Partial<typeof mockFlowContextValue>
   wallet?: Partial<typeof mockWalletContextValue>
   config?: Partial<typeof mockConfigContextValue>
+  lnurl?: Partial<LnurlValue>
 }
 
 function buildTree(overrides?: RenderOverrides) {
@@ -79,6 +89,7 @@ function buildTree(overrides?: RenderOverrides) {
   const flow = { ...mockFlowContextValue, ...overrides?.flow }
   const wallet = { ...mockWalletContextValue, ...overrides?.wallet }
   const config = { ...mockConfigContextValue, ...overrides?.config }
+  const lnurl: LnurlValue = { lnurl: '', active: false, error: undefined, ...overrides?.lnurl }
 
   return (
     <ToastProvider>
@@ -91,7 +102,9 @@ function buildTree(overrides?: RenderOverrides) {
                   <FlowContext.Provider value={flow as any}>
                     <WalletContext.Provider value={wallet as any}>
                       <LimitsContext.Provider value={mockLimitsContextValue}>
-                        <ReceiveQRCode />
+                        <LnurlContext.Provider value={lnurl}>
+                          <ReceiveQRCode />
+                        </LnurlContext.Provider>
                       </LimitsContext.Provider>
                     </WalletContext.Provider>
                   </FlowContext.Provider>
@@ -352,5 +365,61 @@ describe('Receive QR Code screen', () => {
     const copied = copyToClipboardMock.mock.calls[0][0]
     expect(copied).toMatch(/^bitcoin:/)
     expect(copied).toContain('ark1testaddr')
+  })
+
+  // Bug 2: amountless LNURL belongs in the QR; with an amount it must not.
+  it('includes the LNURL in the QR when no amount is set', async () => {
+    renderReceiveQrCode({ ...tapFixture(), lnurl: { lnurl: 'LNURL1TESTXYZ', active: true } })
+
+    const qrButton = await screen.findByRole('button', { name: 'Copy QR code' })
+    await act(async () => {
+      fireEvent.click(qrButton)
+    })
+
+    expect(copyToClipboardMock.mock.calls.at(-1)?.[0]).toContain('LNURL1TESTXYZ')
+  })
+
+  it('drops the LNURL from the QR once an amount is set', async () => {
+    renderReceiveQrCode({
+      swaps: { connected: false, arkadeSwaps: null },
+      flow: {
+        recvInfo: {
+          ...mockFlowContextValue.recvInfo,
+          satoshis: 50_000,
+          offchainAddr: 'ark1testaddr',
+          boardingAddr: 'bc1testaddr',
+        },
+      },
+      wallet: { svcWallet: mockSvcWallet as any },
+      lnurl: { lnurl: 'LNURL1TESTXYZ', active: true },
+    })
+
+    const qrButton = await screen.findByRole('button', { name: 'Copy QR code' })
+    await act(async () => {
+      fireEvent.click(qrButton)
+    })
+
+    const copied = copyToClipboardMock.mock.calls.at(-1)?.[0]
+    expect(copied).not.toContain('LNURL1TESTXYZ')
+    expect(copied).toContain('amount=')
+  })
+})
+
+describe('resolveQrValue', () => {
+  const opts = { bip21: 'bitcoin:unified', btc: 'bc1addr', ark: 'ark1addr', invoice: 'lnbc1inv', lnurl: 'LNURL1x' }
+
+  it('defaults to the unified BIP21 URI when nothing is selected', () => {
+    expect(resolveQrValue('', opts)).toBe('bitcoin:unified')
+  })
+
+  it('keeps an explicit selection that is still on offer', () => {
+    expect(resolveQrValue('ark1addr', opts)).toBe('ark1addr')
+    expect(resolveQrValue('lnbc1inv', opts)).toBe('lnbc1inv')
+  })
+
+  it('falls back to the unified URI when the selection is no longer offered', () => {
+    // e.g. the previously-selected invoice was regenerated / cleared
+    expect(resolveQrValue('lnbc1stale', opts)).toBe('bitcoin:unified')
+    expect(resolveQrValue('ark1addr', { ...opts, ark: '' })).toBe('bitcoin:unified')
   })
 })


### PR DESCRIPTION
## Summary

Fixes three reported bugs on the Receive and Send pages. Scoped to `src/lib/bip21.ts`, `src/screens/Wallet/Receive/QrCode.tsx`, and their tests.

### Receive — wrong value copied to clipboard
The BIP21-build effect called `setQrCodeValue(bip21)` on **every** async dependency change (LNURL session re-emit, invoice arrival, swap-address update). When a user picked a specific address in the "Copy address" sheet, the next effect fire silently reverted the QR back to the unified URI — so the bottom **Copy** button and QR tap then copied the wrong thing (timing-dependent → "sometimes").

- Extracted a pure `resolveQrValue()` that honors an explicit selection **while it is still on offer**, falling back to the unified URI only when the selected value is regenerated/removed.
- Tapping a copy-sheet **row** now copies that address **and** switches the QR (previously it switched without copying).
- `encodeBip21` formats the amount with `useGrouping: false`, so large amounts no longer produce a malformed `amount=1,000`.

### Receive — LNURL lingers after an amount is set
`isAmountlessLnurl` was computed but never applied: `createBip21()` and the copy sheet received `lnurlSession.lnurl` unconditionally. Now gated through `displayLnurl` — once an amount is set, LNURL is dropped from the QR and the copy list. **The LNURL provider session is untouched and keeps running underneath.**

### Send — BIP21 case handling ("finnicky")
`decodeBip21` only matched query keys that were *exactly* lowercase or *exactly* uppercase, so mixed-case keys from QR codes (`Amount`, `Ark`, `Lightning`, `AssetId`) were silently dropped. Replaced with a case-insensitive `getParam()`. The Arkade → LN → BTC preference is already enforced downstream and is unchanged.

## Test plan

- `src/test/lib/bip21.test.ts`: mixed-case key decode (`Ark`/`Lightning`/`Amount`), and no-thousands-separator encode.
- `src/test/screens/wallet/receive-qrcode.test.tsx`: LNURL present when amountless / dropped once an amount is set; `resolveQrValue` selection-persistence + stale-fallback.
- Each new test was confirmed to fail without its fix.
- Full unit suite: 284 passed / 4 skipped, 0 failures. `tsc --noEmit`, `eslint`, `prettier --check` all clean on the changed files.

## Not verifiable in CI (needs a real device)
The copy-sheet row interaction runs through vaul's portaled `Drawer`, which jsdom cannot click (documented in the existing test file). The sheet behavior is covered via the pure `resolveQrValue` logic; please confirm on-device that tapping a row copies + switches the QR, and that a selected address no longer reverts after an LNURL reconnect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BIP21 URI parameters now parse case-insensitively for improved compatibility
  * LNURL display corrected for amountless payment sessions
  * QR code address selection now persists correctly across rebuilds
  * Amount formatting improved for consistency in BIP21 URIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->