### PR TITLE
remove currencyDisplay from config

### DIFF
--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -6,7 +6,6 @@ import { PrivacyAmount, maskedFiat } from './PrivacyAmount'
 import { prettyBitcoinAmount, prettyBitcoinHide, prettyCurrencyAssetAmount } from '../lib/format'
 import { useContext } from 'react'
 import { ConfigContext } from '../providers/config'
-import { Unit } from '../lib/types'
 
 interface AssetCardProps {
   assetId: string
@@ -45,7 +44,7 @@ export default function AssetCard({
       : Number.isFinite(balance) && Number.isInteger(balance)
         ? BigInt(balance)
         : BigInt(0)
-  const bitcoinUnit = config.currencyDisplay as unknown as Unit
+  const bitcoinUnit = config.unit
   const isBitcoin = tokenTick.toUpperCase() === 'BTC'
   const prettyBalance = isBitcoin
     ? prettyBitcoinAmount(Number(rawBalance), bitcoinUnit)

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import { prettyBitcoinAmount, prettyFiatAmount, prettyFiatHide } from '../lib/format'
-import { Currencies, Unit } from '../lib/types'
+import { Currencies } from '../lib/types'
 import { FiatContext } from '../providers/fiat'
 import Text from './Text'
 import FlexCol from './FlexCol'
@@ -19,12 +19,12 @@ export default function Balance({ amount }: BalanceProps) {
   const currencyAmount = toFiat(amount)
   const mainValue = config.showBalance
     ? config.fiat === Currencies.BTC
-      ? prettyBitcoinAmount(amount, config.currencyDisplay as unknown as Unit)
+      ? prettyBitcoinAmount(amount, config.unit)
       : prettyFiatAmount(currencyAmount, config.fiat, {
           maximumFractionDigits: fiatDecimals(),
           minimumFractionDigits: fiatDecimals(),
         })
-    : prettyFiatHide(currencyAmount, config.fiat, { bitcoinUnit: config.currencyDisplay })
+    : prettyFiatHide(currencyAmount, config.fiat, { bitcoinUnit: config.unit })
   const [mainBalance, mainUnit = ''] = mainValue.split(' ')
   const toggleShow = () => updateConfig({ ...config, showBalance: !config.showBalance })
 

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -14,7 +14,7 @@ import Table, { TableData } from './Table'
 import StatusIcon from '../icons/Status'
 import HashIcon from '../icons/Hash'
 import InfoIcon from '../icons/Info'
-import { Unit, Wallet } from '../lib/types'
+import { Wallet } from '../lib/types'
 import {
   openInNewTab,
   openOffchainTxInNewTab,
@@ -76,12 +76,10 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     if (useFiat) {
       const fiat = toFiat(amount)
       return config.showBalance
-        ? prettyFiatAmount(fiat, config.fiat, { bitcoinUnit: config.currencyDisplay })
-        : prettyFiatHide(fiat, config.fiat, { bitcoinUnit: config.currencyDisplay })
+        ? prettyFiatAmount(fiat, config.fiat, { bitcoinUnit: config.unit })
+        : prettyFiatHide(fiat, config.fiat, { bitcoinUnit: config.unit })
     }
-    return config.showBalance
-      ? prettyBitcoinAmount(amount, config.currencyDisplay as unknown as Unit)
-      : prettyBitcoinHide(amount, config.currencyDisplay)
+    return config.showBalance ? prettyBitcoinAmount(amount, config.unit) : prettyBitcoinHide(amount, config.unit)
   }
 
   // Only show explorer link if URL is available (e.g., mainnet for vmempool)

--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -5,7 +5,7 @@ import { ConfigContext } from '../providers/config'
 import { fromSatoshis, prettyNumber, toSatoshis } from '../lib/format'
 import { FIAT_SYMBOLS } from '../lib/fiat'
 import { LimitsContext } from '../providers/limits'
-import { AssetOption } from '../lib/types'
+import { AssetOption, Unit } from '../lib/types'
 import { TextSecondary } from './Text'
 import { hapticLight } from '../lib/haptics'
 
@@ -55,7 +55,7 @@ export default function InputAmount({
   const input = useRef<HTMLInputElement>(null)
 
   const toSats = (value: number): number => {
-    return config.currencyDisplay === 'BTC' ? toSatoshis(value) : value
+    return config.unit === Unit.BTC ? toSatoshis(value) : value
   }
 
   // focus input when focus prop changes
@@ -79,7 +79,7 @@ export default function InputAmount({
   // update other value when satsValue change
   useEffect(() => {
     setError(satsValue ? (satsValue < 0 ? 'Invalid amount' : '') : '')
-    const useBTC = config.currencyDisplay === 'BTC'
+    const useBTC = config.unit === Unit.BTC
     const btcValue = useBTC ? fromSatoshis(satsValue) : satsValue
     const decimals = useBTC ? 8 : 0
     setOtherValue(useFiat ? prettyNumber(btcValue, decimals) : prettyNumber(toFiat(satsValue), fiatDecimals()))
@@ -97,10 +97,10 @@ export default function InputAmount({
   const maximumSats = max ? Math.min(max, maxSwapAllowed()) : 0
 
   const fiatSymbol = FIAT_SYMBOLS[config.fiat]
-  const fiatLabel = useFiat ? (fiatSymbol ?? config.fiat) : config.currencyDisplay
+  const fiatLabel = useFiat ? (fiatSymbol ?? config.fiat) : config.unit
 
-  const leftLabel = asset?.assetId ? asset.ticker : useFiat ? fiatLabel : config.currencyDisplay
-  const rightLabel = !asset?.assetId && useFiat ? `${otherValue} ${config.currencyDisplay}` : ''
+  const leftLabel = asset?.assetId ? asset.ticker : useFiat ? fiatLabel : config.unit
+  const rightLabel = !asset?.assetId && useFiat ? `${otherValue} ${config.unit}` : ''
   const bottomLeft =
     minimumSats && satsValue !== undefined && satsValue < minimumSats
       ? `Min: ${prettyNumber(minimumSats)} ${minimumSats === 1 ? 'sat' : 'sats'}`

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -12,7 +12,7 @@ import ButtonsOnBottom from './ButtonsOnBottom'
 import { ConfigContext } from '../providers/config'
 import FlexCol from './FlexCol'
 import SwapIcon from '../icons/Swap'
-import { AssetOption, Currencies } from '../lib/types'
+import { AssetOption, Currencies, Unit } from '../lib/types'
 import { prettyAssetAmount, unitsToCents } from '../lib/assets'
 
 export type KeyboardInputMode = 'sats' | 'fiat' | 'asset' | 'btc'
@@ -39,8 +39,8 @@ export default function Keyboard({ asset, back, hideBalance, onClear, onSave, in
   const [textValue, setTextValue] = useState('')
 
   useEffect(() => {
-    setInputMode(asset?.assetId ? 'asset' : useFiat ? 'fiat' : config.currencyDisplay === 'BTC' ? 'btc' : 'sats')
-  }, [asset, useFiat, config.currencyDisplay])
+    setInputMode(asset?.assetId ? 'asset' : useFiat ? 'fiat' : config.unit === Unit.BTC ? 'btc' : 'sats')
+  }, [asset, useFiat, config.unit])
 
   useEffect(() => {
     if (initialValue && inputMode && toFiat && fiatDecimals) {
@@ -138,7 +138,7 @@ export default function Keyboard({ asset, back, hideBalance, onClear, onSave, in
       setInputMode('fiat')
     } else {
       setTextValue(amountInSats ? prettyNumber(amountInSats, 0, false) : '')
-      setInputMode(config.currencyDisplay === 'BTC' ? 'btc' : 'sats')
+      setInputMode(config.unit === Unit.BTC ? 'btc' : 'sats')
     }
   }
 
@@ -151,9 +151,9 @@ export default function Keyboard({ asset, back, hideBalance, onClear, onSave, in
   }
 
   const prettyBitcoinAmount = (sats: number) => {
-    return config.currencyDisplay === 'BTC'
-      ? prettyAmount(fromSatoshis(sats), config.currencyDisplay, 8)
-      : prettyAmount(sats, config.currencyDisplay, 0)
+    return config.unit === Unit.BTC
+      ? prettyAmount(fromSatoshis(sats), config.unit, 8)
+      : prettyAmount(sats, config.unit, 0)
   }
 
   // Display amounts based on input mode
@@ -163,21 +163,21 @@ export default function Keyboard({ asset, back, hideBalance, onClear, onSave, in
         ? `${textValue || '0'} ${asset?.ticker}`
         : inputMode === 'fiat'
           ? prettyFiatAmount(amountInSats ? toFiat(amountInSats) : 0, config.fiat, {
-              bitcoinUnit: config.currencyDisplay,
+              bitcoinUnit: config.unit,
             })
-          : `${textValue || '0'} ${config.currencyDisplay}`,
+          : `${textValue || '0'} ${config.unit}`,
     secondary: !useFiat
       ? ''
       : inputMode === 'fiat'
         ? prettyBitcoinAmount(amountInSats)
         : prettyFiatAmount(amountInSats ? toFiat(amountInSats) : 0, config.fiat, {
-            bitcoinUnit: config.currencyDisplay,
+            bitcoinUnit: config.unit,
           }),
     balance:
       inputMode === 'asset'
         ? `${prettyAssetAmount(asset?.balance ?? BigInt(0), asset?.decimals ?? 0)} ${asset?.ticker}`
         : inputMode === 'fiat'
-          ? prettyFiatAmount(toFiat(available), config.fiat, { bitcoinUnit: config.currencyDisplay })
+          ? prettyFiatAmount(toFiat(available), config.fiat, { bitcoinUnit: config.unit })
           : prettyBitcoinAmount(available),
   }
 

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -1,7 +1,7 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useContext, useRef } from 'react'
 import { WalletContext } from '../providers/wallet'
-import { Currencies, Tx, Unit } from '../lib/types'
+import { Currencies, Tx } from '../lib/types'
 import {
   isBurn,
   isIssuance,
@@ -57,8 +57,8 @@ const TransactionLine = ({
     const secondaryClassName = asAssets ? ' activity-row__amount--secondary' : ''
     return (
       <span className={`activity-row__amount${statusClassName}${secondaryClassName}`}>
-        <PrivacyAmount masked={prettyFiatHide(value, config.fiat, { bitcoinUnit: config.currencyDisplay })}>
-          {prettyFiatAmount(value, config.fiat, { bitcoinUnit: config.currencyDisplay })}
+        <PrivacyAmount masked={prettyFiatHide(value, config.fiat, { bitcoinUnit: config.unit })}>
+          {prettyFiatAmount(value, config.fiat, { bitcoinUnit: config.unit })}
         </PrivacyAmount>
       </span>
     )
@@ -95,8 +95,8 @@ const TransactionLine = ({
         }`}
       >
         <PrivacyAmount
-          masked={`${prefix} ${prettyFiatHide(toFiat(tx.amount), config.fiat, { bitcoinUnit: config.currencyDisplay })}`}
-        >{`${prefix} ${prettyBitcoinAmount(tx.amount, config.currencyDisplay as unknown as Unit)}`}</PrivacyAmount>
+          masked={`${prefix} ${prettyFiatHide(toFiat(tx.amount), config.fiat, { bitcoinUnit: config.unit })}`}
+        >{`${prefix} ${prettyBitcoinAmount(tx.amount, config.unit)}`}</PrivacyAmount>
       </span>
     )
 

--- a/src/hooks/usePortfolioBalanceDisplay.ts
+++ b/src/hooks/usePortfolioBalanceDisplay.ts
@@ -13,16 +13,16 @@ export function usePortfolioBalanceDisplay() {
   const decimals = fiatDecimals()
 
   const { amount: balance, unit } = formatFiatAmountParts(totalFiat, config.fiat, {
-    bitcoinUnit: config.currencyDisplay,
+    bitcoinUnit: config.unit,
     maximumFractionDigits: decimals,
     minimumFractionDigits: decimals,
   })
 
   const maskedBalance =
     config.fiat === 'BTC'
-      ? config.currencyDisplay === '₿'
+      ? config.unit === '₿'
         ? '₿••••'
-        : `•••• ${config.currencyDisplay}`
+        : `•••• ${config.unit}`
       : FIAT_SYMBOLS[config.fiat]
         ? maskedFiat(FIAT_SYMBOLS[config.fiat])
         : `•••• ${config.fiat}`

--- a/src/hooks/usePortfolioBalanceDisplay.ts
+++ b/src/hooks/usePortfolioBalanceDisplay.ts
@@ -5,6 +5,7 @@ import { formatFiatAmountParts } from '../lib/format'
 import { usePortfolioFiat } from './usePortfolioFiat'
 import { FIAT_SYMBOLS } from '../lib/fiat'
 import { maskedFiat } from '../components/PrivacyAmount'
+import { Currencies, Unit } from '../lib/types'
 
 export function usePortfolioBalanceDisplay() {
   const { config } = useContext(ConfigContext)
@@ -19,9 +20,9 @@ export function usePortfolioBalanceDisplay() {
   })
 
   const maskedBalance =
-    config.fiat === 'BTC'
-      ? config.unit === '₿'
-        ? '₿••••'
+    config.fiat === Currencies.BTC
+      ? config.unit === Unit.BIP177
+        ? `${config.unit}••••`
         : `•••• ${config.unit}`
       : FIAT_SYMBOLS[config.fiat]
         ? maskedFiat(FIAT_SYMBOLS[config.fiat])

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -39,14 +39,12 @@ export const prettyAmount = (sats: number, suffix?: string, decimals = 2): strin
 }
 
 type FiatAmountFormatOptions = {
-  bitcoinUnit?: Unit | CurrencyDisplayUnit
+  bitcoinUnit?: Unit
   maximumFractionDigits?: number
   minimumFractionDigits?: number
 }
 
-type CurrencyDisplayUnit = `${Unit}` | 'SATS' | 'btc' | 'sat' | 'Sats only' | 'Fiat only' | 'Show both'
-
-export const normalizeBitcoinUnit = (unit?: CurrencyDisplayUnit): Unit => {
+export const normalizeBitcoinUnit = (unit?: Unit | string): Unit => {
   if (unit === Unit.SATS || unit === 'SATS' || unit === 'sat' || unit === 'Sats only') return Unit.SATS
   if (unit === Unit.BIP177) return Unit.BIP177
   return Unit.BTC
@@ -191,7 +189,7 @@ export const prettyFiatHide = (value: number, currency: Currencies, options: Fia
   return symbol ? `${symbol}${dots}` : `${dots} ${currency}`
 }
 
-export const prettyBitcoinHide = (value: number, unit: Unit | CurrencyDisplayUnit): string => {
+export const prettyBitcoinHide = (value: number, unit: Unit): string => {
   return prettyFiatHide(value, Currencies.BTC, { bitcoinUnit: unit })
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,7 +16,6 @@ export type Config = {
     }
   }
   aspUrl: string
-  currencyDisplay: CurrencyDisplay
   delegate: boolean
   fiat: Currencies
   importedAssets: string[]
@@ -29,12 +28,6 @@ export type Config = {
   theme: Themes
   unit: Unit
   walletMode: ServiceWorkerWalletMode
-}
-
-export enum CurrencyDisplay {
-  BTC = 'BTC',
-  Sats = 'sats',
-  Bip177 = '₿',
 }
 
 export type Delegate = {

--- a/src/providers/config.tsx
+++ b/src/providers/config.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, createContext, useEffect, useState } from 'react'
 import { readConfigFromStorage, saveConfigToStorage } from '../lib/storage'
 import { defaultArkServer, devServer } from '../lib/constants'
-import { Config, CurrencyDisplay, Currencies, Themes, Unit } from '../lib/types'
+import { Config, Currencies, Themes, Unit } from '../lib/types'
 import { normalizeBitcoinUnit } from '../lib/format'
 import { BackupProvider } from '../lib/backup'
 import { consoleError } from '../lib/logs'
@@ -13,7 +13,6 @@ const defaultConfig: Config = {
   apps: { assets: { enabled: false }, boltz: { connected: true } },
   aspUrl: defaultArkServer(),
   dismissedBanners: [],
-  currencyDisplay: CurrencyDisplay.BTC,
   delegate: import.meta.env.VITE_DELEGATE_ENABLED !== 'false',
   fiat: Currencies.USD,
   importedAssets: [],
@@ -68,7 +67,6 @@ const updateDefaultConfig = (config: Partial<Config>): Config => {
       assets: { enabled: config.apps?.assets?.enabled ?? defaultConfig.apps.assets.enabled },
       boltz: { connected: config.apps?.boltz?.connected ?? defaultConfig.apps.boltz.connected },
     },
-    currencyDisplay: normalizeBitcoinUnit(config.currencyDisplay as `${CurrencyDisplay}`) as unknown as CurrencyDisplay,
     fiat: config.fiat === Currencies.BTC ? Currencies.BTC : (config.fiat ?? defaultConfig.fiat),
     unit: normalizeBitcoinUnit(config.unit as `${Unit}`),
   }

--- a/src/providers/fiat.tsx
+++ b/src/providers/fiat.tsx
@@ -31,6 +31,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
   const [loading, setLoading] = useState(false)
 
   const prices = useRef<FiatPrices>(emptyFiatPrices)
+  const selectedBitcoinUnit = config.unit
 
   const fromEUR = (fiat = 0) => (prices.current.eur ? toSatoshis(Decimal.div(fiat, prices.current.eur).toNumber()) : 0)
   const fromUSD = (fiat = 0) => (prices.current.usd ? toSatoshis(Decimal.div(fiat, prices.current.usd).toNumber()) : 0)
@@ -38,7 +39,6 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
   const fromJPY = (fiat = 0) => (prices.current.jpy ? toSatoshis(Decimal.div(fiat, prices.current.jpy).toNumber()) : 0)
   const fromGBP = (fiat = 0) => (prices.current.gbp ? toSatoshis(Decimal.div(fiat, prices.current.gbp).toNumber()) : 0)
   const fromCNY = (fiat = 0) => (prices.current.cny ? toSatoshis(Decimal.div(fiat, prices.current.cny).toNumber()) : 0)
-  const selectedBitcoinUnit = config.currencyDisplay as unknown as Unit
   const fromBTC = (amount = 0) => (selectedBitcoinUnit === Unit.BTC ? toSatoshis(amount) : Math.floor(amount))
   const toEUR = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.eur).toNumber()
   const toUSD = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.usd).toNumber()
@@ -69,7 +69,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
   }
   const toFiat = (sats = 0) => toFiatAmount(sats, config.fiat)
 
-  const fiatDecimals = () => fiatDecimalsFor(config.fiat, config.currencyDisplay as unknown as Unit)
+  const fiatDecimals = () => fiatDecimalsFor(config.fiat, config.unit)
 
   const updateFiatPrices = async () => {
     if (loading) return

--- a/src/screens/Settings/Display.tsx
+++ b/src/screens/Settings/Display.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { CurrencyDisplay } from '../../lib/types'
+import { Unit } from '../../lib/types'
 import Select from '../../components/Select'
 import Padded from '../../components/Padded'
 import Content from '../../components/Content'
@@ -9,8 +9,9 @@ import Header from './Header'
 export default function Display() {
   const { backupConfig, config, updateConfig } = useContext(ConfigContext)
 
-  const handleChange = async (currencyDisplay: string) => {
-    const newConfig = { ...config, currencyDisplay: currencyDisplay as CurrencyDisplay }
+  const handleChange = async (value: string) => {
+    const unit = value as Unit
+    const newConfig = { ...config, unit }
     if (config.nostrBackup) await backupConfig(newConfig)
     updateConfig(newConfig)
   }
@@ -23,11 +24,7 @@ export default function Display() {
           <div className='settings-page'>
             <section className='settings-section'>
               <p className='settings-section-label'>Bitcoin unit</p>
-              <Select
-                onChange={handleChange}
-                options={[CurrencyDisplay.BTC, CurrencyDisplay.Sats, CurrencyDisplay.Bip177]}
-                selected={config.currencyDisplay}
-              />
+              <Select onChange={handleChange} options={[Unit.BTC, Unit.SATS, Unit.BIP177]} selected={config.unit} />
             </section>
           </div>
         </Padded>

--- a/src/screens/Settings/General.tsx
+++ b/src/screens/Settings/General.tsx
@@ -42,7 +42,7 @@ export default function General() {
               <p className='settings-section-label'>Preferences</p>
               <div className='settings-row-group'>
                 <Row option={SettingsOptions.Currency} value={config.fiat} />
-                <Row option={SettingsOptions.BitcoinUnit} value={config.currencyDisplay} />
+                <Row option={SettingsOptions.BitcoinUnit} value={config.unit} />
                 <Row option={SettingsOptions.Haptics} value={config.haptics ? 'On' : 'Off'} />
                 <Row
                   option={SettingsOptions.Theme}

--- a/src/screens/Wallet/AssetsSection.tsx
+++ b/src/screens/Wallet/AssetsSection.tsx
@@ -17,7 +17,7 @@ export default function AssetsSection() {
   const fiatLabel = (amount: number) => {
     const decimals = fiatDecimals()
     return prettyFiatAmount(amount, config.fiat, {
-      bitcoinUnit: config.currencyDisplay,
+      bitcoinUnit: config.unit,
       maximumFractionDigits: decimals,
       minimumFractionDigits: decimals,
     })

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -23,7 +23,7 @@ import {
 import { fiatDecimalsFor } from '../../lib/fiat'
 import { hapticLight, hapticSubtle } from '../../lib/haptics'
 import { consoleError } from '../../lib/logs'
-import { Currencies, Themes, Unit } from '../../lib/types'
+import { Currencies, Themes } from '../../lib/types'
 import { useReducedMotion } from '../../hooks/useReducedMotion'
 import { ConfigContext } from '../../providers/config'
 import { FiatContext } from '../../providers/fiat'
@@ -59,7 +59,7 @@ export default function BitcoinDetail() {
 
   const marketFiat = config.fiat === Currencies.BTC ? Currencies.USD : config.fiat
   const marketDecimals = fiatDecimalsFor(marketFiat)
-  const bitcoinUnit = config.currencyDisplay as unknown as Unit
+  const bitcoinUnit = config.unit
   const fallbackUnitPrice = toFiatAmount(100_000_000, marketFiat)
   const liveChartData = useBitcoinMarketChartData(marketFiat, chartWindow)
   const unitPrice = liveChartData.at(-1)?.value ?? fallbackUnitPrice

--- a/src/screens/Wallet/Notes/Success.tsx
+++ b/src/screens/Wallet/Notes/Success.tsx
@@ -23,7 +23,7 @@ export default function NotesSuccess() {
   }, [])
 
   const displayAmount = useFiat
-    ? prettyFiatAmount(toFiat(noteInfo.satoshis), config.fiat, { bitcoinUnit: config.currencyDisplay })
+    ? prettyFiatAmount(toFiat(noteInfo.satoshis), config.fiat, { bitcoinUnit: config.unit })
     : prettyAmount(noteInfo.satoshis)
 
   return (

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -39,7 +39,7 @@ import Focusable from '../../../components/Focusable'
 import { LnurlContext } from '../../../providers/lnurl'
 import { useReducedMotion } from '../../../hooks/useReducedMotion'
 import ButtonsOnBottom from '../../../components/ButtonsOnBottom'
-import { AssetOption } from '../../../lib/types'
+import { AssetOption, Unit } from '../../../lib/types'
 import { EASE_OUT_QUINT } from '../../../lib/animations'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
@@ -357,7 +357,7 @@ export default function ReceiveQRCode() {
       const num = Number(value)
       if (Number.isNaN(num) || !Number.isFinite(num)) throw new Error('Invalid amount')
       const shouldConvertFromFiat = inputMode === 'fiat' || (useFiat && inputMode === undefined)
-      const shouldConvertToSats = inputMode === 'btc' || (!useFiat && config.currencyDisplay === 'BTC')
+      const shouldConvertToSats = inputMode === 'btc' || (!useFiat && config.unit === Unit.BTC)
       const sats = shouldConvertFromFiat ? fromFiat(num) : shouldConvertToSats ? toSatoshis(num) : num
       // if amount was changed, we need to reset invoice and swap address, since they are amount-specific
       // this will also trigger the useEffect to create new ones if needed

--- a/src/screens/Wallet/Receive/Success.tsx
+++ b/src/screens/Wallet/Receive/Success.tsx
@@ -75,7 +75,7 @@ export default function ReceiveSuccess() {
   }, [assetDetails])
 
   const displayAmount = useFiat
-    ? prettyFiatAmount(toFiat(recvInfo.satoshis), config.fiat, { bitcoinUnit: config.currencyDisplay })
+    ? prettyFiatAmount(toFiat(recvInfo.satoshis), config.fiat, { bitcoinUnit: config.unit })
     : prettyAmount(recvInfo.satoshis)
 
   if (isAssetReceive) {

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -29,7 +29,7 @@ import Shadow from '../../../components/Shadow'
 import Scanner from '../../../components/Scanner'
 import LoadingLogo from '../../../components/LoadingLogo'
 import { consoleError } from '../../../lib/logs'
-import { Addresses, AssetOption, SettingsOptions, Themes } from '../../../lib/types'
+import { Addresses, AssetOption, SettingsOptions, Themes, Unit } from '../../../lib/types'
 import { aspErrorText, getReceivingAddresses } from '../../../lib/asp'
 import { OptionsContext } from '../../../providers/options'
 import { isMobileBrowser } from '../../../lib/browser'
@@ -424,6 +424,7 @@ export default function SendForm() {
           const textValue = useFiat ? toFiat(min) : config.unit === 'BTC' ? fromSatoshis(min) : min
           setSendInfo({ ...sendInfo, satoshis: min })
           setAmountTextValue(textValue.toString())
+          setAmountIsReadOnly(true)
         }
         return setLnUrlResponse({ ...conditions, minSendable: min, maxSendable: max })
       })
@@ -601,7 +602,7 @@ export default function SendForm() {
     } else {
       const num = Number(value)
       if (Number.isNaN(num) || !Number.isFinite(num)) return setError('Invalid amount')
-      const sats = useFiat ? fromFiat(num) : config.currencyDisplay === 'BTC' ? toSatoshis(num) : Math.floor(num)
+      const sats = useFiat ? fromFiat(num) : config.unit === Unit.BTC ? toSatoshis(num) : Math.floor(num)
       setSendInfo({ ...sendInfo, satoshis: sats })
     }
   }
@@ -700,7 +701,7 @@ export default function SendForm() {
       setAmountTextValue(
         useFiat
           ? prettyNumber(toFiat(liquidBalance), fiatDecimals(), false)
-          : config.currencyDisplay === 'BTC'
+          : config.unit === Unit.BTC
             ? prettyNumber(fromSatoshis(liquidBalance), 8, false)
             : prettyNumber(liquidBalance, 0, false),
       )
@@ -729,9 +730,9 @@ export default function SendForm() {
     }
 
     const pretty = useFiat
-      ? prettyFiatAmount(toFiat(liquidBalance), config.fiat, { bitcoinUnit: config.currencyDisplay })
-      : config.currencyDisplay === 'BTC'
-        ? prettyAmount(fromSatoshis(liquidBalance), config.currencyDisplay, 8)
+      ? prettyFiatAmount(toFiat(liquidBalance), config.fiat, { bitcoinUnit: config.unit })
+      : config.unit === Unit.BTC
+        ? prettyAmount(fromSatoshis(liquidBalance), config.unit, 8)
         : prettyAmount(liquidBalance)
 
     return (
@@ -772,7 +773,7 @@ export default function SendForm() {
     ? `${prettyAssetAmount(selectedAsset.balance, selectedAsset.decimals)} ${selectedAsset.ticker} available`
     : `${
         useFiat
-          ? prettyFiatAmount(toFiat(liquidBalance), config.fiat, { bitcoinUnit: config.currencyDisplay })
+          ? prettyFiatAmount(toFiat(liquidBalance), config.fiat, { bitcoinUnit: config.unit })
           : prettyAmount(liquidBalance)
       } available`
 
@@ -953,7 +954,7 @@ export default function SendForm() {
                                 <span className='send-asset-option__meta'>
                                   {useFiat
                                     ? prettyFiatAmount(toFiat(liquidBalance), config.fiat, {
-                                        bitcoinUnit: config.currencyDisplay,
+                                        bitcoinUnit: config.unit,
                                       })
                                     : prettyAmount(liquidBalance)}{' '}
                                   available

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -421,7 +421,7 @@ export default function SendForm() {
         const max = Math.floor(conditions.maxSendable / 1000) // from millisatoshis to satoshis
         // when the LNURL resolves to a fixed amount, set amountTextValue
         if (min === max) {
-          const textValue = useFiat ? toFiat(min) : config.unit === 'BTC' ? fromSatoshis(min) : min
+          const textValue = useFiat ? toFiat(min) : config.unit === Unit.BTC ? fromSatoshis(min) : min
           setSendInfo({ ...sendInfo, satoshis: min })
           setAmountTextValue(textValue.toString())
           setAmountIsReadOnly(true)

--- a/src/screens/Wallet/Send/Success.tsx
+++ b/src/screens/Wallet/Send/Success.tsx
@@ -123,7 +123,7 @@ export default function SendSuccess() {
   const displayAmount = isAssetSend
     ? `${prettyAssetAmount(assetAmountValue, assetDecimals)} ${assetTicker}`
     : useFiat
-      ? prettyFiatAmount(toFiat(totalSats), config.fiat, { bitcoinUnit: config.currencyDisplay })
+      ? prettyFiatAmount(toFiat(totalSats), config.fiat, { bitcoinUnit: config.unit })
       : prettyAmount(totalSats)
 
   if (isAssetSend && assetId) {

--- a/src/test/e2e/utils.ts
+++ b/src/test/e2e/utils.ts
@@ -3,6 +3,7 @@ import { faucetOffchain } from './fundedWallet'
 import { sleep } from '../../lib/sleep'
 import { exec } from 'child_process'
 import { promisify } from 'util'
+import { Currencies, Unit } from '@/lib/types'
 
 const execAsync = promisify(exec)
 
@@ -13,8 +14,8 @@ export const test = base.extend({
     await page.addInitScript(() => {
       const raw = localStorage.getItem('config')
       const config = raw ? JSON.parse(raw) : {}
-      config.fiat = 'BTC'
-      config.unit = 'sats'
+      config.fiat = Currencies.BTC
+      config.unit = Unit.SATS
       localStorage.setItem('config', JSON.stringify(config))
     })
     await use(page)

--- a/src/test/e2e/utils.ts
+++ b/src/test/e2e/utils.ts
@@ -14,7 +14,7 @@ export const test = base.extend({
       const raw = localStorage.getItem('config')
       const config = raw ? JSON.parse(raw) : {}
       config.fiat = 'BTC'
-      config.currencyDisplay = 'sats'
+      config.unit = 'sats'
       localStorage.setItem('config', JSON.stringify(config))
     })
     await use(page)

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -3,7 +3,7 @@ import { Pages, Tabs } from '../../providers/navigation'
 import { emptyInitInfo, emptyNoteInfo, emptyRecvInfo, emptySendInfo } from '../../providers/flow'
 import { AspInfo } from '../../providers/asp'
 import { SingleKey, IVtxoManager } from '@arkade-os/sdk'
-import { CurrencyDisplay, Currencies, SettingsOptions, Themes, Unit } from '../../lib/types'
+import { Currencies, SettingsOptions, Themes, Unit } from '../../lib/types'
 import { AssetIconApprovalManager } from '../../lib/assetIconApproval'
 
 const mockAspInfo: AspInfo = {
@@ -59,7 +59,6 @@ export const mockConfigContextValue = {
     apps: { assets: { enabled: true }, boltz: { connected: true } },
     aspUrl: 'http://asp.local',
     dismissedBanners: [],
-    currencyDisplay: CurrencyDisplay.BTC,
     delegate: import.meta.env.VITE_DELEGATE_ENABLED !== 'false',
     fiat: Currencies.EUR,
     importedAssets: [],

--- a/src/test/screens/wallet/bitcoin-detail.test.tsx
+++ b/src/test/screens/wallet/bitcoin-detail.test.tsx
@@ -13,7 +13,7 @@ import {
   mockNavigationContextValue,
   mockWalletContextValue,
 } from '../mocks'
-import { CurrencyDisplay, Currencies } from '../../../lib/types'
+import { Currencies, Unit } from '../../../lib/types'
 
 vi.mock('liveline', () => ({
   Liveline: ({ paused }: { paused?: boolean }) => <div data-testid='liveline-chart' data-paused={String(paused)} />,
@@ -82,7 +82,7 @@ describe('Bitcoin detail screen', () => {
           ...mockConfigContextValue,
           config: {
             ...mockConfigContextValue.config,
-            currencyDisplay: CurrencyDisplay.Bip177,
+            unit: Unit.BIP177,
             fiat: Currencies.BTC,
           },
         }}

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -23,7 +23,7 @@ import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 import { SwapsContext } from '../../../providers/swaps'
 import { OptionsContext } from '../../../providers/options'
-import { Currencies, CurrencyDisplay } from '@/lib/types'
+import { Currencies, Unit } from '../../../lib/types'
 
 describe('Send screen', () => {
   const renderSendForm = ({
@@ -158,7 +158,7 @@ describe('Send screen', () => {
     const configValue = {
       ...mockConfigContextValue,
       useFiat: false,
-      config: { ...mockConfigContextValue.config, fiat: Currencies.BTC, currencyDisplay: CurrencyDisplay.BTC },
+      config: { ...mockConfigContextValue.config, fiat: Currencies.BTC, unit: Unit.BTC },
     }
 
     renderSendForm({ configContext: configValue, walletContext: walletValue })
@@ -181,7 +181,7 @@ describe('Send screen', () => {
     const configValue = {
       ...mockConfigContextValue,
       useFiat: false,
-      config: { ...mockConfigContextValue.config, fiat: Currencies.BTC, currencyDisplay: CurrencyDisplay.Sats },
+      config: { ...mockConfigContextValue.config, fiat: Currencies.BTC, unit: Unit.SATS },
     }
 
     renderSendForm({ configContext: configValue, walletContext: walletValue })
@@ -204,7 +204,7 @@ describe('Send screen', () => {
     const configValue = {
       ...mockConfigContextValue,
       useFiat: true,
-      config: { ...mockConfigContextValue.config, fiat: Currencies.USD, currencyDisplay: CurrencyDisplay.BTC },
+      config: { ...mockConfigContextValue.config, fiat: Currencies.USD, unit: Unit.BTC },
     }
     const fiatValue = {
       ...mockFiatContextValue,
@@ -236,7 +236,7 @@ describe('Send screen', () => {
     const configValue = {
       ...mockConfigContextValue,
       useFiat: false,
-      config: { ...mockConfigContextValue.config, fiat: Currencies.BTC, currencyDisplay: CurrencyDisplay.BTC },
+      config: { ...mockConfigContextValue.config, fiat: Currencies.BTC, unit: Unit.BTC },
     }
 
     renderSendForm({


### PR DESCRIPTION
Removes currencyDisplay from code, since it doesn't make any sense anymore and it was making AI confused.

We now have
- fiat, where BTC is one of them :(
- unit, preferred BTC unit ('btc', 'sats', or 'bip177')

To remind, currencyDisplay was:
- sats only
- fiat only
- show both

This does not make sense anymore, the new behaviour is:
- if user is using fiat, show auxiliary amounts in BTC preferred unit
- if user is using BTC, no auxiliary amounts are shown, since we don't know in which fiat to show it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet amounts, balances, transaction lists, and send/receive screens now use the selected Bitcoin unit consistently.
  * Fixed unit display across settings and wallet views, including BTC, sats, and BIP177 options.
  * Improved amount conversion and formatting, including read-only handling for fixed LNURL amounts.
  * Updated fiat and Bitcoin formatting so masked and “available” values stay in sync with the chosen unit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->