### PR TITLE
fix(delegates): don't mark zero-fee delegate as inactive

### DIFF
--- a/src/screens/Settings/Delegates.tsx
+++ b/src/screens/Settings/Delegates.tsx
@@ -48,11 +48,15 @@ const testConnection = (aspInfo: AspInfo): Promise<Delegate> => {
         if (!res.ok) return reject(new Error('Unable to connect'))
         res
           .json()
-          .then((data: { delegatorAddress: string; pubkey: string; fee: string }) => {
+          .then((data: { delegatorAddress: string; pubkey: string; fee: string | number }) => {
             if (!data) return reject(new Error('Invalid delegate response'))
-            if (!data.fee) return reject(new Error('Missing delegate fee'))
-            if (isNaN(parseInt(data.fee, 10))) return reject(new Error('Invalid delegate fee'))
-            if (parseInt(data.fee, 10) < 0) return reject(new Error("Delegate fee can't be negative"))
+            // a fee of 0 is valid (e.g. the free Arkade default delegate), so only reject when the
+            // field is actually absent rather than treating a falsy 0 as missing
+            if (data.fee === undefined || data.fee === null || data.fee === '')
+              return reject(new Error('Missing delegate fee'))
+            const fee = typeof data.fee === 'number' ? data.fee : parseInt(data.fee, 10)
+            if (isNaN(fee)) return reject(new Error('Invalid delegate fee'))
+            if (fee < 0) return reject(new Error("Delegate fee can't be negative"))
             if (!data.pubkey) return reject(new Error('Missing delegate pubkey'))
             if (data.pubkey.length !== 66) return reject(new Error('Invalid delegate pubkey size'))
             if (!/^[0-9a-fA-F]{66}$/.test(data.pubkey)) return reject(new Error('Invalid delegate pubkey hex'))
@@ -60,7 +64,7 @@ const testConnection = (aspInfo: AspInfo): Promise<Delegate> => {
             if (!isArkAddress(data.delegatorAddress)) return reject(new Error('Invalid delegate address'))
             const { serverPubKey } = decodeArkAddress(data.delegatorAddress)
             if (serverPubKey !== expectedPubKey) return reject(new Error('Invalid delegate server key'))
-            resolve({ ...delegate, address: data.delegatorAddress, pubkey: data.pubkey, fee: parseInt(data.fee, 10) })
+            resolve({ ...delegate, address: data.delegatorAddress, pubkey: data.pubkey, fee })
           })
           .catch(() => reject(new Error('Invalid json in delegate response')))
       })

--- a/src/screens/Settings/Delegates.tsx
+++ b/src/screens/Settings/Delegates.tsx
@@ -140,7 +140,12 @@ function DelegateCard() {
         setDelegate(delegate)
         setActive(true)
       })
-      .catch(() => setActive(false))
+      .catch((err) => {
+        // surface why the delegate is considered inactive so a reachable-but-rejected
+        // delegate (e.g. an unexpected response shape) can be diagnosed instead of failing silently
+        console.error('Delegate connection test failed:', err)
+        setActive(false)
+      })
   }, [config.delegate, aspInfo.signerPubkey])
 
   if (!config.delegate) return null


### PR DESCRIPTION
## Problem

The Delegates settings screen shows the Arkade Default delegate as **"Inactive"** even though `https://delegate.arkade.money/v1/delegator/info` returns HTTP 200.

The card still renders empty `address`/`pubkey` and `fee: 0 SATS` — i.e. the initial defaults — which means `testConnection()` *rejected* and `setDelegate`/`setActive(true)` never ran. Since the fetch returns 200, the rejection happens in the response **validation**, not the network call.

## Root cause

In `src/screens/Settings/Delegates.tsx`, the validation rejected any falsy fee:

```ts
if (!data.fee) return reject(new Error('Missing delegate fee'))
```

The free Arkade default delegate has a fee of **0**, and `!0 === true`, so a reachable, valid delegate was rejected as "missing fee" and the card fell back to **Inactive**. (Note: this rejects both number `0` *and* string `"0"`, since both are falsy — so the defect holds regardless of how the server serializes the fee.)

## Fix

- Only reject when the fee field is genuinely absent (`null` / `undefined` / `''`) rather than treating `0` as missing.
- Parse the fee robustly whether the server returns it as a number or a string.
- All other pubkey/address/server-key validation is unchanged.

```ts
if (data.fee === undefined || data.fee === null || data.fee === '')
  return reject(new Error('Missing delegate fee'))
const fee = typeof data.fee === 'number' ? data.fee : parseInt(data.fee, 10)
if (isNaN(fee)) return reject(new Error('Invalid delegate fee'))
if (fee < 0) return reject(new Error("Delegate fee can't be negative"))
```

## Diagnosability (second commit)

The status check previously swallowed the rejection reason (`.catch(() => setActive(false))`), so a reachable-but-rejected delegate appeared "Inactive" with no way to tell *which* validation failed. It now logs the error (`console.error`, matching the existing idiom in `src/lib/address.ts`). This makes any future "Inactive despite 200" report self-diagnosing and de-risks the residual uncertainty below.

## Honest limitations

This was reviewed dialectically (a fix-defending pass and an adversarial refutation pass). The residual risk worth flagging to a reviewer:

- The fee-`0` defect is **unconditionally real** and worth fixing regardless. What is *not* fully proven is that fee was the *first* failing validation for this specific delegate, because the exact `/v1/delegator/info` payload could not be observed — `delegate.arkade.money` is blocked by the authoring environment's egress policy. If the live response used unexpected field names or pubkey/address encodings, a *different* check could be the blocker; the new logging will reveal that immediately.
- The linter/typechecker was **not** run here (`node_modules` not installed; `@arkade-os/*` packages behind a restricted registry). The changes are small and self-contained but unbuilt locally — please confirm CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yQ8yLqi8QhigqbuFUqTZt