### PR TITLE
fix flash of unlock screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,6 +149,7 @@ export default function App() {
   }, [])
 
   useEffect(() => {
+    if (!aspInfo.url) return
     if (!allChecksReady) return
     if (!wallet.pubkey || initialized) return
     if (authState !== 'passwordless') return
@@ -165,7 +166,7 @@ export default function App() {
         // ignore session storage errors; keep the app on loading instead of retry-looping
       }
     })
-  }, [allChecksReady, wallet.pubkey, initialized, authState, unlockWallet])
+  }, [allChecksReady, wallet.pubkey, initialized, authState, unlockWallet, aspInfo.url])
 
   useEffect(() => {
     if (!hasDevAutoInit) devAutoInitHomeRedirected.current = false


### PR DESCRIPTION
Sometimes when reloading the app, we would see a flash of the unlock screen, even though the app was not locked.

The main cause was:
- `unlockWallet()` does not only unlocks the wallet, it also `initWallet()`
- to `initWallet()`, the app needs to know the server url or else will throw
- in some rare occasions (mainly sw updates) the server url would only arrive AFTER the first try to unlock the wallet
- this means the first try to unlock the wallet would throw and the app would think the default password didn't work, so the app should be locked => show unlock screen
- the app would attempt to `initWallet()` again, and this time would work, removing the unlock UI from the screen

Fix:
- wait for aspInfo.url to be defined before calling `unlockWallet()`