### PR TITLE
always show Paste button

### DIFF
--- a/src/components/InputAddress.tsx
+++ b/src/components/InputAddress.tsx
@@ -1,13 +1,3 @@
-import { isValidLnUrl } from '../lib/lnurl'
-import {
-  isArkAddress,
-  isBTCAddress,
-  isEmailAddress,
-  isLightningInvoice,
-  isURLWithLightningQueryString,
-} from '../lib/address'
-import { isArkNote } from '../lib/arknote'
-import { isBip21 } from '../lib/bip21'
 import InputWithScanner from './InputWithScanner'
 
 interface InputAddressProps {
@@ -19,7 +9,6 @@ interface InputAddressProps {
   openScan: () => void
   placeholder?: string
   value?: string
-  validator?: (data: string) => boolean
 }
 
 export default function InputAddress({
@@ -31,23 +20,7 @@ export default function InputAddress({
   openScan,
   placeholder,
   value,
-  validator,
 }: InputAddressProps) {
-  const isAddress = (data: string): boolean => {
-    const lowerData = data.toLowerCase()
-    return (
-      isBip21(lowerData) ||
-      isArkAddress(lowerData) ||
-      isBTCAddress(lowerData) ||
-      isLightningInvoice(lowerData) ||
-      (lowerData.startsWith('lightning:') && isLightningInvoice(lowerData.slice(10))) ||
-      isURLWithLightningQueryString(lowerData) ||
-      isEmailAddress(data) ||
-      isValidLnUrl(data) ||
-      isArkNote(data) // easter egg :)
-    )
-  }
-
   return (
     <InputWithScanner
       focus={focus}
@@ -57,7 +30,6 @@ export default function InputAddress({
       onEnter={onEnter}
       openScan={openScan}
       placeholder={placeholder}
-      validator={validator ?? isAddress}
       value={value}
     />
   )

--- a/src/components/InputAssetId.tsx
+++ b/src/components/InputAssetId.tsx
@@ -1,5 +1,4 @@
 import InputWithScanner from './InputWithScanner'
-import { isValidAssetId } from '../lib/assets'
 
 interface InputAssetIdProps {
   focus?: boolean
@@ -20,7 +19,6 @@ export default function InputAssetId({ focus, label, name, onChange, onEnter, op
       onChange={onChange}
       onEnter={onEnter}
       openScan={openScan}
-      validator={isValidAssetId}
       value={value}
     />
   )

--- a/src/components/InputNote.tsx
+++ b/src/components/InputNote.tsx
@@ -1,4 +1,3 @@
-import { isArkNote } from '../lib/arknote'
 import InputWithScanner from './InputWithScanner'
 
 interface InputNoteProps {
@@ -9,7 +8,5 @@ interface InputNoteProps {
 }
 
 export default function InputNote({ label, onChange, openScan, value }: InputNoteProps) {
-  return (
-    <InputWithScanner focus label={label} onChange={onChange} openScan={openScan} validator={isArkNote} value={value} />
-  )
+  return <InputWithScanner focus label={label} onChange={onChange} openScan={openScan} value={value} />
 }

--- a/src/components/InputNpub.tsx
+++ b/src/components/InputNpub.tsx
@@ -10,10 +10,6 @@ interface InputNpubProps {
 }
 
 export default function InputNpub({ focus, label, onChange, openScan, placeholder, value }: InputNpubProps) {
-  const isNpub = (data: string): boolean => {
-    return /^npub/.test(data.toLowerCase())
-  }
-
   return (
     <InputWithScanner
       focus={focus}
@@ -21,7 +17,6 @@ export default function InputNpub({ focus, label, onChange, openScan, placeholde
       onChange={onChange}
       openScan={openScan}
       placeholder={placeholder}
-      validator={isNpub}
       value={value}
     />
   )

--- a/src/components/InputUrl.tsx
+++ b/src/components/InputUrl.tsx
@@ -11,10 +11,6 @@ interface InputUrlProps {
 }
 
 export default function InputUrl({ focus, label, onChange, onEnter, openScan, placeholder, value }: InputUrlProps) {
-  const isUrl = (data: string): boolean => {
-    return /^https?:/.test(data.toLowerCase())
-  }
-
   return (
     <InputWithScanner
       focus={focus}
@@ -23,7 +19,6 @@ export default function InputUrl({ focus, label, onChange, onEnter, openScan, pl
       onEnter={onEnter}
       openScan={openScan}
       placeholder={placeholder}
-      validator={isUrl}
       value={value}
     />
   )

--- a/src/components/InputWithScanner.tsx
+++ b/src/components/InputWithScanner.tsx
@@ -14,7 +14,6 @@ interface InputWithScannerProps {
   onEnter?: () => void
   openScan: () => void
   placeholder?: string
-  validator?: (arg0: string) => boolean
   value?: string
 }
 
@@ -27,7 +26,6 @@ export default function InputWithScanner({
   onEnter,
   openScan,
   placeholder,
-  validator,
   value,
 }: InputWithScannerProps) {
   const input = useRef<HTMLInputElement>(null)
@@ -73,7 +71,7 @@ export default function InputWithScanner({
             <ClearButtonOnInput onClick={handleClear} />
           ) : (
             <FlexRow gap='0.25rem'>
-              <Paste validator={validator} onPaste={handlePaste} />
+              <Paste onPaste={handlePaste} />
               <ScanButtonOnInput onClick={handleScan} />
             </FlexRow>
           )}

--- a/src/components/Paste.tsx
+++ b/src/components/Paste.tsx
@@ -1,42 +1,20 @@
-import { useEffect, useState } from 'react'
 import { pasteFromClipboard, queryPastePermission } from '../lib/clipboard'
 import { PasteButtonOnInput } from './Button'
-import { consoleError } from '../lib/logs'
 
 interface PasteProps {
-  validator?: (arg0: string) => boolean
   onPaste: (arg0: string) => void
 }
 
-export default function Paste({ validator, onPaste }: PasteProps) {
-  const [clipboard, setClipboard] = useState('')
-  const [showPaste, setShowPaste] = useState(false)
-
-  useEffect(() => {
-    queryPastePermission()
-      .then((state) => {
-        if (['prompt', 'granted'].includes(state)) {
-          // if content is valid, show it to user in UI
-          pasteFromClipboard().then((data) => {
-            if (!data) return
-            if (!validator || validator(data)) {
-              setClipboard(data)
-              setShowPaste(true)
-            }
-          })
-        }
-      })
-      .catch(() => {
-        consoleError('Clipboard permission query failed')
-      })
-  }, [])
-
+export default function Paste({ onPaste }: PasteProps) {
   const handleClick = () => {
-    if (clipboard) return onPaste(clipboard)
-    pasteFromClipboard().then((data) => {
-      if (data) onPaste(data)
+    queryPastePermission().then((state) => {
+      if (['prompt', 'granted'].includes(state)) {
+        pasteFromClipboard().then((data) => {
+          if (data) onPaste(data)
+        })
+      }
     })
   }
 
-  return showPaste ? <PasteButtonOnInput onClick={handleClick} /> : <></>
+  return <PasteButtonOnInput onClick={handleClick} />
 }

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -23,9 +23,12 @@ export const pasteFromClipboard = async (): Promise<string> => {
 
 export const queryPastePermission = async (): Promise<PermissionState> => {
   try {
+    // Chrome and Edge will handle this perfectly
     return (await navigator.permissions.query({ name: 'clipboard-read' as PermissionName })).state
   } catch (err) {
+    // Safari and Firefox land here because 'clipboard-read' is unsupported in query()
     consoleError(err, 'error querying clipboard-read permission')
-    return 'denied'
+    // we assume 'prompt' status and proceed directly
+    return 'prompt'
   }
 }


### PR DESCRIPTION
Closes https://github.com/arkade-os/wallet/issues/635

@tiero @sahilc0 please review

Current behaviour is:

- Button checks for data in clipboard (requires user auth at least one time)
- The button only appears If this data matches what's expected for that input

New behaviour would be:
- Kill all validations, always show the Paste button

It was a nice feature, but this iOS 16+ changes really kills it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard paste now appears consistently and works with a simpler permission flow.
* **Bug Fixes**
  * Improved clipboard behavior in browsers with limited permission support, allowing paste to proceed more reliably.
  * Removed several field-specific validation checks from scanner-enabled inputs, reducing cases where valid entries were incorrectly blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->