### PR TITLE
fix(receive): show 'Edit amount' after setting an asset amount

### DIFF
--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -407,7 +407,7 @@ export default function ReceiveQRCode() {
     )
   }
 
-  const amountLabel = satoshis ? 'Edit amount' : 'Add amount'
+  const amountLabel = hasAmount ? 'Edit amount' : 'Add amount'
   const unitLabel = assetMeta?.metadata?.ticker ?? 'sats'
 
   return (


### PR DESCRIPTION
closes #694

on the Receive screen the amount button kept reading "Add amount" even after you set an amount for an asset, because the label only looked at the Bitcoin amount (`satoshis`), which is always 0 for asset receives.

this points the label at the existing `hasAmount` helper, which checks `assetAmount` for assets and `satoshis` for Bitcoin, so it correctly shows "Edit amount" in both cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The receive QR screen now correctly updates the “Add/Edit amount” button label when an amount is already set, including asset-based receive flows.
  * Improved consistency so the button reflects both asset amounts and satoshi amounts instead of only checking satoshi values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->