### PR TITLE
fix(wallet): preserve home card borders on first load

### DIFF
--- a/src/components/WalletLoadIn.tsx
+++ b/src/components/WalletLoadIn.tsx
@@ -30,7 +30,7 @@ export function WalletStaggerContainer({
       initial='initial'
       animate={hold ? 'initial' : 'animate'}
       variants={walletLoadInContainer}
-      style={{ contain: 'layout style paint', width: '100%' }}
+      style={{ contain: 'layout style', width: '100%' }}
     >
       {children}
     </motion.div>
@@ -61,7 +61,7 @@ export function WalletStaggerChild({
       className={className}
       variants={walletLoadInChild}
       style={{
-        contain: 'layout style paint',
+        contain: 'layout style',
         width: '100%',
       }}
     >

--- a/src/providers/navigation.tsx
+++ b/src/providers/navigation.tsx
@@ -309,6 +309,8 @@ export const NavigationProvider = ({ children }: { children: ReactNode }) => {
   }, [])
 
   const navigate = useCallback((page: Pages) => {
+    if (page === screenRef.current && backStack.current.length === 0 && subNavHandler.getDepth() === 0) return
+
     const isRootNavigation = ROOT_PAGES.has(page)
 
     previousPage.current = screenRef.current

--- a/src/test/providers/navigation.test.tsx
+++ b/src/test/providers/navigation.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { useContext, useEffect } from 'react'
+import { describe, expect, it } from 'vitest'
+import { NavigationContext, NavigationProvider, Pages } from '../../providers/navigation'
+
+function DuplicateWalletNavigateProbe() {
+  const { isInitialLoad, navigate, screen: currentScreen } = useContext(NavigationContext)
+
+  useEffect(() => {
+    navigate(Pages.Wallet)
+    navigate(Pages.Wallet)
+  }, [navigate])
+
+  return (
+    <div data-testid='navigation-probe' data-screen={currentScreen} data-initial-load={String(isInitialLoad)} />
+  )
+}
+
+describe('NavigationProvider', () => {
+  it('preserves the wallet initial-load flag when duplicate wallet navigations happen before render', async () => {
+    render(
+      <NavigationProvider>
+        <DuplicateWalletNavigateProbe />
+      </NavigationProvider>,
+    )
+
+    const probe = screen.getByTestId('navigation-probe')
+
+    await waitFor(() => expect(probe).toHaveAttribute('data-screen', String(Pages.Wallet)))
+
+    expect(probe).toHaveAttribute('data-initial-load', 'true')
+  })
+})


### PR DESCRIPTION
## Summary
- Preserve the wallet home initial-load state when duplicate wallet navigations happen during startup, so the home sections still use the staggered motion wrappers.
- Remove only `paint` from the wallet stagger wrapper containment so the existing outer card shadows/borders are not clipped on the first render.
- Add a regression test covering duplicate wallet navigations before React renders the wallet page.

## Why
On first load, startup can dispatch `navigate(Pages.Wallet)` twice in the same tick. The second same-page navigation overwrote `previousPage` to `Wallet`, which made `isInitialLoad` false before the wallet screen mounted. That skipped the stagger wrappers entirely. Separately, when the stagger wrappers did render, `contain: paint` clipped card shadow overflow at the wrapper edge, hiding the left/right border-like shadows on first load.

## Testing
- `bun run test src/test/providers/navigation.test.tsx`
- `bun run lint`
- `bun run git-info && bun run build:worker`
- `bun ./node_modules/vite/bin/vite.js build`
- Fresh browser boot verification: home sections start staggered again at roughly 90ms intervals, and card side borders/shadows are visible on first render.

## Affected files
- `src/providers/navigation.tsx`
- `src/components/WalletLoadIn.tsx`
- `src/test/providers/navigation.test.tsx`
