### PR TITLE
feat(dev): support VITE_DEV_MNEMONIC for dev auto-init

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,8 +100,9 @@ export default function App() {
     // avoid redirect if the user is still setting up the wallet
     if (initInfo.password || initInfo.privateKey) return
     if (!walletLoaded) return navigate(Pages.Loading)
-    // dev auto-init: stay on loading screen while VITE_DEV_NSEC initializes the wallet
-    if (import.meta.env.DEV && import.meta.env.VITE_DEV_NSEC && !initialized) return
+    // dev auto-init: stay on loading screen while VITE_DEV_NSEC/MNEMONIC initializes the wallet
+    if (import.meta.env.DEV && (import.meta.env.VITE_DEV_NSEC || import.meta.env.VITE_DEV_MNEMONIC) && !initialized)
+      return
     if (!wallet.pubkey) return navigate(Pages.Init)
     if (authState === 'locked') return navigate(Pages.Unlock)
   }, [walletLoaded, wallet.pubkey, authState, initInfo, aspInfo.unreachable, jsCapabilitiesChecked, isCapable])
@@ -178,9 +179,9 @@ export default function App() {
 
   // Boot animation: persists on Loading, then flies to the LogoIcon position when
   // Wallet is reached. For any other destination (Unlock, Init, etc.), exits with fly-up.
-  // Skip in dev with VITE_DEV_NSEC — the fast auto-init races with the animation.
+  // Skip in dev with VITE_DEV_NSEC/MNEMONIC — the fast auto-init races with the animation.
   useEffect(() => {
-    if (import.meta.env.DEV && import.meta.env.VITE_DEV_NSEC) return
+    if (import.meta.env.DEV && (import.meta.env.VITE_DEV_NSEC || import.meta.env.VITE_DEV_MNEMONIC)) return
 
     if (page === Pages.Loading && !bootAnimActive) {
       setBootAnimDone(false)

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -197,20 +197,21 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
 
   // wallet is read synchronously in useState initializer above
 
+  const devMnemonic = import.meta.env.VITE_DEV_MNEMONIC as string | undefined
   const devNsec = import.meta.env.VITE_DEV_NSEC as string | undefined
-  const isDevAutoInit = import.meta.env.DEV && Boolean(devNsec)
+  const isDevAutoInit = import.meta.env.DEV && (Boolean(devMnemonic) || Boolean(devNsec))
   const [devAutoInitFailed, setDevAutoInitFailed] = useState(false)
 
-  // dev-only: auto-initialize wallet from VITE_DEV_NSEC, bypassing onboarding and unlock
+  // dev-only: auto-initialize wallet from VITE_DEV_MNEMONIC / VITE_DEV_NSEC, bypassing onboarding and unlock
   useEffect(() => {
-    if (!isDevAutoInit || !devNsec || devAutoInitFailed) return
+    if (!isDevAutoInit || devAutoInitFailed) return
     if (initialized) return
     if (!aspInfo.url) return
 
     const autoInit = async () => {
       try {
-        const privateKey = nsecToPrivateKey(devNsec)
-        await initWallet({ privateKey })
+        if (devMnemonic) await initWallet({ mnemonic: devMnemonic })
+        else if (devNsec) await initWallet({ privateKey: nsecToPrivateKey(devNsec) })
         setAuthState('authenticated')
       } catch (err) {
         consoleError(err, 'Dev auto-init failed')

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -130,6 +130,16 @@ describe('App startup routing', () => {
     expect(navigate).not.toHaveBeenCalledWith(Pages.Unlock)
   })
 
+  it('holds on loading during dev auto-init from VITE_DEV_MNEMONIC instead of redirecting', async () => {
+    vi.stubEnv('VITE_DEV_MNEMONIC', 'abandon abandon abandon abandon abandon about')
+    const { navigate } = renderApp({ authState: 'locked', initialized: false })
+
+    await waitFor(() => expect(screen.getByTestId('app')).toBeInTheDocument())
+    // while VITE_DEV_MNEMONIC auto-initializes the wallet we stay on loading, not unlock/init
+    expect(navigate).not.toHaveBeenCalledWith(Pages.Unlock)
+    expect(navigate).not.toHaveBeenCalledWith(Pages.Init)
+  })
+
   it('schedules a single reload after passwordless auto-init failure', async () => {
     vi.useFakeTimers()
     const reloadSpy = vi.spyOn(appReloader, 'reload').mockImplementation(() => {})

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_ARK_SERVER?: string
   readonly VITE_DEV_NSEC?: string
+  readonly VITE_DEV_MNEMONIC?: string
   readonly VITE_BOLTZ_URL?: string
   readonly VITE_DELEGATOR_URL?: string
   // Add other env variables as needed


### PR DESCRIPTION
## Summary

Extends the dev-only auto-init (previously `VITE_DEV_NSEC` only) to also accept a BIP39 mnemonic via `VITE_DEV_MNEMONIC`, so a dev wallet can be auto-initialized from a seed phrase. When both vars are set, the mnemonic takes precedence.

- **`App.tsx`** — the startup routing keeps the wallet on the loading screen, and the boot animation is skipped, while *either* dev var auto-initializes the wallet (previously only `VITE_DEV_NSEC`).
- **`providers/wallet.tsx`** — `WalletProvider` auto-init now initializes from the mnemonic (`initWallet({ mnemonic })`, which builds a `MnemonicIdentity`) or falls back to the nsec/private-key path.
- **`vite-env.d.ts`** — declares `VITE_DEV_MNEMONIC` in `ImportMetaEnv` (parity with `VITE_DEV_NSEC`).

All of this is gated on `import.meta.env.DEV`, so it has no effect on production builds.

## Test plan

- New unit test in `App.test.tsx` asserts that with `VITE_DEV_MNEMONIC` set and the wallet not yet initialized, the app holds on the loading screen instead of redirecting to unlock/init. Verified it fails without the `App.tsx` guard change (genuine regression test).
- `tsc`, `eslint`, prettier, and the existing suite pass locally.

## Notes / follow-up

- The `WalletProvider` credential-selection branch (mnemonic vs. nsec in `wallet.tsx`) is **not** covered by a unit test: `WalletProvider` currently has no test harness, and the pre-existing `VITE_DEV_NSEC` init path was untested too. The new test covers the observable App-level routing behavior. Standing up a full `WalletProvider` test harness (mocking the SDK `MnemonicIdentity`, IndexedDB adapter, boltz-swap repos, ASP context) is a larger, separate effort — happy to do it as a follow-up if wanted.
- Neither `VITE_DEV_NSEC` nor `VITE_DEV_MNEMONIC` is documented in an `.env.example` (none exists in the repo), so this PR doesn't add one to stay consistent with the current convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet auto-initialization now supports both mnemonic seed phrases and nsec private keys during development, with preference for mnemonic when available.

* **Tests**
  * Added test coverage verifying the loading screen remains visible during wallet initialization in development mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->