### PR TITLE
Allow deprecated keys delegate

### DIFF
--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -11,6 +11,7 @@ import {
   IVtxoManager,
   Asset,
   ArkError,
+  DelegateInfo,
 } from '@arkade-os/sdk'
 import { Addresses, Tx, Vtxo } from './types'
 import { AspInfo } from '../providers/asp'
@@ -335,7 +336,14 @@ export const delegateVtxos = async (wallet: ServiceWorkerWallet): Promise<void> 
     throw new Error('Delegator manager not found')
   }
 
-  const delegateInfo = await dm.getDelegateInfo()
+  let delegateInfo: DelegateInfo
+  try {
+    delegateInfo = await dm.getDelegateInfo()
+  } catch (error) {
+    consoleError(error, 'Error fetching delegate info')
+    return
+  }
+
   const vtxosToDelegate = contractWithVtxos
     .filter(({ contract, vtxos }) => {
       if (vtxos.length === 0) return false
@@ -350,8 +358,7 @@ export const delegateVtxos = async (wallet: ServiceWorkerWallet): Promise<void> 
   const destination = await wallet.getAddress()
   const result = await dm.delegate(vtxosToDelegate, destination)
   if (result.failed.length > 0) {
-    // eslint-disable-next-line no-console
-    console.warn('Delegation partial failure:', result.failed)
+    consoleError(result.failed, 'Delegation partial failure:')
   }
 }
 

--- a/src/screens/Settings/Delegates.tsx
+++ b/src/screens/Settings/Delegates.tsx
@@ -21,6 +21,7 @@ import { decodeArkAddress, isArkAddress } from '../../lib/address'
 import { Network } from '@arkade-os/boltz-swap'
 import { copyToClipboard } from '../../lib/clipboard'
 import { useToast } from '../../components/Toast'
+import { consoleError } from '../../lib/logs'
 
 // format the URL to ensure it has the correct protocol and no trailing slashes
 const formatUrl = (host: string, path: string): string => {
@@ -38,9 +39,12 @@ const formatUrl = (host: string, path: string): string => {
 // test connection to delegate by fetching delegate info and validating the response
 const testConnection = (aspInfo: AspInfo): Promise<Delegate> => {
   return new Promise((resolve, reject) => {
-    // ensure expected pubkey is in xonly format
-    const expectedPubKey = aspInfo.signerPubkey.length === 66 ? aspInfo.signerPubkey.slice(2) : aspInfo.signerPubkey
-    if (expectedPubKey.length !== 64) return reject(new Error('Invalid expected server pubkey'))
+    // ensure expected pubkeys are in xonly format
+    const deprecatedSignerPubkeys = (aspInfo.deprecatedSigners || []).map((ds) => ds.pubkey)
+    const possibleXOnlyPubkeys = [...deprecatedSignerPubkeys, aspInfo.signerPubkey].map((pk) =>
+      pk.length === 66 ? pk.slice(2) : pk,
+    )
+    if (possibleXOnlyPubkeys.some((pk) => pk.length !== 64)) return reject(new Error('Invalid expected server pubkey'))
     const delegate = getDelegateUrlForNetwork(aspInfo.network as Network)
     // fetch delegate info from the delegate server
     fetch(formatUrl(delegate.url, '/v1/delegator/info'))
@@ -59,7 +63,7 @@ const testConnection = (aspInfo: AspInfo): Promise<Delegate> => {
             if (!data.delegatorAddress) return reject(new Error('Missing delegate address'))
             if (!isArkAddress(data.delegatorAddress)) return reject(new Error('Invalid delegate address'))
             const { serverPubKey } = decodeArkAddress(data.delegatorAddress)
-            if (serverPubKey !== expectedPubKey) return reject(new Error('Invalid delegate server key'))
+            if (!possibleXOnlyPubkeys.includes(serverPubKey)) return reject(new Error('Invalid delegate server key'))
             resolve({ ...delegate, address: data.delegatorAddress, pubkey: data.pubkey, fee: parseInt(data.fee, 10) })
           })
           .catch(() => reject(new Error('Invalid json in delegate response')))
@@ -136,7 +140,10 @@ function DelegateCard() {
         setDelegate(delegate)
         setActive(true)
       })
-      .catch(() => setActive(false))
+      .catch((error) => {
+        consoleError('Error testing delegate connection:', error)
+        setActive(false)
+      })
   }, [config.delegate, aspInfo.signerPubkey])
 
   if (!config.delegate) return null

--- a/src/screens/Settings/Delegates.tsx
+++ b/src/screens/Settings/Delegates.tsx
@@ -40,7 +40,10 @@ const formatUrl = (host: string, path: string): string => {
 const testConnection = (aspInfo: AspInfo): Promise<Delegate> => {
   return new Promise((resolve, reject) => {
     // ensure expected pubkeys are in xonly format
-    const deprecatedSignerPubkeys = (aspInfo.deprecatedSigners || []).map((ds) => ds.pubkey)
+    const now = Math.floor(Date.now() / 1000)
+    const deprecatedSignerPubkeys = (aspInfo.deprecatedSigners || [])
+      .filter((ds) => ds.cutoffDate > now)
+      .map((ds) => ds.pubkey)
     const possibleXOnlyPubkeys = [...deprecatedSignerPubkeys, aspInfo.signerPubkey].map((pk) =>
       pk.length === 66 ? pk.slice(2) : pk,
     )

--- a/src/screens/Settings/Delegates.tsx
+++ b/src/screens/Settings/Delegates.tsx
@@ -144,7 +144,7 @@ function DelegateCard() {
         setActive(true)
       })
       .catch((error) => {
-        consoleError('Error testing delegate connection:', error)
+        consoleError(error, 'Error testing delegate connection:')
         setActive(false)
       })
   }, [config.delegate, aspInfo.signerPubkey])


### PR DESCRIPTION
When testing for delegate, allows delegate to use deprecated signer keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved delegate connection checks to accept valid current and legacy server keys.
  - Connection testing now handles errors more gracefully and marks failed connections as inactive.
  - Delegation issues are now reported as errors, helping surface failures more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->