### PR TITLE
Add Brazilian Real (BRL) fiat currency support

### DIFF
--- a/src/lib/fiat.ts
+++ b/src/lib/fiat.ts
@@ -8,6 +8,7 @@ export interface FiatPrices {
   jpy: number
   gbp: number
   cny: number
+  brl: number
 }
 
 // Currencies listed here are prefixed with their symbol when displaying amounts.
@@ -18,6 +19,7 @@ export const FIAT_SYMBOLS: Partial<Record<Currencies, string>> = {
   [Currencies.EUR]: '€',
   [Currencies.GBP]: '£',
   [Currencies.JPY]: '¥',
+  [Currencies.BRL]: 'R$',
 }
 
 export const fiatDecimalsFor = (currency: Currencies, bitcoinUnit = Unit.BTC): number => {
@@ -36,6 +38,7 @@ export const getPriceFeed = async (): Promise<FiatPrices | undefined> => {
       jpy: json.JPY?.last,
       gbp: json.GBP?.last,
       cny: json.CNY?.last,
+      brl: json.BRL?.last,
     }
   } catch (err) {
     consoleError(err, 'error fetching fiat prices')

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -120,6 +120,7 @@ export const fiatForTicker = (ticker: string | undefined): Currencies | undefine
   if (normalized === 'GBP') return Currencies.GBP
   if (normalized === 'JPY') return Currencies.JPY
   if (normalized === 'CNY') return Currencies.CNY
+  if (normalized === 'BRL' || normalized === 'DPIX' || normalized === 'DEPIX') return Currencies.BRL
 }
 
 export const prettyCurrencyAssetAmount = (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,6 +48,7 @@ export enum Currencies {
   GBP = 'GBP',
   JPY = 'JPY',
   CNY = 'CNY',
+  BRL = 'BRL',
   BTC = 'BTC',
 }
 

--- a/src/providers/fiat.tsx
+++ b/src/providers/fiat.tsx
@@ -14,7 +14,7 @@ type FiatContextProps = {
   updateFiatPrices: () => void
 }
 
-const emptyFiatPrices: FiatPrices = { eur: 0, usd: 0, chf: 0, jpy: 0, gbp: 0, cny: 0 }
+const emptyFiatPrices: FiatPrices = { eur: 0, usd: 0, chf: 0, jpy: 0, gbp: 0, cny: 0, brl: 0 }
 
 export const FiatContext = createContext<FiatContextProps>({
   toFiat: () => 0,
@@ -39,6 +39,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
   const fromJPY = (fiat = 0) => (prices.current.jpy ? toSatoshis(Decimal.div(fiat, prices.current.jpy).toNumber()) : 0)
   const fromGBP = (fiat = 0) => (prices.current.gbp ? toSatoshis(Decimal.div(fiat, prices.current.gbp).toNumber()) : 0)
   const fromCNY = (fiat = 0) => (prices.current.cny ? toSatoshis(Decimal.div(fiat, prices.current.cny).toNumber()) : 0)
+  const fromBRL = (fiat = 0) => (prices.current.brl ? toSatoshis(Decimal.div(fiat, prices.current.brl).toNumber()) : 0)
   const fromBTC = (amount = 0) => (selectedBitcoinUnit === Unit.BTC ? toSatoshis(amount) : Math.floor(amount))
   const toEUR = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.eur).toNumber()
   const toUSD = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.usd).toNumber()
@@ -46,6 +47,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
   const toJPY = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.jpy).toNumber()
   const toGBP = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.gbp).toNumber()
   const toCNY = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.cny).toNumber()
+  const toBRL = (sats = 0) => Decimal.mul(fromSatoshis(sats), prices.current.brl).toNumber()
   const toBTC = (sats = 0) => (selectedBitcoinUnit === Unit.BTC ? fromSatoshis(sats) : sats)
 
   const fromFiatAmount = (amount = 0, currency: Currencies) => {
@@ -55,6 +57,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
     if (currency === Currencies.JPY) return fromJPY(amount)
     if (currency === Currencies.GBP) return fromGBP(amount)
     if (currency === Currencies.CNY) return fromCNY(amount)
+    if (currency === Currencies.BRL) return fromBRL(amount)
     return fromUSD(amount)
   }
   const fromFiat = (fiat = 0) => fromFiatAmount(fiat, config.currency)
@@ -65,6 +68,7 @@ export const FiatProvider = ({ children }: { children: ReactNode }) => {
     if (currency === Currencies.JPY) return toJPY(sats)
     if (currency === Currencies.GBP) return toGBP(sats)
     if (currency === Currencies.CNY) return toCNY(sats)
+    if (currency === Currencies.BRL) return toBRL(sats)
     return toUSD(sats)
   }
   const toFiat = (sats = 0) => toFiatAmount(sats, config.currency)

--- a/src/screens/Settings/Fiat.tsx
+++ b/src/screens/Settings/Fiat.tsx
@@ -27,6 +27,7 @@ export default function Fiat() {
               <Select
                 onChange={handleChange}
                 options={[
+                  Currencies.BRL,
                   Currencies.BTC,
                   Currencies.CHF,
                   Currencies.CNY,

--- a/src/test/screens/settings/fiat.test.tsx
+++ b/src/test/screens/settings/fiat.test.tsx
@@ -12,14 +12,15 @@ describe('Fiat screen', () => {
       </ConfigContext.Provider>,
     )
     expect(screen.getAllByText('Currency')).toHaveLength(2)
-    expect(screen.getByTestId('select-option-0').querySelector('p')?.textContent).toBe('BTC')
-    expect(screen.getByTestId('select-option-1').querySelector('p')?.textContent).toBe('CHF')
-    expect(screen.getByTestId('select-option-2').querySelector('p')?.textContent).toBe('CNY')
-    expect(screen.getByTestId('select-option-3').querySelector('p')?.textContent).toBe('EUR')
-    expect(screen.getByTestId('select-option-4').querySelector('p')?.textContent).toBe('GBP')
-    expect(screen.getByTestId('select-option-5').querySelector('p')?.textContent).toBe('JPY')
-    expect(screen.getByTestId('select-option-6').querySelector('p')?.textContent).toBe('USD')
-    for (let index = 0; index < 7; index++) {
+    expect(screen.getByTestId('select-option-0').querySelector('p')?.textContent).toBe('BRL')
+    expect(screen.getByTestId('select-option-1').querySelector('p')?.textContent).toBe('BTC')
+    expect(screen.getByTestId('select-option-2').querySelector('p')?.textContent).toBe('CHF')
+    expect(screen.getByTestId('select-option-3').querySelector('p')?.textContent).toBe('CNY')
+    expect(screen.getByTestId('select-option-4').querySelector('p')?.textContent).toBe('EUR')
+    expect(screen.getByTestId('select-option-5').querySelector('p')?.textContent).toBe('GBP')
+    expect(screen.getByTestId('select-option-6').querySelector('p')?.textContent).toBe('JPY')
+    expect(screen.getByTestId('select-option-7').querySelector('p')?.textContent).toBe('USD')
+    for (let index = 0; index < 8; index++) {
       expect(
         screen.getByTestId(`select-option-${index}`).querySelector('.settings-select-row__icon svg'),
       ).toBeInTheDocument()
@@ -41,15 +42,18 @@ describe('Fiat screen', () => {
     expect(
       screen.getByTestId('select-option-2').querySelector('[data-testid="green-status-icon"]'),
     ).not.toBeInTheDocument()
-    expect(screen.getByTestId('select-option-3').querySelector('[data-testid="green-status-icon"]')).toBeInTheDocument()
     expect(
-      screen.getByTestId('select-option-4').querySelector('[data-testid="green-status-icon"]'),
+      screen.getByTestId('select-option-3').querySelector('[data-testid="green-status-icon"]'),
     ).not.toBeInTheDocument()
+    expect(screen.getByTestId('select-option-4').querySelector('[data-testid="green-status-icon"]')).toBeInTheDocument()
     expect(
       screen.getByTestId('select-option-5').querySelector('[data-testid="green-status-icon"]'),
     ).not.toBeInTheDocument()
     expect(
       screen.getByTestId('select-option-6').querySelector('[data-testid="green-status-icon"]'),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId('select-option-7').querySelector('[data-testid="green-status-icon"]'),
     ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
This PR adds support for the Brazilian Real (BRL) as a fiat currency option throughout the application, enabling users to view and convert Bitcoin amounts in BRL.

## Key Changes
- **Type definitions**: Added `brl: number` to the `FiatPrices` interface in `src/lib/fiat.ts`
- **Currency enum**: Added `BRL = 'BRL'` to the `Currencies` enum in `src/lib/types.ts`
- **Price feed**: Updated `getPriceFeed()` to fetch BRL exchange rates from the price API
- **Currency symbol**: Added BRL symbol mapping (`'R$'`) to `FIAT_SYMBOLS` for proper display formatting
- **Conversion functions**: Implemented `fromBRL()` and `toBRL()` conversion functions in the FiatProvider
- **Currency routing**: Added BRL handling in `fromFiatAmount()` and `toFiatAmount()` functions to route conversions correctly
- **Ticker parsing**: Extended `fiatForTicker()` to recognize BRL, DPIX, and DEPIX ticker symbols
- **Initial state**: Added BRL with zero value to `emptyFiatPrices` default state

## Implementation Details
The implementation follows the existing pattern used for other fiat currencies (EUR, USD, CHF, JPY, GBP, CNY). BRL conversion uses the same decimal arithmetic approach via the `Decimal` utility to ensure precision. The ticker parser includes support for DPIX and DEPIX variants, which may be alternative representations used by the price feed API.

https://claude.ai/code/session_016bSCyhcFK9ZKfjHhjrAPhQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Brazilian Real (BRL) across pricing, conversion, and settings.
  * BRL now appears as a selectable fiat currency and shows the correct `R$` symbol.
  * Updated currency parsing to recognize BRL-related tickers.

* **Bug Fixes**
  * Improved fiat amount conversions so BRL values are handled consistently throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->