### PR TITLE
fix(receive): allow clearing a set amount on the mobile keyboard

### DIFF
--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -19,10 +19,11 @@ interface KeyboardProps {
   asset?: AssetOption
   back: () => void
   hideBalance?: boolean
+  onClear?: () => void
   onSave: (value: string) => void
 }
 
-export default function Keyboard({ asset, back, hideBalance, onSave }: KeyboardProps) {
+export default function Keyboard({ asset, back, hideBalance, onClear, onSave }: KeyboardProps) {
   const { config, useFiat } = useContext(ConfigContext)
   const { fromFiat, toFiat, fiatDecimals } = useContext(FiatContext)
   const { balance, svcWallet } = useContext(WalletContext)
@@ -213,6 +214,7 @@ export default function Keyboard({ asset, back, hideBalance, onSave }: KeyboardP
       </div>
       <ButtonsOnBottom>
         <Button label='Save' disabled={disabled} onClick={handleSave} />
+        {onClear ? <Button label='Clear amount' onClick={onClear} secondary /> : null}
       </ButtonsOnBottom>
     </>
   )

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -364,6 +364,8 @@ export default function ReceiveQRCode() {
   }
 
   const handleAmountClear = () => {
+    setShowKeys(false)
+    setShowAmountSheet(false)
     setAmountTextValue('')
     if (assetMeta) setAssetAmount(BigInt(0))
     else setRecvInfo({ ...recvInfo, satoshis: 0 })
@@ -381,6 +383,10 @@ export default function ReceiveQRCode() {
   const data = { title: 'Receive', text: qrCodeValue }
   const shareDisabled = !canBrowserShareData(data) || sharing || hasError || noPaymentMethods
 
+  // Whether an amount is currently requested. Keyed off assetMeta to match how
+  // handleAmountConfirm/handleAmountClear decide between asset units and sats.
+  const hasAmount = assetMeta ? assetAmount > BigInt(0) : satoshis > 0
+
   // Mobile keyboard — bypass sheet on save, go straight to QR
   if (showKeys) {
     return (
@@ -391,6 +397,7 @@ export default function ReceiveQRCode() {
           setShowKeys(false)
           setShowAmountSheet(false)
         }}
+        onClear={hasAmount ? handleAmountClear : undefined}
         onSave={(value: string) => {
           setShowKeys(false)
           setShowAmountSheet(false)
@@ -495,7 +502,7 @@ export default function ReceiveQRCode() {
             onFocus={() => setShowKeys(isMobileBrowser)}
           />
           <Button label='Set amount' onClick={() => handleAmountConfirm()} disabled={!amountTextValue} />
-          {satoshis > 0 ? <Button label='Clear amount' onClick={handleAmountClear} secondary /> : null}
+          {hasAmount ? <Button label='Clear amount' onClick={handleAmountClear} secondary /> : null}
         </FlexCol>
       </SheetModal>
 

--- a/src/test/screens/wallet/receive-clear-amount.test.tsx
+++ b/src/test/screens/wallet/receive-clear-amount.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { FlowContext } from '../../../providers/flow'
+import { LimitsContext } from '../../../providers/limits'
+import {
+  mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockSwapsContextValue,
+  mockLimitsContextValue,
+  mockNavigationContextValue,
+  mockSvcWallet,
+  mockWalletContextValue,
+} from '../mocks'
+import { WalletContext } from '../../../providers/wallet'
+import { NavigationContext } from '../../../providers/navigation'
+import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import { SwapsContext } from '../../../providers/swaps'
+import { NotificationsContext } from '../../../providers/notifications'
+import { ToastProvider } from '../../../components/Toast'
+import { LnurlContext } from '../../../providers/lnurl'
+import ReceiveQRCode from '../../../screens/Wallet/Receive/QrCode'
+
+// Mock qr module used by the QrCode component
+vi.mock('qr', () => ({
+  default: () => Array.from({ length: 21 }, () => new Uint8Array(21).fill(1)),
+}))
+
+// Force the mobile (touch) code path. On mobile, tapping the amount button opens
+// the on-screen Keyboard instead of the desktop sheet — this is the path where a
+// set amount previously could not be removed (the "Clear amount" button only
+// existed in the desktop sheet).
+vi.mock('../../../lib/browser', () => ({
+  isMobileBrowser: true,
+  isIOS: () => false,
+  isAndroid: () => false,
+  isInAppBrowser: () => false,
+}))
+
+// Silence haptics in jsdom
+vi.mock('../../../lib/haptics', () => ({
+  hapticSubtle: vi.fn(),
+  hapticTap: vi.fn(),
+  hapticLight: vi.fn(),
+  setHapticsEnabled: vi.fn(),
+}))
+
+if (!globalThis.URL.createObjectURL) {
+  globalThis.URL.createObjectURL = () => 'blob:mock'
+}
+
+// Mock navigator.serviceWorker for jsdom
+beforeAll(() => {
+  if (!navigator.serviceWorker) {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        ready: Promise.resolve({}),
+      },
+      writable: true,
+    })
+  }
+})
+
+const mockNotificationsContextValue = {
+  notifyPaymentReceived: () => {},
+  notifyPaymentSent: () => {},
+  requestPermission: () => Promise.resolve(),
+}
+
+// Render the receive screen with a non-zero amount already requested, so the
+// amount button reads "Edit amount" and the keyboard is the edit entry point.
+function renderReceiveWithAmount(setRecvInfo: (info: unknown) => void) {
+  const flow = {
+    ...mockFlowContextValue,
+    recvInfo: {
+      ...mockFlowContextValue.recvInfo,
+      satoshis: 50_000,
+      offchainAddr: 'ark1testaddr',
+      boardingAddr: 'bc1testaddr',
+    },
+    setRecvInfo,
+  }
+  const wallet = { ...mockWalletContextValue, svcWallet: mockSvcWallet as any }
+  const swaps = { ...mockSwapsContextValue, connected: false, arkadeSwaps: null }
+  const lnurl = { lnurl: '', active: false, error: undefined }
+
+  return render(
+    <ToastProvider>
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <ConfigContext.Provider value={mockConfigContextValue as any}>
+          <FiatContext.Provider value={mockFiatContextValue as any}>
+            <NotificationsContext.Provider value={mockNotificationsContextValue as any}>
+              <SwapsContext.Provider value={swaps as any}>
+                <FlowContext.Provider value={flow as any}>
+                  <WalletContext.Provider value={wallet as any}>
+                    <LimitsContext.Provider value={mockLimitsContextValue}>
+                      <LnurlContext.Provider value={lnurl}>
+                        <ReceiveQRCode />
+                      </LnurlContext.Provider>
+                    </LimitsContext.Provider>
+                  </WalletContext.Provider>
+                </FlowContext.Provider>
+              </SwapsContext.Provider>
+            </NotificationsContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>
+    </ToastProvider>,
+  )
+}
+
+describe('Receive amount — clearing on the mobile keyboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('lets the user clear a set amount from the keyboard', async () => {
+    const setRecvInfo = vi.fn()
+    renderReceiveWithAmount(setRecvInfo)
+
+    // With an amount set, the amount button reads "Edit amount". Tapping it opens
+    // the on-screen keyboard on mobile.
+    const editButton = await screen.findByRole('button', { name: 'Edit amount' })
+    await act(async () => {
+      fireEvent.click(editButton)
+    })
+
+    // The keyboard must offer a way to remove the amount.
+    const clearButton = await screen.findByRole('button', { name: 'Clear amount' })
+    await act(async () => {
+      fireEvent.click(clearButton)
+    })
+
+    // Clearing resets the requested amount back to zero.
+    expect(setRecvInfo).toHaveBeenCalledWith(expect.objectContaining({ satoshis: 0 }))
+  })
+})


### PR DESCRIPTION
## Summary

On the Receive screen, once an amount is entered there was **no way to remove it on touch devices**. On mobile, tapping the amount button opens the on-screen `Keyboard`, whose only action is a **Save** button that is disabled on empty input and rejects empty saves. The **Clear amount** action existed only in the desktop bottom sheet, which the mobile path never renders — so the amount specifier got stuck once set.

## Fix

- Add an opt-in `onClear?: () => void` prop to `Keyboard`. When provided it renders a secondary **Clear amount** button beneath **Save**. `Keyboard` is shared with Send (where an amount is required), so the prop is opt-in and leaves Send untouched.
- Wire `onClear` on the receive screen, gated on an amount actually being set (`hasAmount`), so it only appears when there is something to clear — mirroring the desktop sheet.
- `handleAmountClear` now also dismisses the keyboard/sheet after clearing, matching the confirm flow (previously the desktop sheet stayed open after clearing).
- The desktop **Clear amount** button now uses the same `hasAmount` check, keyed off `assetMeta` to stay consistent with `handleAmountConfirm`/`handleAmountClear`. Previously it was gated on `satoshis > 0`, which is always 0 for asset amounts, so the button also now appears for asset receives.

## Test

Adds `src/test/screens/wallet/receive-clear-amount.test.tsx`, which forces the mobile (`isMobileBrowser`) path, sets an amount, opens the keyboard via **Edit amount**, clicks **Clear amount**, and asserts the requested amount resets to zero. It fails before the fix (no clear control on the keyboard) and passes after.

## Test plan

- [x] `vitest run src/test/screens/wallet/receive-clear-amount.test.tsx` — passes (failed before the fix)
- [x] Full wallet unit suite green, no regressions
- [x] `pnpm lint` clean
- [x] `pnpm build` succeeds
- [ ] Manual on a touch device: set a receive amount → **Edit amount** → **Clear amount** → amount specifier removed from the QR/URI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced "Clear amount" functionality to properly dismiss UI elements and consistently support both satoshi and asset-denominated amount requests.

* **Tests**
  * Added comprehensive test coverage for mobile "Clear amount" behavior on the Receive QR code screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->