### PR TITLE
Show eight decimals for non-zero BTC amounts

### DIFF
--- a/src/components/InputAmount.tsx
+++ b/src/components/InputAmount.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useRef, useState } from 'react'
 import { FiatContext } from '../providers/fiat'
 import InputContainer from './InputContainer'
 import { ConfigContext } from '../providers/config'
-import { fromSatoshis, prettyNumber, toSatoshis } from '../lib/format'
+import { formatBitcoinAmountParts, prettyNumber, toSatoshis } from '../lib/format'
 import { FIAT_SYMBOLS } from '../lib/fiat'
 import { LimitsContext } from '../providers/limits'
 import { AssetOption, Unit } from '../lib/types'
@@ -79,10 +79,9 @@ export default function InputAmount({
   // update other value when satsValue change
   useEffect(() => {
     setError(satsValue ? (satsValue < 0 ? 'Invalid amount' : '') : '')
-    const useBTC = config.unit === Unit.BTC
-    const btcValue = useBTC ? fromSatoshis(satsValue) : satsValue
-    const decimals = useBTC ? 8 : 0
-    setOtherValue(useFiat ? prettyNumber(btcValue, decimals) : prettyNumber(toFiat(satsValue), fiatDecimals()))
+    const bitcoinAmount =
+      config.unit === Unit.BTC ? formatBitcoinAmountParts(satsValue, config.unit).amount : prettyNumber(satsValue, 0)
+    setOtherValue(useFiat ? bitcoinAmount : prettyNumber(toFiat(satsValue), fiatDecimals()))
   }, [satsValue, toFiat, fiatDecimals, useFiat])
 
   const handleAmountChange = (ev: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -4,6 +4,7 @@ import { Currencies, Tx, Unit } from './types'
 import { Decimal } from 'decimal.js'
 
 export const BITCOIN_SYMBOL = '₿'
+export const BITCOIN_DECIMALS = 8
 
 export const fromSatoshis = (num: number): number => {
   return Decimal.div(num, 100_000_000).toNumber()
@@ -11,6 +12,11 @@ export const fromSatoshis = (num: number): number => {
 
 export const toSatoshis = (num: number): number => {
   return Decimal.mul(num, 100_000_000).floor().toNumber()
+}
+
+const prettyBitcoinNumber = (amount: number): string => {
+  if (amount === 0) return '0'
+  return prettyNumber(amount, BITCOIN_DECIMALS, true, BITCOIN_DECIMALS)
 }
 
 export const prettyAgo = (timestamp: number | string, long = false): string => {
@@ -30,10 +36,15 @@ export const prettyAgo = (timestamp: number | string, long = false): string => {
 }
 
 export const prettyAmount = (sats: number, suffix?: string, decimals = 2): string => {
-  if (suffix) return `${prettyNumber(sats, decimals)} ${suffix}`
-  if (sats >= 100_000_000_000_000) return `${prettyNumber(fromSatoshis(sats), 0)}K BTC`
-  if (sats >= 100_000_000_000) return `${prettyNumber(fromSatoshis(sats), 0)} BTC`
-  if (sats >= 100_000_000) return `${prettyNumber(fromSatoshis(sats), 3)} BTC`
+  if (suffix) {
+    if (suffix.trim().toUpperCase() === Unit.BTC) {
+      return `${prettyBitcoinNumber(sats)} ${Unit.BTC}`
+    }
+    return `${prettyNumber(sats, decimals)} ${suffix}`
+  }
+  if (sats >= 100_000_000) {
+    return `${prettyBitcoinNumber(fromSatoshis(sats))} ${Unit.BTC}`
+  }
   if (sats >= 1_000_000) return `${prettyNumber(sats / 1_000_000, 3)}M sats`
   return `${prettyNumber(sats, 0)} ${sats === 1 ? 'sat' : 'sats'}`
 }
@@ -50,11 +61,7 @@ export const normalizeBitcoinUnit = (unit?: Unit | string): Unit => {
   return Unit.BTC
 }
 
-const formatBitcoinUnitAmountParts = (
-  amount: number,
-  unit: Unit,
-  options: FiatAmountFormatOptions = {},
-): { amount: string; unit: string } => {
+const formatBitcoinUnitAmountParts = (amount: number, unit: Unit): { amount: string; unit: string } => {
   if (unit === Unit.SATS) {
     const sats = Math.round(amount)
     return { amount: prettyNumber(sats, 0), unit: sats === 1 ? 'sat' : 'sats' }
@@ -64,10 +71,8 @@ const formatBitcoinUnitAmountParts = (
     return { amount: `${BITCOIN_SYMBOL}${prettyNumber(Math.round(amount), 0)}`, unit: '' }
   }
 
-  const maximumFractionDigits = options.maximumFractionDigits ?? 8
-  const minimumFractionDigits = options.minimumFractionDigits ?? 0
   return {
-    amount: prettyNumber(amount, maximumFractionDigits, true, minimumFractionDigits),
+    amount: prettyBitcoinNumber(amount),
     unit: 'BTC',
   }
 }
@@ -77,8 +82,10 @@ export const formatBitcoinAmountParts = (
   unit: Unit,
   options: FiatAmountFormatOptions = {},
 ): { amount: string; unit: string } => {
-  if (unit === Unit.BTC) return formatBitcoinUnitAmountParts(fromSatoshis(sats), unit, options)
-  return formatBitcoinUnitAmountParts(sats, unit, options)
+  // Preserve the existing API while keeping BTC display precision fixed.
+  void options
+  if (unit === Unit.BTC) return formatBitcoinUnitAmountParts(fromSatoshis(sats), unit)
+  return formatBitcoinUnitAmountParts(sats, unit)
 }
 
 export const prettyBitcoinAmount = (sats: number, unit: Unit, options?: FiatAmountFormatOptions): string => {
@@ -92,7 +99,7 @@ export const formatFiatAmountParts = (
   options: FiatAmountFormatOptions = {},
 ): { amount: string; unit: string } => {
   if (currency === Currencies.BTC)
-    return formatBitcoinUnitAmountParts(amount, normalizeBitcoinUnit(options.bitcoinUnit), options)
+    return formatBitcoinUnitAmountParts(amount, normalizeBitcoinUnit(options.bitcoinUnit))
 
   const symbol = FIAT_SYMBOLS[currency]
   const maximumFractionDigits =

--- a/src/test/lib/format.test.ts
+++ b/src/test/lib/format.test.ts
@@ -46,8 +46,10 @@ describe('format utilities', () => {
 
     it('should format amounts in BTC for large values', () => {
       expect(prettyAmount(50000000)).toBe('50M sats')
-      expect(prettyAmount(100000000)).toBe('1 BTC')
-      expect(prettyAmount(150000000)).toBe('1.5 BTC')
+      expect(prettyAmount(100000000)).toBe('1.00000000 BTC')
+      expect(prettyAmount(150000000)).toBe('1.50000000 BTC')
+      expect(prettyAmount(0, 'BTC')).toBe('0 BTC')
+      expect(prettyAmount(0.001, 'BTC')).toBe('0.00100000 BTC')
     })
 
     it('should handle fiat currency formatting', () => {
@@ -88,7 +90,15 @@ describe('format utilities', () => {
     })
 
     it('should format BTC currency using the selected bitcoin unit', () => {
-      expect(prettyFiatAmount(0.000021, Currencies.BTC, { bitcoinUnit: Unit.BTC })).toBe('0.000021 BTC')
+      expect(prettyFiatAmount(0, Currencies.BTC, { bitcoinUnit: Unit.BTC })).toBe('0 BTC')
+      expect(prettyFiatAmount(0.000021, Currencies.BTC, { bitcoinUnit: Unit.BTC })).toBe('0.00002100 BTC')
+      expect(
+        prettyFiatAmount(1, Currencies.BTC, {
+          bitcoinUnit: Unit.BTC,
+          maximumFractionDigits: 2,
+          minimumFractionDigits: 2,
+        }),
+      ).toBe('1.00000000 BTC')
       expect(prettyFiatAmount(2100, Currencies.BTC, { bitcoinUnit: Unit.SATS })).toBe('2,100 sats')
       expect(prettyFiatAmount(2100, Currencies.BTC, { bitcoinUnit: Unit.BIP177 })).toBe('₿2,100')
     })
@@ -96,7 +106,8 @@ describe('format utilities', () => {
 
   describe('prettyBitcoinAmount', () => {
     it('should format satoshi amounts in the selected bitcoin unit', () => {
-      expect(prettyBitcoinAmount(2100, Unit.BTC)).toBe('0.000021 BTC')
+      expect(prettyBitcoinAmount(0, Unit.BTC)).toBe('0 BTC')
+      expect(prettyBitcoinAmount(2100, Unit.BTC)).toBe('0.00002100 BTC')
       expect(prettyBitcoinAmount(2100, Unit.SATS)).toBe('2,100 sats')
       expect(prettyBitcoinAmount(2100, Unit.BIP177)).toBe('₿2,100')
     })

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -18,6 +18,7 @@ describe('Wallet screen', () => {
     expect(screen.getByTestId('swap-coming-soon-sheet')).toBeInTheDocument()
     expect(screen.getByText('Assets')).toBeInTheDocument()
     expect(screen.getByText('Bitcoin')).toBeInTheDocument()
+    expect(screen.getByText('0 BTC')).toBeInTheDocument()
     expect(screen.getByText('Recent activity')).toBeInTheDocument()
   })
 

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -218,7 +218,7 @@ describe('Send screen', () => {
     const amountInput = document.querySelector('input[name="send-amount"]') as HTMLInputElement
     fireEvent.change(amountInput, { target: { value: '10' } })
 
-    expect(await screen.findByText('0.0001 BTC')).toBeInTheDocument()
+    expect(await screen.findByText('0.00010000 BTC')).toBeInTheDocument()
     expect(screen.queryByText('10,000 sats')).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

- Show every non-zero BTC display amount with exactly eight decimal places, including trailing zeroes.
- Keep the zero exception as `0 BTC`.
- Reuse the same presentation formatter for converted amount readouts so wallet, send, receive, balance, and transaction UI stay consistent.
- Preserve the existing formatter function signatures for caller compatibility.

## Scope and reviewer note

This changes presentation formatting only. It does not change wallet values, satoshi/BTC conversion rules, transaction construction, APIs, persistence, or backend behavior.

@bordalix: the shared UI formatter is intentionally used so the rule applies consistently anywhere BTC is displayed. Because that formatter is reused across several screens, could you please confirm that this is the right shared presentation-layer scope and that you do not see an unintended downstream display impact? Editable amount fields still preserve the user's raw text while they are typing; formatted BTC readouts use the new rule.

## Visual verification

- Wallet asset row: zero renders as `0 BTC`.
- Receive amount dialog: a non-zero conversion renders as `0.00160986 BTC` (exactly eight decimal places).
- Fresh screenshots were captured from the final local build and are included in the implementation handoff.

## Testing

- `bun run test:unit` — 47 files passed, 316 tests passed, 3 existing skips.
- `bun run lint` — passed.
- `bunx tsc --noEmit` — passed.
- `bun run format:check` — passed.
- `bun run build` — passed.
- Focused formatter/wallet/send tests — 47 passed.
- Browser verification at a 375×667 viewport — zero and non-zero states verified; no console warnings or errors.

## Affected files

- `src/lib/format.ts` — central BTC display rule and zero exception.
- `src/components/InputAmount.tsx` — reuse the BTC presentation formatter for converted readouts.
- `src/test/lib/format.test.ts` — formatter coverage for zero, trailing zeroes, and fixed BTC precision.
- `src/test/screens/wallet/index.test.tsx` — wallet zero-state coverage.
- `src/test/screens/wallet/send.test.tsx` — send conversion coverage for eight decimals.

No unrelated repository files or behavior were changed.
