### PR TITLE
fix(send): respect bitcoin unit in amount fields

### DIFF
--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -2,10 +2,10 @@ import { useContext, useEffect, useRef, useState } from 'react'
 import { FiatContext } from '../providers/fiat'
 import InputContainer from './InputContainer'
 import { ConfigContext } from '../providers/config'
-import { prettyNumber } from '../lib/format'
+import { bitcoinUnitToSats, formatBitcoinAmountParts, prettyBitcoinAmount, prettyNumber } from '../lib/format'
 import { FIAT_SYMBOLS } from '../lib/fiat'
 import { LimitsContext } from '../providers/limits'
-import { AssetOption } from '../lib/types'
+import { AssetOption, Unit } from '../lib/types'
 import { TextSecondary } from './Text'
 import { hapticLight } from '../lib/haptics'
 
@@ -45,14 +45,14 @@ export default function InputAmount({
   valueSats,
 }: InputAmountProps) {
   const { config, useFiat } = useContext(ConfigContext)
-  const { toFiat, fromFiat, fiatDecimals } = useContext(FiatContext)
+  const { fromFiat } = useContext(FiatContext)
   const { minSwapAllowed, maxSwapAllowed } = useContext(LimitsContext)
 
   const [error, setError] = useState('')
-  const [otherValue, setOtherValue] = useState('')
   const [satsValue, setSatsValue] = useState(0)
 
   const input = useRef<HTMLInputElement>(null)
+  const bitcoinUnit = config.currencyDisplay as unknown as Unit
 
   // focus input when focus prop changes
   useEffect(() => {
@@ -69,21 +69,20 @@ export default function InputAmount({
   useEffect(() => {
     if (valueSats !== undefined) return
     if (!value || isNaN(Number(value))) return
-    setSatsValue(useFiat ? fromFiat(Number(value)) : Number(value))
-  }, [value, fromFiat, useFiat, valueSats])
+    setSatsValue(useFiat ? fromFiat(Number(value)) : bitcoinUnitToSats(Number(value), bitcoinUnit))
+  }, [value, fromFiat, useFiat, valueSats, bitcoinUnit])
 
   // update other value when satsValue change
   useEffect(() => {
     setError(satsValue ? (satsValue < 0 ? 'Invalid amount' : '') : '')
-    setOtherValue(useFiat ? prettyNumber(satsValue, 0) : prettyNumber(toFiat(satsValue), fiatDecimals()))
-  }, [satsValue, toFiat, fiatDecimals, useFiat])
+  }, [satsValue])
 
   const handleAmountChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
     const textValue = ev.currentTarget.value
     onChange(textValue)
     if (asset?.assetId) return
     const value = Number(textValue)
-    setSatsValue(useFiat ? fromFiat(value) : value)
+    setSatsValue(useFiat ? fromFiat(value) : bitcoinUnitToSats(value, bitcoinUnit))
   }
 
   const minimumSats = min ? Math.max(min, minSwapAllowed()) : 0
@@ -91,9 +90,10 @@ export default function InputAmount({
 
   const fiatSymbol = FIAT_SYMBOLS[config.fiat]
   const fiatLabel = useFiat ? (fiatSymbol ?? config.fiat) : config.currencyDisplay
+  const bitcoinUnitLabel = formatBitcoinAmountParts(0, bitcoinUnit).unit || config.currencyDisplay
 
-  const leftLabel = asset?.assetId ? asset.ticker : useFiat ? fiatLabel : 'sats'
-  const rightLabel = !asset?.assetId && useFiat ? `${otherValue} sats` : ''
+  const leftLabel = asset?.assetId ? asset.ticker : useFiat ? fiatLabel : bitcoinUnitLabel
+  const rightLabel = !asset?.assetId && useFiat ? prettyBitcoinAmount(satsValue, bitcoinUnit) : ''
   const bottomLeft =
     minimumSats && satsValue !== undefined && satsValue < minimumSats
       ? `Min: ${prettyNumber(minimumSats)} ${minimumSats === 1 ? 'sat' : 'sats'}`

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -13,6 +13,16 @@ export const toSatoshis = (num: number): number => {
   return Decimal.mul(num, 100_000_000).floor().toNumber()
 }
 
+export const bitcoinUnitToSats = (amount: number, unit: Unit): number => {
+  if (unit === Unit.BTC) return toSatoshis(amount)
+  return Math.floor(amount)
+}
+
+export const satsToBitcoinUnit = (sats: number, unit: Unit): number => {
+  if (unit === Unit.BTC) return fromSatoshis(sats)
+  return sats
+}
+
 export const prettyAgo = (timestamp: number | string, long = false): string => {
   if (!timestamp) return ''
   const now = Math.floor(Date.now() / 1000)

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -19,7 +19,7 @@ import InputAmount from '../../../components/InputAmount'
 import InputAddress from '../../../components/InputAddress'
 import Header from '../../../components/Header'
 import { WalletContext } from '../../../providers/wallet'
-import { prettyAmount, prettyFiatAmount, prettyNumber } from '../../../lib/format'
+import { bitcoinUnitToSats, prettyBitcoinAmount, prettyFiatAmount, prettyNumber, satsToBitcoinUnit } from '../../../lib/format'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import FlexRow from '../../../components/FlexRow'
@@ -155,6 +155,7 @@ export default function SendForm() {
   const hasAssets = assetBalances.length > 0
   const reserveApplied = !isAssetSend && hasAssets
   const liquidBalance = availableBalance - (reserveApplied ? DUST_AMOUNT : 0)
+  const bitcoinUnit = config.currencyDisplay as unknown as Unit
 
   const smartSetError = (str: string) => {
     setError(str === '' ? (aspInfo.unreachable ? aspErrorText(aspInfo, 'Arkade server unreachable') : '') : str)
@@ -179,7 +180,7 @@ export default function SendForm() {
         const units = centsToUnits(cents, selectedAsset.decimals)
         setAmountTextValue(units)
       } else {
-        const units = useFiat ? prettyNumber(toFiat(info.satoshis), fiatDecimals()) : info.satoshis
+        const units = useFiat ? prettyNumber(toFiat(info.satoshis), fiatDecimals()) : satsToBitcoinUnit(info.satoshis, bitcoinUnit)
         setAmountTextValue(units.toString())
       }
     }
@@ -615,7 +616,7 @@ export default function SendForm() {
     } else {
       const num = Number(value)
       if (Number.isNaN(num) || !Number.isFinite(num)) return setError('Invalid amount')
-      const sats = useFiat ? fromFiat(num) : num
+      const sats = useFiat ? fromFiat(num) : bitcoinUnitToSats(num, bitcoinUnit)
       setState({ ...sendInfo, satoshis: sats })
     }
   }
@@ -625,7 +626,7 @@ export default function SendForm() {
     if (inputMode === 'asset' || isAssetSend) return handleAmountChange(value)
     const num = Number(value)
     if (Number.isNaN(num) || !Number.isFinite(num)) return setError('Invalid amount')
-    const sats = inputMode === 'sats' ? num : fromFiat(num)
+    const sats = inputMode === 'sats' ? bitcoinUnitToSats(num, bitcoinUnit) : fromFiat(num)
     setState({ ...sendInfo, satoshis: sats })
   }
 
@@ -708,8 +709,8 @@ export default function SendForm() {
       setState({ ...sendInfo, satoshis: liquidBalance })
       setAmountTextValue(
         useFiat
-          ? toFiat(liquidBalance).toFixed(fiatDecimalsFor(config.fiat, config.currencyDisplay as unknown as Unit))
-          : liquidBalance.toString(),
+          ? toFiat(liquidBalance).toFixed(fiatDecimalsFor(config.fiat, bitcoinUnit))
+          : satsToBitcoinUnit(liquidBalance, bitcoinUnit).toString(),
       )
       setAmount(liquidBalance)
       setValueSats(liquidBalance)
@@ -739,7 +740,7 @@ export default function SendForm() {
 
     const pretty = useFiat
       ? prettyFiatAmount(toFiat(liquidBalance), config.fiat, { bitcoinUnit: config.currencyDisplay })
-      : prettyAmount(liquidBalance)
+      : prettyBitcoinAmount(liquidBalance, bitcoinUnit)
 
     return (
       <div onClick={handleSendAll} style={{ cursor: 'pointer' }}>
@@ -780,7 +781,7 @@ export default function SendForm() {
     : `${
         useFiat
           ? prettyFiatAmount(toFiat(liquidBalance), config.fiat, { bitcoinUnit: config.currencyDisplay })
-          : prettyAmount(liquidBalance)
+          : prettyBitcoinAmount(liquidBalance, bitcoinUnit)
       } available`
 
   const overlayOpen = scan || (keys && !amountIsReadOnly)
@@ -969,7 +970,7 @@ export default function SendForm() {
                                     ? prettyFiatAmount(toFiat(liquidBalance), config.fiat, {
                                         bitcoinUnit: config.currencyDisplay,
                                       })
-                                    : prettyAmount(liquidBalance)}{' '}
+                                    : prettyBitcoinAmount(liquidBalance, bitcoinUnit)}{' '}
                                   available
                                 </span>
                               </span>

--- a/src/test/lib/format.test.ts
+++ b/src/test/lib/format.test.ts
@@ -14,6 +14,8 @@ import {
   isIssuance,
   isBurn,
   prettyBitcoinAmount,
+  bitcoinUnitToSats,
+  satsToBitcoinUnit,
 } from '../../lib/format'
 import { Currencies, Tx, Unit } from '../../lib/types'
 import { Asset } from '@arkade-os/sdk'
@@ -34,6 +36,20 @@ describe('format utilities', () => {
       expect(toSatoshis(0.000001)).toBe(100)
       expect(toSatoshis(0.00000999)).toBe(999)
       expect(toSatoshis(1)).toBe(100_000_000)
+    })
+  })
+
+  describe('bitcoin unit conversions', () => {
+    it('converts display bitcoin units to satoshis', () => {
+      expect(bitcoinUnitToSats(0.0001, Unit.BTC)).toBe(10000)
+      expect(bitcoinUnitToSats(10000, Unit.SATS)).toBe(10000)
+      expect(bitcoinUnitToSats(10000, Unit.BIP177)).toBe(10000)
+    })
+
+    it('converts satoshis to display bitcoin units', () => {
+      expect(satsToBitcoinUnit(10000, Unit.BTC)).toBe(0.0001)
+      expect(satsToBitcoinUnit(10000, Unit.SATS)).toBe(10000)
+      expect(satsToBitcoinUnit(10000, Unit.BIP177)).toBe(10000)
     })
   })
 

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -23,8 +23,37 @@ import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 import { SwapsContext } from '../../../providers/swaps'
 import { OptionsContext } from '../../../providers/options'
+import { Currencies, CurrencyDisplay } from '../../../lib/types'
 
 describe('Send screen', () => {
+  const renderSendForm = ({
+    configContext = mockConfigContextValue,
+    fiatContext = mockFiatContextValue,
+    flowContext = mockFlowContextValue,
+    walletContext = { ...mockWalletContextValue, svcWallet: mockSvcWallet as any },
+  } = {}) =>
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <AspContext.Provider value={mockAspContextValue}>
+          <ConfigContext.Provider value={configContext as any}>
+            <FiatContext.Provider value={fiatContext as any}>
+              <SwapsContext.Provider value={mockSwapsContextValue as any}>
+                <OptionsContext.Provider value={mockOptionsContextValue as any}>
+                  <FlowContext.Provider value={flowContext as any}>
+                    <WalletContext.Provider value={walletContext as any}>
+                      <LimitsContext.Provider value={mockLimitsContextValue}>
+                        <SendForm />
+                      </LimitsContext.Provider>
+                    </WalletContext.Provider>
+                  </FlowContext.Provider>
+                </OptionsContext.Provider>
+              </SwapsContext.Provider>
+            </FiatContext.Provider>
+          </ConfigContext.Provider>
+        </AspContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
   it('renders the loading send screen correctly', async () => {
     render(
       <NavigationContext.Provider value={mockNavigationContextValue}>
@@ -80,6 +109,90 @@ describe('Send screen', () => {
     expect(screen.getByText('Recipient address')).toBeInTheDocument()
     expect(screen.getByText('Continue')).toBeInTheDocument()
   })
+
+  it('shows BTC units on the send amount field when currency and bitcoin unit are BTC', async () => {
+    const walletValue = {
+      ...mockWalletContextValue,
+      svcWallet: {
+        ...mockSvcWallet,
+        getAddress: () => 'tark1mockoffchain',
+        getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+        getBalance: () => Promise.resolve({ available: 12128 }),
+      } as any,
+    }
+    const configValue = {
+      ...mockConfigContextValue,
+      useFiat: false,
+      config: { ...mockConfigContextValue.config, fiat: Currencies.BTC, currencyDisplay: CurrencyDisplay.BTC },
+    }
+
+    renderSendForm({ configContext: configValue, walletContext: walletValue })
+
+    expect(await screen.findByText('0.00012128 BTC available')).toBeInTheDocument()
+    expect(screen.queryByText('12,128 sats available')).not.toBeInTheDocument()
+    expect(screen.getByText('BTC')).toBeInTheDocument()
+  })
+
+  it('shows BTC as the secondary send amount when fiat currency uses BTC as the bitcoin unit', async () => {
+    const walletValue = {
+      ...mockWalletContextValue,
+      svcWallet: {
+        ...mockSvcWallet,
+        getAddress: () => 'tark1mockoffchain',
+        getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+        getBalance: () => Promise.resolve({ available: 12128 }),
+      } as any,
+    }
+    const configValue = {
+      ...mockConfigContextValue,
+      useFiat: true,
+      config: { ...mockConfigContextValue.config, fiat: Currencies.USD, currencyDisplay: CurrencyDisplay.BTC },
+    }
+    const fiatValue = {
+      ...mockFiatContextValue,
+      toFiat: (satoshis?: number) => Number(((satoshis ?? 0) / 1000).toFixed(2)),
+      fromFiat: (fiat?: number) => Math.floor((fiat ?? 0) * 1000),
+      fiatDecimals: () => 2,
+    }
+
+    renderSendForm({ configContext: configValue, fiatContext: fiatValue, walletContext: walletValue })
+
+    const amountInput = document.querySelector('input[name="send-amount"]') as HTMLInputElement
+    fireEvent.change(amountInput, { target: { value: '10' } })
+
+    expect(await screen.findByText('0.0001 BTC')).toBeInTheDocument()
+    expect(screen.queryByText('10,000 sats')).not.toBeInTheDocument()
+  })
+
+  it('converts typed BTC send amounts to satoshis before updating send state', async () => {
+    const setSendInfo = vi.fn()
+    const walletValue = {
+      ...mockWalletContextValue,
+      svcWallet: {
+        ...mockSvcWallet,
+        getAddress: () => 'tark1mockoffchain',
+        getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+        getBalance: () => Promise.resolve({ available: 1_000_000 }),
+      } as any,
+    }
+    const configValue = {
+      ...mockConfigContextValue,
+      useFiat: false,
+      config: { ...mockConfigContextValue.config, fiat: Currencies.BTC, currencyDisplay: CurrencyDisplay.BTC },
+    }
+
+    renderSendForm({
+      configContext: configValue,
+      flowContext: { ...mockFlowContextValue, setSendInfo },
+      walletContext: walletValue,
+    })
+
+    const amountInput = document.querySelector('input[name="send-amount"]') as HTMLInputElement
+    fireEvent.change(amountInput, { target: { value: '0.0001' } })
+
+    await waitFor(() => expect(setSendInfo).toHaveBeenCalledWith(expect.objectContaining({ satoshis: 10000 })))
+  })
+
   it('fills the amount field when an LNURL resolves to a fixed amount', async () => {
     // regression: a fixed-amount LNURL (minSendable === maxSendable) must
     // populate the read-only amount input instead of leaving it blank


### PR DESCRIPTION
## Summary
- Fix the redesigned Send amount input so bitcoin balances, placeholders, secondary fiat conversions, and max-send values respect the selected bitcoin unit instead of always showing sats.
- Add shared bitcoin-unit conversion helpers for converting display values to satoshis and satoshis back to the selected display unit.
- Cover the regression with focused unit/component tests for BTC display units and typed BTC amount conversion.

## Why
PR 627's redesigned Display settings can select `Currency BTC` and `bitcoin unit BTC`, or `Currency USD` with `bitcoin unit BTC`, but the Send form still rendered sats in the amount field. This made the Send screen inconsistent with the user's display preference and could interpret BTC-denominated input incorrectly.

## Affected files
- `src/components/InputAmount.tsx`
- `src/screens/Wallet/Send/Form.tsx`
- `src/lib/format.ts`
- `src/test/screens/wallet/send.test.tsx`
- `src/test/lib/format.test.ts`

## Testing
- `bun run vitest run src/test/screens/wallet/send.test.tsx src/test/lib/format.test.ts`
- `bunx tsc -b --pretty false`
- `bunx eslint src/components/InputAmount.tsx src/screens/Wallet/Send/Form.tsx src/test/screens/wallet/send.test.tsx src/lib/format.ts src/test/lib/format.test.ts`
- Manual browser verification on the PR 627 branch with a seeded funded wallet:
  - `Currency USD` + `bitcoin unit BTC`: Send secondary amount now displays BTC instead of sats.
  - `Currency BTC` + `bitcoin unit BTC`: Send available amount and amount placeholder now display BTC instead of sats.

## Visual evidence
Manual before/after screenshots were captured locally during verification. The post-fix states show BTC units in the same flows that previously showed sats.
