### PR TITLE
chore: bump regtest submodule to master + finish Node-CLI migration

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -1,11 +1,6 @@
 # wallet arkade-regtest overrides
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.5
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.5
 FULMINE_IMAGE=ghcr.io/arklabshq/fulmine:v0.3.23
 BOLTZ_IMAGE=boltz/boltz:latest
-
-# nbxplorer guard in start-env.sh handles missing container gracefully
-BITCOIN_LOW_FEE=true
 
 # Match wallet's existing arkd config
 ARKD_SCHEDULER_TYPE=gocron

--- a/.env.regtest
+++ b/.env.regtest
@@ -1,5 +1,8 @@
 # wallet arkade-regtest overrides
-FULMINE_IMAGE=ghcr.io/arklabshq/fulmine:v0.3.23
+# NOTE: don't pin FULMINE_IMAGE here — the arkade-regtest stack's compose tracks
+# the matching Fulmine env-var contract (FULMINE_DELEGATE_*), so an out-of-date
+# pin (e.g. v0.3.23, which only reads FULMINE_DELEGATOR_*) silently breaks the
+# delegator. Use the submodule's default Fulmine image.
 BOLTZ_IMAGE=boltz/boltz:latest
 
 # Match wallet's existing arkd config

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,14 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        submodules: true
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.23'
-    - uses: actions/cache@v4
-      with:
-        path: regtest/_build
-        key: nigiri-${{ hashFiles('regtest/.env.defaults', '.env.regtest') }}
+        submodules: recursive
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
@@ -30,9 +23,7 @@ jobs:
     - name: Install Playwright Browsers
       run: pnpm exec playwright install chrome chromium --with-deps
     - name: Start regtest environment
-      run: chmod +x regtest/*.sh regtest/helpers/*.sh && ./regtest/start-env.sh
-    - name: Add nigiri to PATH
-      run: echo "${{ github.workspace }}/regtest/_build/nigiri/build" >> $GITHUB_PATH
+      run: node regtest/regtest.mjs start --env .env.regtest
     - name: Start nostr relay
       run: docker compose -f docker-compose.nak.yml up -d --build
     - name: Verify environment
@@ -54,4 +45,4 @@ jobs:
       if: always()
       run: |
         docker compose -f docker-compose.nak.yml down -v 2>/dev/null || true
-        chmod +x regtest/*.sh regtest/helpers/*.sh 2>/dev/null; ./regtest/clean-env.sh
+        node regtest/regtest.mjs clean --env .env.regtest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        persist-credentials: false
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*

--- a/README.md
+++ b/README.md
@@ -111,24 +111,27 @@ It correctly bundles React in production mode and optimizes the build for the be
 The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
 
-### `pnpm run regtest`
+### `pnpm run regtest:start`
 
 Starts the regtest environment and sets up the arkd instance.\
-Requires Docker to be installed and [Nigiri](https://nigiri.vulpem.com/) to be running with `--ln` flag.
+Requires Docker and Node.js >= 18. The stack is driven by the in-house
+`arkade-regtest` Node CLI (`regtest/regtest.mjs`) — no Nigiri required.
+
+Use `pnpm run regtest:stop` to stop it and `pnpm run regtest:clean` to tear it down.
 
 ### Funding your local wallet
 To interact with Ark features, you need Regtest coins.
 1. Copy your address from the wallet's **Receive** screen (ensure it starts with bcrt1 for Regtest).
-2. Run the Nigiri faucet command: 
+2. Run the faucet command (the `--confirm` flag mines a block so the deposit confirms):
 ```bash
-nigiri faucet <bcrt-address>
+node regtest/regtest.mjs faucet <bcrt-address> <btc> --confirm
 ```
 
 
 ### e2e tests
 
 > note: e2e tests require a regtest environment to be running.
-> `pnpm run regtest` to start and setup the regtest environment.
+> `pnpm run regtest:start` to start and setup the regtest environment.
 
 > note: e2e tests use playwright for ui testing, you may need to run
 > `pnpm exec playwright install` once to download new browsers.
@@ -153,6 +156,6 @@ pnpm run test:codegen
 
 ## Troubleshooting
 ### `address already in use` (Port 5000) on macOS
-macOS AirPlay Receiver uses port 5000 by default, which conflicts with Nigiri.
+macOS AirPlay Receiver uses port 5000 by default, which conflicts with the regtest stack.
 - **Fix:** Go to `System Settings > General > AirDrop & Handoff` and disable **AirPlay Receiver**.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Your app is ready to be deployed!
 ### `pnpm run regtest:start`
 
 Starts the regtest environment and sets up the arkd instance.\
-Requires Docker and Node.js >= 18. The stack is driven by the in-house
+Requires Docker and Node.js v20.19+ or v22.12+. The stack is driven by the in-house
 `arkade-regtest` Node CLI (`regtest/regtest.mjs`) — no Nigiri required.
 
 Use `pnpm run regtest:stop` to stop it and `pnpm run regtest:clean` to tear it down.

--- a/docker-compose.nak.yml
+++ b/docker-compose.nak.yml
@@ -1,4 +1,4 @@
-name: nigiri
+name: wallet-nak
 services:
   nak:
     build:
@@ -11,5 +11,7 @@ services:
 
 networks:
   default:
-    name: nigiri
+    # Join the arkade-regtest base stack network (started before this in CI) so
+    # the relay sits alongside the regtest services, as it did on nigiri's network.
+    name: arkade-regtest_default
     external: true

--- a/docs/swaps.regtest.md
+++ b/docs/swaps.regtest.md
@@ -1,223 +1,125 @@
 # Swaps
 
-The purpose of this guide is to make you able to test Ark/LN submarine and reverse submarine swaps and walks you through setting a full stack on regtest that includes:
+This guide walks you through testing Ark/Lightning **submarine** and **reverse
+submarine** swaps against a full local regtest stack.
 
-- Ark stack
-  - Bitcoind
-  - Arkd
-- Boltz stack
-  - Bitcoind
-  - LND
-  - Fulmine
-  - Boltz backend
-- User stack
-  - Bitcoind
-  - LND
-  - Arkade
+The stack is orchestrated end-to-end by the in-house `arkade-regtest` Node CLI
+(`regtest/regtest.mjs`, vendored as the `regtest` git submodule) — there is no
+Nigiri and no manual service wiring. A single `pnpm run regtest:start` brings up
+**and provisions** everything:
 
-NOTE: _For sake of simplicity, all stacks use the same Bitcoind instance._
+- **Ark** — Bitcoin Core + `arkd`/`arkd-wallet` (the server wallet is created,
+  unlocked and funded automatically).
+- **Boltz** — the Boltz backend, its Lightning node (`boltz-lnd`) and Fulmine
+  (`boltz-fulmine`). The `boltz-lnd ⇄ lnd` channel is opened and balanced, Boltz's
+  Bitcoin Core wallet is funded, and the ARK/BTC pairs are verified.
+- **Counterparty Lightning** — a second LND node (`lnd`) that you drive with
+  `lncli` to play the remote side of each swap.
+- **Arkade wallet** — the app under test (run with `pnpm start`).
+
+> Everything the earlier (Nigiri-based) edition of this guide did by hand —
+> `nigiri start --ln`, manual `arkd wallet` create/unlock, opening LND channels,
+> wiring Fulmine — is now automatic. Funding is done with the CLI faucet:
+> `node regtest/regtest.mjs faucet <address> <btc> --confirm`.
 
 ## Requirements
 
 - [Docker](https://docs.docker.com/engine/install/)
 - [Node.js](https://nodejs.org/) v20.19+ or v22.12+ (drives the `arkade-regtest` stack via `regtest/regtest.mjs`)
-- [jq](https://formulae.brew.sh/formula/jq)
+- [jq](https://formulae.brew.sh/formula/jq) (optional — used below to pull fields out of `lncli` JSON)
 
-> **Note:** This guide predates the migration of `arkade-regtest` off Nigiri and still
-> describes a manual Nigiri/`test.docker-compose.yml` based flow that no longer matches the
-> in-house Node CLI stack. The `nigiri faucet` calls below have been updated to the new CLI,
-> but the `nigiri start --ln`, `nigiri lnd …` and `nigiri rpc …` LN helper steps do not have
-> direct 1:1 equivalents in the Node CLI and need a manual rewrite — see the PR open questions.
+## 1. Start the regtest stack
 
-## Setup regtest environment
-
-Start regtest environment with Bitcoin and LND:
+From the repo root:
 
 ```sh
-nigiri start --ln
+pnpm run regtest:start
 ```
 
-Fund LND wallet:
+This runs `node regtest/regtest.mjs start --env .env.regtest` (the full stack,
+including the `boltz` profile) and the local nostr relay. The first run pulls
+images and can take a few minutes; it's ready when the CLI prints the service
+URLs (arkd on `http://localhost:7070`, Fulmine on `http://localhost:7003`, the
+Boltz CORS proxy on `http://localhost:9069`, …).
+
+A handy alias for the counterparty Lightning node:
 
 ```sh
-# Faucet 1 BTC
-nigiri faucet lnd
+alias lncli="docker exec -i lnd lncli --network=regtest"
 ```
 
-Start LND used by boltz:
+## 2. Start the wallet
 
 ```sh
-docker compose -f test.docker-compose.yml up -d boltz-lnd
-# Create an alias for lncli
-alias lncli="docker exec -i boltz-lnd lncli --network=regtest"
+pnpm start
 ```
 
-Fund LND wallet:
+Open <http://localhost:3002> and create/unlock a wallet. On `localhost` the app
+automatically targets the local `arkd` (`http://localhost:7070`) and its regtest
+network — no `VITE_ARK_SERVER` needed. The regtest Boltz endpoint
+(`http://localhost:9069`) is likewise built in.
+
+> To exercise the LNURL / nostr-backup features as well, start with:
+> `VITE_LNURL_SERVER_URL=http://localhost:9090 VITE_NOSTR_RELAY_URL=ws://localhost:10547 pnpm start`
+
+## 3. Fund the wallet
+
+On the wallet's **Receive** screen, copy the on-chain (boarding) address — the
+`bcrt1…` one — and faucet it:
 
 ```sh
-lncli newaddress p2wkh
-# Faucet 1 BTC
-node regtest/regtest.mjs faucet <address> 1 --confirm
-```
-
-Connect the LND instances:
-
-```sh
-lncli connect `nigiri lnd getinfo | jq -r .identity_pubkey`@lnd:9735
-# Check the list of peers contains exactly one peer on both sides
-lncli listpeers | jq .peers | jq length
-nigiri lnd listpeers | jq .peers | jq length
-```
-
-Open and fund channel between the LND instances:
-
-```sh
-# 100k sats channel Boltz <> User
-lncli openchannel --node_key=`nigiri lnd getinfo | jq -r .identity_pubkey` --local_amt=100000
-# Make the channel mature by mining 10 blocks
-nigiri rpc --generate 10
-# Send 50k sats to the other side to balance the channel
-nigiri lnd addinvoice --amt 50000
-# Type 'yes' if asked
-lncli payinvoice --force <invoice aka payment_request>
-```
-
-Start and provision Arkd:
-
-```sh
-docker compose -f test.docker-compose.yml up -d arkd
-# Create an alias for arkd
-alias arkd="docker exec arkd arkd"
-# Initialize the wallet
-arkd wallet create --password password
-# Unlock the service
-arkd wallet unlock --password password
-# Get an address to deposit funds.
-# If it returns error, just wait a few seconds and retry.
-arkd wallet address
-# Faucet 1 BTC (better if you repeat a few times)
-node regtest/regtest.mjs faucet <address> 1 --confirm
-```
-
-NOTE: _The Docker services in `test.docker-compose.yml` use temporary volumes; restarting them wipes all state._ **AVOID RESTARTING.**
-
-## Setup Fulmine used by Boltz
-
-Start Fulmine used by Boltz:
-
-```sh
-docker compose -f test.docker-compose.yml up -d boltz-fulmine
-```
-
-Open [http://localhost:7003](http://localhost:7003) in your browser and initialise/unlock Fulmine — the Arkd URL field is pre-filled.
-
-Go to the receive page, copy the bitcoin address (the second one) and send it some funds:
-
-```sh
-# Faucet 100k sats
+# 0.001 BTC; --confirm mines a block so the deposit confirms
 node regtest/regtest.mjs faucet <address> 0.001 --confirm
 ```
 
-On your browser, go back to homepage of Fulmine, click on the pending tx and settle - click on the action menu, three dots on the top-right.
+Back on the wallet home, open the pending transaction and **settle** it. You're
+now ready to test swaps.
 
-Lastly, connect Fulmine with Boltz's LND instance. For this, you need an lndconnect URL that you can generate with:
+## Test Submarine Swap (Ark → Lightning)
+
+Create a 5,000-sat invoice on the counterparty node and pay it from the wallet:
 
 ```sh
-docker exec boltz-lnd bash -c \
-  'echo -n "lndconnect://boltz-lnd:10009?cert=$(grep -v CERTIFICATE /root/.lnd/tls.cert \
-     | tr -d = | tr "/+" "_-")&macaroon=$(base64 /root/.lnd/data/chain/bitcoin/regtest/admin.macaroon \
-     | tr -d = | tr "/+" "_-")"' | tr -d '\n'
+lncli addinvoice --amt 5000 | jq -r .payment_request
 ```
 
-Copy the generated URL to the clipboard. On Fulmine's tab of your browser, go to Settings > Lightning, paste the URL and click the Connect button.
+Copy the `payment_request` and pay it in Arkade. After payment your transaction
+history shows the outgoing swap (amount + Boltz fee), and Fulmine's history
+(<http://localhost:7003>) shows the matching incoming movement.
 
-## Start Boltz backend
+> The exact sat split (amount vs. fee) depends on the Boltz release and on-chain
+> fee rate, so don't expect fixed numbers — just that `amount + fees` reconciles.
 
-Start Boltz backend with:
+## Test Reverse Swap (Lightning → Ark)
+
+In Arkade go to **Receive**, enter an amount (e.g. 4,000 sats) and continue to get
+a Lightning invoice. Pay it from the counterparty node:
 
 ```sh
-docker compose -f test.docker-compose.yml up -d boltz-postgres boltz
+lncli payinvoice --force <invoice>
 ```
 
-## Start CORS proxy
+The wallet should show the received funds a moment later.
 
-Start CORS proxy with:
-
-```sh
-docker compose -f test.docker-compose.yml up -d cors
-```
-
-## Setup Arkade used by end user
-
-Start Arkade:
+## Teardown
 
 ```sh
-VITE_ARK_SERVER=http://localhost:7070 pnpm start
-```
-
-Open [http://localhost:3002](http://localhost:3002) in a new browser tab and initialise/unlock the service.
-
-Go then to the receive page, click Skip, copy the boarding address - the second one - and send it some funds:
-
-```sh
-nigiri faucet <address> 0.001
-```
-
-On your browser, go back to homepage of Arkade, click on the pending tx and settle.
-
-You're good to go to test submarine and reverse submarine swaps on Ark!
-
-## Test Submarine Swap (Ark => Lightning)
-
-Generate a 5000 sats Lightning invoice:
-
-```sh
-nigiri lnd addinvoice --amt 5000
-```
-
-Copy the invoice (aka payment_request) and try to pay it on Arkade
-
-After payment, your [transaction history](http://localhost:3002/) should have a new movement of -5001 sats
-
-Boltz Fulmine's [transaction history](http://localhost:7003/) should have a new movement of +5001 sats
-
-Your LND channel balance should be 55000 sats
-
-```sh
-nigiri lnd channelbalance | jq .balance
-```
-
-## Test Reverse Swap (Lightning => Ark)
-
-In Arkade go to Receive, define an amount of 4000 sats and click Continue
-
-Copy the Lightning invoice, the fourth one.
-
-Pay the invoice with LND:
-
-```sh
-nigiri lnd payinvoice <invoice>
-```
-
-Check if you receive the payment on Arkade
-
-After payment, your [transaction history](http://localhost:3002/) should have a new movement of +3984 sats
-
-Boltz Fulmine's [transaction history](http://localhost:7003/) should have a new movement of -3984 sats
-
-Your LND channel balance should be 51000 sats
-
-```sh
-nigiri lnd channelbalance | jq .balance
+pnpm run regtest:stop     # stop the stack
+pnpm run regtest:clean    # stop and wipe all volumes/state
 ```
 
 ## Troubleshooting
 
-- If you're on Mac M-family, you have to build the boltz-backend docker image locally:
+- On Apple Silicon (M-family) you may need to build the boltz-backend image
+  locally and point the stack at it:
 
-```sh
-# Clone boltz-backend locally
-git clone git@github.com:BoltzExchange/boltz-backend.git && cd boltz-backend
-# Build the image, the VERSION=ark makes sure that the ark branch of the repo is built.
-docker build --build-arg NODE_VERSION=lts-bookworm-slim --build-arg VERSION=ark -t boltz/boltz:ark -f docker/boltz/Dockerfile .
-```
+  ```sh
+  # Clone boltz-backend locally
+  git clone git@github.com:BoltzExchange/boltz-backend.git && cd boltz-backend
+  # Build the image; VERSION=ark builds the ark branch.
+  docker build --build-arg NODE_VERSION=lts-bookworm-slim --build-arg VERSION=ark \
+    -t boltz/boltz:ark -f docker/boltz/Dockerfile .
+  ```
+
+  Then set `BOLTZ_IMAGE=boltz/boltz:ark` in `.env.regtest` and re-run
+  `pnpm run regtest:start`.

--- a/docs/swaps.regtest.md
+++ b/docs/swaps.regtest.md
@@ -20,7 +20,7 @@ NOTE: _For sake of simplicity, all stacks use the same Bitcoind instance._
 ## Requirements
 
 - [Docker](https://docs.docker.com/engine/install/)
-- [Node.js](https://nodejs.org/) >= 18 (drives the `arkade-regtest` stack via `regtest/regtest.mjs`)
+- [Node.js](https://nodejs.org/) v20.19+ or v22.12+ (drives the `arkade-regtest` stack via `regtest/regtest.mjs`)
 - [jq](https://formulae.brew.sh/formula/jq)
 
 > **Note:** This guide predates the migration of `arkade-regtest` off Nigiri and still

--- a/docs/swaps.regtest.md
+++ b/docs/swaps.regtest.md
@@ -20,8 +20,14 @@ NOTE: _For sake of simplicity, all stacks use the same Bitcoind instance._
 ## Requirements
 
 - [Docker](https://docs.docker.com/engine/install/)
-- [Nigiri](https://nigiri.vulpem.com/)
+- [Node.js](https://nodejs.org/) >= 18 (drives the `arkade-regtest` stack via `regtest/regtest.mjs`)
 - [jq](https://formulae.brew.sh/formula/jq)
+
+> **Note:** This guide predates the migration of `arkade-regtest` off Nigiri and still
+> describes a manual Nigiri/`test.docker-compose.yml` based flow that no longer matches the
+> in-house Node CLI stack. The `nigiri faucet` calls below have been updated to the new CLI,
+> but the `nigiri start --ln`, `nigiri lnd …` and `nigiri rpc …` LN helper steps do not have
+> direct 1:1 equivalents in the Node CLI and need a manual rewrite — see the PR open questions.
 
 ## Setup regtest environment
 
@@ -51,7 +57,7 @@ Fund LND wallet:
 ```sh
 lncli newaddress p2wkh
 # Faucet 1 BTC
-nigiri faucet <address>
+node regtest/regtest.mjs faucet <address> 1 --confirm
 ```
 
 Connect the LND instances:
@@ -90,7 +96,7 @@ arkd wallet unlock --password password
 # If it returns error, just wait a few seconds and retry.
 arkd wallet address
 # Faucet 1 BTC (better if you repeat a few times)
-nigiri faucet <address>
+node regtest/regtest.mjs faucet <address> 1 --confirm
 ```
 
 NOTE: _The Docker services in `test.docker-compose.yml` use temporary volumes; restarting them wipes all state._ **AVOID RESTARTING.**
@@ -109,7 +115,7 @@ Go to the receive page, copy the bitcoin address (the second one) and send it so
 
 ```sh
 # Faucet 100k sats
-nigiri faucet <address> 0.001
+node regtest/regtest.mjs faucet <address> 0.001 --confirm
 ```
 
 On your browser, go back to homepage of Fulmine, click on the pending tx and settle - click on the action menu, three dots on the top-right.

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
     "format": "prettier --write src",
     "format:check": "prettier --check src",
     "git-info": "node scripts/git-commit-info.js",
-    "regtest:start": "./regtest/start-env.sh && docker compose -f docker-compose.nak.yml up -d",
-    "regtest:stop": "./regtest/stop-env.sh && docker compose -f docker-compose.nak.yml down",
-    "regtest:clean": "./regtest/clean-env.sh && docker compose -f docker-compose.nak.yml down -v",
+    "regtest:start": "node regtest/regtest.mjs start --env .env.regtest && docker compose -f docker-compose.nak.yml up -d",
+    "regtest:stop": "node regtest/regtest.mjs stop --env .env.regtest && docker compose -f docker-compose.nak.yml down",
+    "regtest:clean": "node regtest/regtest.mjs clean --env .env.regtest && docker compose -f docker-compose.nak.yml down -v",
     "regtest:setup": "node src/test/setup.mjs"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "format:check": "prettier --check src",
     "git-info": "node scripts/git-commit-info.js",
     "regtest:start": "node regtest/regtest.mjs start --env .env.regtest && docker compose -f docker-compose.nak.yml up -d",
-    "regtest:stop": "node regtest/regtest.mjs stop --env .env.regtest && docker compose -f docker-compose.nak.yml down",
-    "regtest:clean": "node regtest/regtest.mjs clean --env .env.regtest && docker compose -f docker-compose.nak.yml down -v",
+    "regtest:stop": "docker compose -f docker-compose.nak.yml down && node regtest/regtest.mjs stop --env .env.regtest",
+    "regtest:clean": "docker compose -f docker-compose.nak.yml down -v && node regtest/regtest.mjs clean --env .env.regtest",
     "regtest:setup": "node src/test/setup.mjs"
   },
   "eslintConfig": {

--- a/src/lib/explorers.ts
+++ b/src/lib/explorers.ts
@@ -13,7 +13,7 @@ const explorers: Explorers = {
     web: 'https://mempool.space',
   },
   regtest: {
-    api: 'http://localhost:3000',
+    api: 'http://localhost:3000/api',
     web: 'http://localhost:5000',
   },
   signet: {

--- a/src/test/e2e/receive.test.ts
+++ b/src/test/e2e/receive.test.ts
@@ -9,9 +9,12 @@ import {
   readClipboard,
   createWalletWithFiat,
 } from './utils'
-import { exec } from 'child_process'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { faucetOffchain } from './fundedWallet'
 import { sleep } from '../../lib/sleep'
+
+const execFileAsync = promisify(execFile)
 
 test('should receive onchain funds', async ({ page }) => {
   test.setTimeout(60000)
@@ -23,8 +26,10 @@ test('should receive onchain funds', async ({ page }) => {
   expect(boardingAddress).toBeDefined()
   expect(boardingAddress).toBeTruthy()
 
-  // faucet (--confirm mines a block so the deposit confirms, matching old nigiri auto-mine)
-  exec(`node regtest/regtest.mjs faucet ${boardingAddress} 0.0001 --confirm`)
+  // faucet (--confirm mines a block so the deposit confirms, matching old nigiri auto-mine).
+  // Await it (and pass args, not a shell string) so the deposit is sent+confirmed
+  // before we wait — a fire-and-forget exec races waitForPaymentReceived.
+  await execFileAsync('node', ['regtest/regtest.mjs', 'faucet', boardingAddress, '0.0001', '--confirm'])
 
   // wait for payment received
   await waitForPaymentReceived(page)

--- a/src/test/e2e/receive.test.ts
+++ b/src/test/e2e/receive.test.ts
@@ -23,8 +23,8 @@ test('should receive onchain funds', async ({ page }) => {
   expect(boardingAddress).toBeDefined()
   expect(boardingAddress).toBeTruthy()
 
-  // faucet
-  exec(`nigiri faucet ${boardingAddress} 0.0001`)
+  // faucet (--confirm mines a block so the deposit confirms, matching old nigiri auto-mine)
+  exec(`node regtest/regtest.mjs faucet ${boardingAddress} 0.0001 --confirm`)
 
   // wait for payment received
   await waitForPaymentReceived(page)

--- a/src/test/e2e/swap.test.ts
+++ b/src/test/e2e/swap.test.ts
@@ -172,9 +172,19 @@ test('should send funds to Bitcoin', async ({ page, isMobile }) => {
   expect(await page.getByTestId('Direction').textContent()).toBe('Arkade to BTC')
   expect(await page.getByTestId('BTC Address').textContent()).toBe(prettyLongText(someOnchainAddress))
   expect(await page.getByTestId('Status').textContent()).toBe('transaction.claimed')
-  expect(await page.getByTestId('Amount').textContent()).toBe('2,111 SATS')
-  expect(await page.getByTestId('Fees').textContent()).toBe('164 SATS')
-  expect(await page.getByTestId('Total').textContent()).toBe('2,275 SATS')
+  // The exact sat split depends on the onchain claim fee, which differs between
+  // Boltz releases: the arkade-regtest stack runs boltz/boltz:latest at a
+  // realistic 1 sat/vB, whereas nigiri's pinned Boltz produced a different fee
+  // (which is where the old 2,111 / 164 / 2,275 constants came from). Assert the
+  // amounts are present and internally consistent (Amount + Fees === Total)
+  // rather than pinning environment-specific sat values.
+  const toSats = (s: string | null) => Number((s ?? '').replace(/[^0-9]/g, ''))
+  const amount = toSats(await page.getByTestId('Amount').textContent())
+  const fees = toSats(await page.getByTestId('Fees').textContent())
+  const total = toSats(await page.getByTestId('Total').textContent())
+  expect(amount).toBeGreaterThan(0)
+  expect(fees).toBeGreaterThan(0)
+  expect(total).toEqual(amount + fees)
 })
 
 test('should refund failing swap', async ({ page }) => {


### PR DESCRIPTION
Bumps the `regtest` submodule to arkade-regtest `master` and completes the nigiri → in-house Node-CLI migration on the wallet (consumer) side.

### Background
The submodule migration was only half-landed on `master`: the `regtest` submodule was still pinned to a **pre-migration nigiri commit** (`cd47313`, ships `start-env.sh`), and the wallet's workflow/scripts still invoked those `.sh` files. Pointing the submodule at the Node-CLI `master` tip (`0ed365d`) removes those scripts, so the consumer side has to migrate too. This brings over the consumer-side changes from the now-closed #644.

### Changes
- **`regtest` submodule** `cd47313 → 0ed365d` (arkade-regtest `master`; clean forward bump, `.gitmodules` already tracks `branch = master`).
- **`.github/workflows/playwright.yml`** + **`package.json`**: `start-env.sh`/`stop-env.sh`/`clean-env.sh` → `node regtest/regtest.mjs start|stop|clean --env .env.regtest`.
- **`src/test/e2e/{receive,swap}.test.ts`**: faucet via the Node CLI; the chain-swap test asserts the split invariant (`Amount + Fees === Total`) instead of nigiri-Boltz-specific sat constants (`boltz/boltz:latest` uses a different, realistic claim fee).
- **`src/lib/explorers.ts` / `.env.regtest` / `docker-compose.nak.yml` / docs**: point at the in-house stack; drop the stale `arkd v0.9.5` pin so the submodule default is used.

### Note
arkade-regtest `master` is still behind its `denigiri-regtest` branch (no signer-rotation hardening, and the emulator/solver/lnurl image bumps in ArkLabsHQ/arkade-regtest#34 aren't on `master` yet), so this pins the current master stack. A follow-up bump picks those up once they land on arkade-regtest `master`.

Supersedes #644.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local development and regtest instructions to use the Node.js-based arkade-regtest stack instead of Nigiri
  * Updated local wallet funding and faucet workflow commands for regtest
  * Clarified regtest troubleshooting guidance and regtest swaps guidance (including warnings about older Nigiri steps)
* **Tests**
  * Enhanced swap e2e test to validate displayed Amount/Fees/Total dynamically (using UI values and arithmetic) instead of hardcoded expectations
  * Updated receive e2e test to fund via the local regtest faucet command
<!-- end of auto-generated comment: release notes by coderabbit.ai -->