### PR TITLE
Order settings by product priority

### DIFF
--- a/src/providers/options.tsx
+++ b/src/providers/options.tsx
@@ -65,23 +65,8 @@ export const options: Option[] = [
     section: SettingsSections.Advanced,
   },
   {
-    icon: <InfoIcon />,
-    option: SettingsOptions.About,
-    section: SettingsSections.Display,
-  },
-  {
-    icon: <PuzzleIcon />,
-    option: SettingsOptions.Advanced,
-    section: SettingsSections.Display,
-  },
-  {
     icon: <CogIcon />,
     option: SettingsOptions.Display,
-    section: SettingsSections.Display,
-  },
-  {
-    icon: <NotesIcon />,
-    option: SettingsOptions.Notes,
     section: SettingsSections.Display,
   },
   {
@@ -90,8 +75,23 @@ export const options: Option[] = [
     section: SettingsSections.Display,
   },
   {
+    icon: <NotesIcon />,
+    option: SettingsOptions.Notes,
+    section: SettingsSections.Display,
+  },
+  {
+    icon: <InfoIcon />,
+    option: SettingsOptions.About,
+    section: SettingsSections.Display,
+  },
+  {
     icon: <SupportIcon />,
     option: SettingsOptions.Support,
+    section: SettingsSections.Display,
+  },
+  {
+    icon: <PuzzleIcon />,
+    option: SettingsOptions.Advanced,
     section: SettingsSections.Display,
   },
   {

--- a/src/test/screens/settings/menu.test.tsx
+++ b/src/test/screens/settings/menu.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import SettingsMenu from '../../../screens/Settings/Menu'
+import { OptionsContext } from '../../../providers/options'
+import { mockOptionsContextValue } from '../mocks'
+
+function renderSettingsMenu() {
+  return render(
+    <OptionsContext.Provider value={mockOptionsContextValue as any}>
+      <SettingsMenu />
+    </OptionsContext.Provider>,
+  )
+}
+
+describe('Settings menu', () => {
+  it('orders settings by product priority instead of alphabetically', () => {
+    renderSettingsMenu()
+
+    const orderedOptions = [
+      'display',
+      'notifications',
+      'notes',
+      'about',
+      'support',
+      'advanced',
+      'backup',
+      'lock wallet',
+      'reset wallet',
+    ].map((label) => screen.getByText(label))
+
+    for (let index = 0; index < orderedOptions.length - 1; index++) {
+      expect(
+        orderedOptions[index].compareDocumentPosition(orderedOptions[index + 1]) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Reorders the visible settings menu by product priority instead of alphabetical order.
- Places the everyday settings first: display, notifications, notes, about, support, then advanced.
- Keeps security settings grouped separately and adds a regression test for the visible menu order.

## Product rationale
Logical ordering makes the settings page easier to scan than alphabetical sorting. Users are more likely to look for everyday configuration such as display preferences and notifications before lower-frequency or technical surfaces. In particular, putting advanced near the top makes the page feel implementation-driven instead of user-task-driven.

## Testing
- `bun run vitest run src/test/screens/settings/menu.test.tsx`
- `bun run format:check`
- `bun run lint`
- Browser verification of the settings menu order at `https://wt-reorder-settings-20260707.arkade.localhost:1355`

Note: the Husky pre-commit hook invokes pnpm and was blocked locally by pnpm approve-builds for existing ignored build scripts (`esbuild`, `msw`). The equivalent checks above were run with Bun and passed.

## Affected files
- `src/providers/options.tsx`
- `src/test/screens/settings/menu.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Settings menu item order to match the intended product priority, making key sections appear in a more consistent and predictable sequence.
  * Refreshed the visible arrangement of several settings entries within the menu for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->