### PR TITLE
feat(wallet): unify fiat-backed assets as accounts

### DIFF
--- a/src/components/TokenLogo.tsx
+++ b/src/components/TokenLogo.tsx
@@ -1,3 +1,5 @@
+import { walletAccountTicker } from '../lib/accountAssets'
+
 export type TokenLogoTicker = 'BTC' | 'USD' | 'USDT' | 'USDC' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
 
 export function tokenLogoTickerForTicker(ticker: string | undefined): TokenLogoTicker | undefined {
@@ -19,13 +21,7 @@ export function tokenLogoTickerForTicker(ticker: string | undefined): TokenLogoT
 }
 
 export function accountTickerForAssetTicker(ticker: string | undefined): TokenLogoTicker | undefined {
-  const normalized = ticker?.trim().toUpperCase()
-  if (normalized === 'BTC') return 'BTC'
-  if (normalized === 'USD' || normalized === 'AUSD') return 'USD'
-  if (normalized === 'USDT') return 'USDT'
-  if (normalized === 'USDC') return 'USDC'
-  if (normalized === 'CHF') return 'CHF'
-  if (normalized === 'BRL' || normalized === 'DPIX' || normalized === 'DEPIX') return 'BRL'
+  return walletAccountTicker(ticker)
 }
 
 export default function TokenLogo({ ticker }: { ticker: TokenLogoTicker }) {

--- a/src/components/TokenLogo.tsx
+++ b/src/components/TokenLogo.tsx
@@ -1,4 +1,4 @@
-import { walletAccountTicker } from '../lib/accountAssets'
+import { walletAccountTicker, type WalletAccountTicker } from '../lib/accountAssets'
 
 export type TokenLogoTicker = 'BTC' | 'USD' | 'USDT' | 'USDC' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
 
@@ -20,7 +20,7 @@ export function tokenLogoTickerForTicker(ticker: string | undefined): TokenLogoT
   }
 }
 
-export function accountTickerForAssetTicker(ticker: string | undefined): TokenLogoTicker | undefined {
+export function accountTickerForAssetTicker(ticker: string | undefined): WalletAccountTicker | undefined {
   return walletAccountTicker(ticker)
 }
 

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -27,6 +27,7 @@ import TokenLogo, { accountTickerForAssetTicker, tokenLogoTickerForTicker, type 
 import { PrivacyAmount } from './PrivacyAmount'
 import SwapRouteIcon from './SwapRouteIcon'
 import { swapRouteLabel, swapStatusForTx, swapStatusLabel, swapUnitOfAccountAmount } from '../lib/swapDisplay'
+import { fiatAccountAssetSatoshis } from '../lib/accountAssets'
 
 const border = '1px solid color-mix(in srgb, var(--fg) 6%, transparent)'
 
@@ -52,10 +53,21 @@ const TransactionLine = ({
   const swapStatus = swap ? swapStatusForTx(tx) : undefined
   const issuance = isIssuance(tx)
   const burn = isBurn(tx)
+  const accountValueSatoshis = tx.assets?.reduce<number | undefined>((total, asset) => {
+    const accountInfo = accountInfoForAssetId(asset.assetId)
+    const metadata = assetMetadataCache.get(asset.assetId)?.metadata
+    const value = fiatAccountAssetSatoshis(
+      BigInt(asset.amount),
+      accountInfo?.decimals ?? metadata?.decimals ?? 8,
+      accountInfo?.ticker ?? metadata?.ticker,
+      fromFiatAmount,
+    )
+    return value === undefined ? total : (total ?? 0) + value
+  }, undefined)
 
   const Currency = () => {
     if (issuance || burn || swap) return null
-    const value = toFiat(tx.amount)
+    const value = toFiat(accountValueSatoshis ?? tx.amount)
     const statusClassName = tx.boardingTxid && tx.preconfirmed ? ' activity-row__amount--pending' : ''
     const secondaryClassName = asAssets ? ' activity-row__amount--secondary' : ''
     return (
@@ -188,7 +200,7 @@ const TransactionLine = ({
       ) : tx.assets?.length ? (
         <>
           <AssetInfo />
-          {config.currency === Currencies.BTC ? <Bitcoin /> : <Currency />}
+          {config.currency === Currencies.BTC && accountValueSatoshis === undefined ? <Bitcoin /> : <Currency />}
         </>
       ) : (
         <>{config.currency === Currencies.BTC ? <Bitcoin /> : <Currency />}</>

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -53,17 +53,20 @@ const TransactionLine = ({
   const swapStatus = swap ? swapStatusForTx(tx) : undefined
   const issuance = isIssuance(tx)
   const burn = isBurn(tx)
-  const accountValueSatoshis = tx.assets?.reduce<number | undefined>((total, asset) => {
+  const accountAssetValues = tx.assets?.map((asset) => {
     const accountInfo = accountInfoForAssetId(asset.assetId)
     const metadata = assetMetadataCache.get(asset.assetId)?.metadata
-    const value = fiatAccountAssetSatoshis(
+    return fiatAccountAssetSatoshis(
       BigInt(asset.amount),
       accountInfo?.decimals ?? metadata?.decimals ?? 8,
       accountInfo?.ticker ?? metadata?.ticker,
       fromFiatAmount,
     )
-    return value === undefined ? total : (total ?? 0) + value
-  }, undefined)
+  })
+  const accountValueSatoshis =
+    accountAssetValues?.length && accountAssetValues.every((value) => value !== undefined)
+      ? accountAssetValues.reduce((total, value) => total + value, 0)
+      : undefined
 
   const Currency = () => {
     if (issuance || burn || swap) return null

--- a/src/hooks/usePortfolioFiat.ts
+++ b/src/hooks/usePortfolioFiat.ts
@@ -5,7 +5,7 @@ import { fiatForTicker } from '../lib/format'
 import { Currencies } from '../lib/types'
 import { FiatContext } from '../providers/fiat'
 import { WalletContext } from '../providers/wallet'
-import { normalizeAssetMinorUnits, type FiatAccountSourceAsset } from '../lib/accountAssets'
+import { aggregateFiatAccountMinorUnits, type FiatAccountSourceAsset } from '../lib/accountAssets'
 
 export interface PortfolioRow {
   /** 'btc' for the native bitcoin row, otherwise the asset's on-chain id. */
@@ -63,7 +63,6 @@ export function usePortfolioFiat(): PortfolioFiat {
     hasFiatPrice: true,
   })
 
-  const fiatAccountBalances = new Map<Currencies, bigint>()
   const fiatAccountSources = new Map<Currencies, FiatAccountSourceAsset[]>()
 
   // Non-bitcoin asset rows from real SDK data.
@@ -73,12 +72,6 @@ export function usePortfolioFiat(): PortfolioFiat {
     const sourceFiat = fiatForTicker(meta?.ticker)
 
     if (sourceFiat) {
-      const accountDecimals = fiatDecimalsFor(sourceFiat)
-      const currentBalance = fiatAccountBalances.get(sourceFiat) ?? BigInt(0)
-      fiatAccountBalances.set(
-        sourceFiat,
-        currentBalance + normalizeAssetMinorUnits(ab.amount, decimals, accountDecimals),
-      )
       fiatAccountSources.set(sourceFiat, [
         ...(fiatAccountSources.get(sourceFiat) ?? []),
         { assetId: ab.assetId, balance: BigInt(ab.amount), decimals },
@@ -104,7 +97,9 @@ export function usePortfolioFiat(): PortfolioFiat {
 
     const accountId = `account:${sourceFiat.toLowerCase()}`
     const decimals = fiatDecimalsFor(sourceFiat)
-    const minorUnits = (fiatAccountBalances.get(sourceFiat) ?? BigInt(0)) + (prototypeDeltas[accountId] ?? BigInt(0))
+    const sourceAssets = fiatAccountSources.get(sourceFiat) ?? []
+    const minorUnits =
+      aggregateFiatAccountMinorUnits(sourceAssets, decimals) + (prototypeDeltas[accountId] ?? BigInt(0))
     if (minorUnits <= BigInt(0)) continue
 
     const amount = Decimal.div(minorUnits.toString(), Decimal.pow(10, decimals)).toNumber()
@@ -121,8 +116,8 @@ export function usePortfolioFiat(): PortfolioFiat {
       satsEquivalent,
       hasFiatPrice: true,
       fiatCurrency: sourceFiat,
-      sourceAssetIds: (fiatAccountSources.get(sourceFiat) ?? []).map((source) => source.assetId),
-      sourceAssets: fiatAccountSources.get(sourceFiat) ?? [],
+      sourceAssetIds: sourceAssets.map((source) => source.assetId),
+      sourceAssets,
     })
   }
 

--- a/src/hooks/usePortfolioFiat.ts
+++ b/src/hooks/usePortfolioFiat.ts
@@ -5,6 +5,7 @@ import { fiatForTicker } from '../lib/format'
 import { Currencies } from '../lib/types'
 import { FiatContext } from '../providers/fiat'
 import { WalletContext } from '../providers/wallet'
+import { normalizeAssetMinorUnits, type FiatAccountSourceAsset } from '../lib/accountAssets'
 
 export interface PortfolioRow {
   /** 'btc' for the native bitcoin row, otherwise the asset's on-chain id. */
@@ -25,6 +26,8 @@ export interface PortfolioRow {
   fiatCurrency?: Currencies
   /** IDs of the underlying wallet assets when this is a product-level account row. */
   sourceAssetIds?: string[]
+  /** Backing asset balances used internally to fulfill account actions. */
+  sourceAssets?: FiatAccountSourceAsset[]
 }
 
 export interface PortfolioFiat {
@@ -61,7 +64,7 @@ export function usePortfolioFiat(): PortfolioFiat {
   })
 
   const fiatAccountBalances = new Map<Currencies, bigint>()
-  const fiatAccountSourceAssetIds = new Map<Currencies, string[]>()
+  const fiatAccountSources = new Map<Currencies, FiatAccountSourceAsset[]>()
 
   // Non-bitcoin asset rows from real SDK data.
   for (const ab of assetBalances) {
@@ -72,8 +75,14 @@ export function usePortfolioFiat(): PortfolioFiat {
     if (sourceFiat) {
       const accountDecimals = fiatDecimalsFor(sourceFiat)
       const currentBalance = fiatAccountBalances.get(sourceFiat) ?? BigInt(0)
-      fiatAccountBalances.set(sourceFiat, currentBalance + normalizeMinorUnits(ab.amount, decimals, accountDecimals))
-      fiatAccountSourceAssetIds.set(sourceFiat, [...(fiatAccountSourceAssetIds.get(sourceFiat) ?? []), ab.assetId])
+      fiatAccountBalances.set(
+        sourceFiat,
+        currentBalance + normalizeAssetMinorUnits(ab.amount, decimals, accountDecimals),
+      )
+      fiatAccountSources.set(sourceFiat, [
+        ...(fiatAccountSources.get(sourceFiat) ?? []),
+        { assetId: ab.assetId, balance: BigInt(ab.amount), decimals },
+      ])
       continue
     }
 
@@ -112,7 +121,8 @@ export function usePortfolioFiat(): PortfolioFiat {
       satsEquivalent,
       hasFiatPrice: true,
       fiatCurrency: sourceFiat,
-      sourceAssetIds: fiatAccountSourceAssetIds.get(sourceFiat) ?? [],
+      sourceAssetIds: (fiatAccountSources.get(sourceFiat) ?? []).map((source) => source.assetId),
+      sourceAssets: fiatAccountSources.get(sourceFiat) ?? [],
     })
   }
 
@@ -121,11 +131,4 @@ export function usePortfolioFiat(): PortfolioFiat {
     totalSats,
     rows,
   }
-}
-
-function normalizeMinorUnits(rawAmount: number | bigint, fromDecimals: number, toDecimals: number): bigint {
-  const amount = typeof rawAmount === 'bigint' ? rawAmount : BigInt(rawAmount)
-  if (fromDecimals === toDecimals) return amount
-  if (fromDecimals > toDecimals) return amount / BigInt(10) ** BigInt(fromDecimals - toDecimals)
-  return amount * BigInt(10) ** BigInt(toDecimals - fromDecimals)
 }

--- a/src/hooks/usePortfolioFiat.ts
+++ b/src/hooks/usePortfolioFiat.ts
@@ -1,5 +1,7 @@
 import Decimal from 'decimal.js'
 import { useContext } from 'react'
+import { fiatDecimalsFor } from '../lib/fiat'
+import { fiatForTicker } from '../lib/format'
 import { Currencies } from '../lib/types'
 import { FiatContext } from '../providers/fiat'
 import { WalletContext } from '../providers/wallet'
@@ -19,6 +21,8 @@ export interface PortfolioRow {
   satsEquivalent: number
   /** True if this asset has a price feed and fiatAmount is meaningful. */
   hasFiatPrice: boolean
+  /** Fiat currency represented by this product-level account. */
+  fiatCurrency?: Currencies
   /** IDs of the underlying wallet assets when this is a product-level account row. */
   sourceAssetIds?: string[]
 }
@@ -56,97 +60,59 @@ export function usePortfolioFiat(): PortfolioFiat {
     hasFiatPrice: true,
   })
 
-  let usdMinorUnits = BigInt(0)
-  const usdSourceAssetIds: string[] = []
-  let chfMinorUnits = BigInt(0)
-  const chfSourceAssetIds: string[] = []
+  const fiatAccountBalances = new Map<Currencies, bigint>()
+  const fiatAccountSourceAssetIds = new Map<Currencies, string[]>()
 
   // Non-bitcoin asset rows from real SDK data.
   for (const ab of assetBalances) {
     const meta = assetMetadataCache.get(ab.assetId)?.metadata
     const decimals = meta?.decimals ?? 8
-    const normalizedTicker = meta?.ticker?.trim().toUpperCase()
+    const sourceFiat = fiatForTicker(meta?.ticker)
 
-    if (normalizedTicker === 'USDT' || normalizedTicker === 'USDC') {
-      usdMinorUnits += normalizeMinorUnits(ab.amount, decimals, 2)
-      usdSourceAssetIds.push(ab.assetId)
+    if (sourceFiat) {
+      const accountDecimals = fiatDecimalsFor(sourceFiat)
+      const currentBalance = fiatAccountBalances.get(sourceFiat) ?? BigInt(0)
+      fiatAccountBalances.set(sourceFiat, currentBalance + normalizeMinorUnits(ab.amount, decimals, accountDecimals))
+      fiatAccountSourceAssetIds.set(sourceFiat, [...(fiatAccountSourceAssetIds.get(sourceFiat) ?? []), ab.assetId])
       continue
     }
 
-    if (normalizedTicker === 'CHF') {
-      chfMinorUnits += normalizeMinorUnits(ab.amount, decimals, 2)
-      chfSourceAssetIds.push(ab.assetId)
-      continue
-    }
-
-    const pricedFiat = priceAssetFiat(ab.amount, decimals, meta?.ticker, convertToSelectedFiat)
-    const sourceFiat = fiatForAssetTicker(meta?.ticker)
-    const fiatUnits = Decimal.div(ab.amount.toString(), Decimal.pow(10, decimals)).toNumber()
-    const satsEquivalent = sourceFiat ? fromFiatAmount(fiatUnits, sourceFiat) : 0
-    totalSats += satsEquivalent
     rows.push({
       assetId: ab.assetId,
-      name: displayNameForAsset(meta?.ticker, meta?.name) ?? `Asset ${ab.assetId.slice(0, 8)}...`,
+      name: meta?.name ?? `Asset ${ab.assetId.slice(0, 8)}...`,
       ticker: meta?.ticker?.trim().toUpperCase() ?? 'TKN',
       icon: meta?.icon,
       decimals,
       balance: ab.amount,
-      fiatAmount: pricedFiat,
-      satsEquivalent,
-      hasFiatPrice: pricedFiat > 0,
+      fiatAmount: 0,
+      satsEquivalent: 0,
+      hasFiatPrice: false,
     })
   }
 
-  usdMinorUnits += prototypeDeltas['account:usd'] ?? BigInt(0)
-  const usdFiatAmount = Math.max(0, Number(usdMinorUnits) / 100)
-  const usdAccountFiatAmount = convertToSelectedFiat(usdFiatAmount, Currencies.USD)
-  if (usdFiatAmount > 0) {
-    const satsEquivalent = fromFiatAmount(usdFiatAmount, Currencies.USD)
+  for (const sourceFiat of Object.values(Currencies)) {
+    if (sourceFiat === Currencies.BTC) continue
+
+    const accountId = `account:${sourceFiat.toLowerCase()}`
+    const decimals = fiatDecimalsFor(sourceFiat)
+    const minorUnits = (fiatAccountBalances.get(sourceFiat) ?? BigInt(0)) + (prototypeDeltas[accountId] ?? BigInt(0))
+    if (minorUnits <= BigInt(0)) continue
+
+    const amount = Decimal.div(minorUnits.toString(), Decimal.pow(10, decimals)).toNumber()
+    const fiatAmount = convertToSelectedFiat(amount, sourceFiat)
+    const satsEquivalent = fromFiatAmount(amount, sourceFiat)
     totalSats += satsEquivalent
     rows.push({
-      assetId: 'account:usd',
-      name: 'USD',
-      ticker: 'USD',
-      decimals: 2,
-      balance: usdMinorUnits,
-      fiatAmount: usdAccountFiatAmount,
-      satsEquivalent,
-      hasFiatPrice: true,
-      sourceAssetIds: usdSourceAssetIds,
-    })
-  }
-
-  const chfAccountMinorUnits =
-    (chfMinorUnits > BigInt(0) ? chfMinorUnits : BigInt(0)) + (prototypeDeltas['account:chf'] ?? BigInt(0))
-
-  const fiatAccounts = [
-    {
-      assetId: 'account:chf',
-      name: 'CHF',
-      ticker: 'CHF',
-      minorUnits: chfAccountMinorUnits,
-      sourceFiat: Currencies.CHF,
-      sourceAssetIds: chfSourceAssetIds,
-    },
-  ]
-
-  for (const account of fiatAccounts) {
-    if (account.minorUnits <= BigInt(0)) continue
-
-    const amount = Number(account.minorUnits) / 100
-    const fiatAmount = convertToSelectedFiat(amount, account.sourceFiat)
-    const satsEquivalent = fromFiatAmount(amount, account.sourceFiat)
-    totalSats += satsEquivalent
-    rows.push({
-      assetId: account.assetId,
-      name: account.name,
-      ticker: account.ticker,
-      decimals: 2,
-      balance: account.minorUnits,
+      assetId: accountId,
+      name: sourceFiat,
+      ticker: sourceFiat,
+      decimals,
+      balance: minorUnits,
       fiatAmount,
       satsEquivalent,
       hasFiatPrice: true,
-      sourceAssetIds: account.sourceAssetIds,
+      fiatCurrency: sourceFiat,
+      sourceAssetIds: fiatAccountSourceAssetIds.get(sourceFiat) ?? [],
     })
   }
 
@@ -162,42 +128,4 @@ function normalizeMinorUnits(rawAmount: number | bigint, fromDecimals: number, t
   if (fromDecimals === toDecimals) return amount
   if (fromDecimals > toDecimals) return amount / BigInt(10) ** BigInt(fromDecimals - toDecimals)
   return amount * BigInt(10) ** BigInt(toDecimals - fromDecimals)
-}
-
-function priceAssetFiat(
-  rawAmount: number | bigint,
-  decimals: number,
-  ticker: string | undefined,
-  convertToSelectedFiat: (amount: number, from: Currencies) => number,
-): number {
-  const sourceFiat = fiatForAssetTicker(ticker)
-  if (!sourceFiat) return 0
-
-  const fiatAmount = Decimal.div(rawAmount.toString(), Decimal.pow(10, decimals)).toNumber()
-  return convertToSelectedFiat(fiatAmount, sourceFiat)
-}
-
-function displayNameForAsset(ticker: string | undefined, name: string | undefined): string | undefined {
-  const normalizedTicker = ticker?.trim().toUpperCase()
-  if (
-    normalizedTicker === 'USDT' ||
-    normalizedTicker === 'USDC' ||
-    normalizedTicker === 'USD' ||
-    normalizedTicker === 'AUSD'
-  )
-    return 'USD'
-  if (normalizedTicker === 'CHF') return 'CHF'
-  return name
-}
-
-function fiatForAssetTicker(ticker: string | undefined): Currencies | undefined {
-  const normalized = ticker?.trim().toUpperCase()
-
-  if (normalized === 'USDT' || normalized === 'USDC' || normalized === 'USD' || normalized === 'AUSD')
-    return Currencies.USD
-  if (normalized === 'CHF') return Currencies.CHF
-  if (normalized === 'EUR') return Currencies.EUR
-  if (normalized === 'GBP') return Currencies.GBP
-  if (normalized === 'JPY') return Currencies.JPY
-  if (normalized === 'CNY') return Currencies.CNY
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3577,6 +3577,13 @@ html.palette-dark .settings-row--danger .settings-row__chevron {
   font-variant-numeric: tabular-nums;
 }
 
+.asset-detail-price--unavailable {
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-family: inherit;
+  font-size: var(--asset-detail-section-size);
+  line-height: 1;
+}
+
 .asset-detail-delta {
   display: inline-flex;
   min-height: 2rem;
@@ -3691,19 +3698,14 @@ html.palette-dark .settings-row--danger .settings-row__chevron {
 }
 
 .asset-detail-chart-fallback {
+  display: flex;
   width: 100%;
   height: 100%;
-  background:
-    linear-gradient(
-      135deg,
-      transparent 0%,
-      transparent 42%,
-      color-mix(in srgb, var(--purple-700) 24%, transparent) 43%,
-      color-mix(in srgb, var(--purple-700) 24%, transparent) 44%,
-      transparent 45%,
-      transparent 100%
-    ),
-    var(--neutral-50);
+  align-items: center;
+  justify-content: center;
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: var(--asset-detail-control-size);
+  font-weight: var(--asset-detail-support-weight);
 }
 
 .asset-detail-range-tabs {

--- a/src/lib/accountAssets.ts
+++ b/src/lib/accountAssets.ts
@@ -1,7 +1,23 @@
 import Decimal from 'decimal.js'
+import type { Asset } from '@arkade-os/sdk'
 import { Currencies } from './types'
 
 export type WalletAccountTicker = 'BTC' | 'USD' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
+
+export interface FiatAccountSourceAsset {
+  assetId: string
+  balance: bigint
+  decimals: number
+}
+
+export interface FiatAccountSend {
+  assetId: string
+  ticker: WalletAccountTicker
+  balance: bigint
+  decimals: number
+  amount: bigint
+  sources: FiatAccountSourceAsset[]
+}
 
 const ACCOUNT_CHART_COLOR_TOKENS: Record<WalletAccountTicker, string> = {
   BTC: '--account-chart-btc',
@@ -56,4 +72,47 @@ export function fiatAccountAssetSatoshis(
 
   const accountAmount = Decimal.div(amount.toString(), Decimal.pow(10, decimals)).toNumber()
   return fromFiatAmount(accountAmount, accountTicker as Currencies)
+}
+
+export function normalizeAssetMinorUnits(rawAmount: number | bigint, fromDecimals: number, toDecimals: number): bigint {
+  const amount = typeof rawAmount === 'bigint' ? rawAmount : BigInt(rawAmount)
+  if (fromDecimals === toDecimals) return amount
+  if (fromDecimals > toDecimals) return amount / BigInt(10) ** BigInt(fromDecimals - toDecimals)
+  return amount * BigInt(10) ** BigInt(toDecimals - fromDecimals)
+}
+
+export function allocateFiatAccountAssets(
+  amount: bigint,
+  accountDecimals: number,
+  sources: FiatAccountSourceAsset[],
+): Asset[] {
+  let remaining = amount > BigInt(0) ? amount : BigInt(0)
+  const assets: Asset[] = []
+
+  for (const source of sources) {
+    if (remaining === BigInt(0)) break
+    const available = normalizeAssetMinorUnits(source.balance, source.decimals, accountDecimals)
+    const allocated = remaining < available ? remaining : available
+    if (allocated <= BigInt(0)) continue
+
+    assets.push({
+      assetId: source.assetId,
+      amount: normalizeAssetMinorUnits(allocated, accountDecimals, source.decimals),
+    })
+    remaining -= allocated
+  }
+
+  return assets
+}
+
+export function primaryFiatAccountSource(
+  sources: FiatAccountSourceAsset[] | undefined,
+  accountDecimals: number,
+): FiatAccountSourceAsset | undefined {
+  return sources?.reduce<FiatAccountSourceAsset | undefined>((primary, source) => {
+    if (!primary) return source
+    const sourceBalance = normalizeAssetMinorUnits(source.balance, source.decimals, accountDecimals)
+    const primaryBalance = normalizeAssetMinorUnits(primary.balance, primary.decimals, accountDecimals)
+    return sourceBalance > primaryBalance ? source : primary
+  }, undefined)
 }

--- a/src/lib/accountAssets.ts
+++ b/src/lib/accountAssets.ts
@@ -3,6 +3,17 @@ import { Currencies } from './types'
 
 export type WalletAccountTicker = 'BTC' | 'USD' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
 
+const ACCOUNT_CHART_COLOR_TOKENS: Record<WalletAccountTicker, string> = {
+  BTC: '--account-chart-btc',
+  USD: '--account-chart-usd',
+  CHF: '--account-chart-chf',
+  BRL: '--account-chart-brl',
+  CNY: '--account-chart-cny',
+  EUR: '--account-chart-eur',
+  GBP: '--account-chart-gbp',
+  JPY: '--account-chart-jpy',
+}
+
 export function walletAccountTicker(ticker: string | undefined): WalletAccountTicker | undefined {
   const normalized = ticker?.trim().toUpperCase()
   if (normalized === 'BTC') return 'BTC'
@@ -13,6 +24,11 @@ export function walletAccountTicker(ticker: string | undefined): WalletAccountTi
   if (normalized === 'EUR') return 'EUR'
   if (normalized === 'GBP') return 'GBP'
   if (normalized === 'JPY') return 'JPY'
+}
+
+export function accountChartColorToken(ticker: string | undefined): string {
+  const accountTicker = walletAccountTicker(ticker)
+  return accountTicker ? ACCOUNT_CHART_COLOR_TOKENS[accountTicker] : '--account-chart-default'
 }
 
 export function walletAssetPresentation(

--- a/src/lib/accountAssets.ts
+++ b/src/lib/accountAssets.ts
@@ -1,0 +1,27 @@
+export type WalletAccountTicker = 'BTC' | 'USD' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
+
+export function walletAccountTicker(ticker: string | undefined): WalletAccountTicker | undefined {
+  const normalized = ticker?.trim().toUpperCase()
+  if (normalized === 'BTC') return 'BTC'
+  if (normalized === 'USD' || normalized === 'AUSD' || normalized === 'USDT' || normalized === 'USDC') return 'USD'
+  if (normalized === 'CHF') return 'CHF'
+  if (normalized === 'BRL' || normalized === 'DPIX' || normalized === 'DEPIX') return 'BRL'
+  if (normalized === 'CNY') return 'CNY'
+  if (normalized === 'EUR') return 'EUR'
+  if (normalized === 'GBP') return 'GBP'
+  if (normalized === 'JPY') return 'JPY'
+}
+
+export function walletAssetPresentation(
+  metadata: { name?: string; ticker?: string; icon?: string } | undefined,
+  fallbackName = 'Asset',
+): { name: string; ticker: string; icon?: string } {
+  const accountTicker = walletAccountTicker(metadata?.ticker)
+  if (accountTicker) return { name: accountTicker, ticker: accountTicker }
+
+  return {
+    name: metadata?.name ?? fallbackName,
+    ticker: metadata?.ticker?.trim().toUpperCase() ?? '',
+    icon: metadata?.icon,
+  }
+}

--- a/src/lib/accountAssets.ts
+++ b/src/lib/accountAssets.ts
@@ -1,3 +1,6 @@
+import Decimal from 'decimal.js'
+import { Currencies } from './types'
+
 export type WalletAccountTicker = 'BTC' | 'USD' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
 
 export function walletAccountTicker(ticker: string | undefined): WalletAccountTicker | undefined {
@@ -24,4 +27,17 @@ export function walletAssetPresentation(
     ticker: metadata?.ticker?.trim().toUpperCase() ?? '',
     icon: metadata?.icon,
   }
+}
+
+export function fiatAccountAssetSatoshis(
+  amount: bigint,
+  decimals: number,
+  ticker: string | undefined,
+  fromFiatAmount: (amount: number, currency: Currencies) => number,
+): number | undefined {
+  const accountTicker = walletAccountTicker(ticker)
+  if (!accountTicker || accountTicker === 'BTC') return undefined
+
+  const accountAmount = Decimal.div(amount.toString(), Decimal.pow(10, decimals)).toNumber()
+  return fromFiatAmount(accountAmount, accountTicker as Currencies)
 }

--- a/src/lib/accountAssets.ts
+++ b/src/lib/accountAssets.ts
@@ -61,6 +61,12 @@ export function walletAssetPresentation(
   }
 }
 
+export function walletAssetLabel(presentation: { name: string; ticker: string }): string {
+  return !presentation.ticker || presentation.name === presentation.ticker
+    ? presentation.name
+    : `${presentation.name} (${presentation.ticker})`
+}
+
 export function fiatAccountAssetSatoshis(
   amount: bigint,
   decimals: number,
@@ -79,6 +85,18 @@ export function normalizeAssetMinorUnits(rawAmount: number | bigint, fromDecimal
   if (fromDecimals === toDecimals) return amount
   if (fromDecimals > toDecimals) return amount / BigInt(10) ** BigInt(fromDecimals - toDecimals)
   return amount * BigInt(10) ** BigInt(toDecimals - fromDecimals)
+}
+
+export function aggregateFiatAccountMinorUnits(sources: FiatAccountSourceAsset[], accountDecimals: number): bigint {
+  const sharedDecimals = sources.reduce(
+    (highestDecimals, source) => Math.max(highestDecimals, source.decimals),
+    accountDecimals,
+  )
+  const sharedPrecisionTotal = sources.reduce(
+    (total, source) => total + normalizeAssetMinorUnits(source.balance, source.decimals, sharedDecimals),
+    BigInt(0),
+  )
+  return normalizeAssetMinorUnits(sharedPrecisionTotal, sharedDecimals, accountDecimals)
 }
 
 export function allocateFiatAccountAssets(

--- a/src/lib/fiat.ts
+++ b/src/lib/fiat.ts
@@ -12,14 +12,13 @@ export interface FiatPrices {
 }
 
 // Currencies listed here are prefixed with their symbol when displaying amounts.
-// Those omitted (CHF, CNY) keep the trailing ISO code — CNY skips ¥ to avoid
-// clashing with JPY.
+// Those omitted (BRL, CHF, CNY) keep the trailing ISO code. BRL is explicit by
+// product convention, while CNY skips ¥ to avoid clashing with JPY.
 export const FIAT_SYMBOLS: Partial<Record<Currencies, string>> = {
   [Currencies.USD]: '$',
   [Currencies.EUR]: '€',
   [Currencies.GBP]: '£',
   [Currencies.JPY]: '¥',
-  [Currencies.BRL]: 'R$',
 }
 
 export const fiatDecimalsFor = (currency: Currencies, bitcoinUnit = Unit.BTC): number => {

--- a/src/lib/marketData.ts
+++ b/src/lib/marketData.ts
@@ -36,6 +36,44 @@ export const fetchHistoricalMarketData = async (
   return isValidHistoricalMarketDataResponse(data) ? data.data : []
 }
 
+export const buildCrossRatePoints = (sourcePoints: LivelinePoint[], marketPoints: LivelinePoint[]): LivelinePoint[] => {
+  const source = validMarketPoints(sourcePoints)
+  const market = validMarketPoints(marketPoints)
+  if (source.length < 2 || market.length < 2) return []
+
+  const tolerance = Math.ceil(Math.max(estimatePointInterval(source), estimatePointInterval(market)) * 1.5)
+  let marketIndex = 0
+
+  return source.flatMap((sourcePoint) => {
+    while (
+      marketIndex + 1 < market.length &&
+      Math.abs(market[marketIndex + 1].time - sourcePoint.time) <= Math.abs(market[marketIndex].time - sourcePoint.time)
+    ) {
+      marketIndex += 1
+    }
+
+    const marketPoint = market[marketIndex]
+    if (!marketPoint || Math.abs(marketPoint.time - sourcePoint.time) > tolerance) return []
+    return [{ time: sourcePoint.time, value: marketPoint.value / sourcePoint.value }]
+  })
+}
+
+const validMarketPoints = (points: LivelinePoint[]): LivelinePoint[] => {
+  return points
+    .filter((point) => Number.isFinite(point.time) && Number.isFinite(point.value) && point.time > 0 && point.value > 0)
+    .sort((a, b) => a.time - b.time)
+}
+
+const estimatePointInterval = (points: LivelinePoint[]): number => {
+  const intervals = points
+    .slice(1)
+    .map((point, index) => point.time - points[index].time)
+    .filter((interval) => interval > 0)
+    .sort((a, b) => a - b)
+
+  return intervals[Math.floor(intervals.length / 2)] ?? 3_600
+}
+
 const isValidHistoricalMarketDataResponse = (data: unknown): data is HistoricalMarketDataResponse => {
   return (
     data !== null &&

--- a/src/lib/swapDisplay.ts
+++ b/src/lib/swapDisplay.ts
@@ -1,4 +1,5 @@
 import { prettyCurrencyAssetAmount, prettyFiatAmount, prettyFiatHide, prettyHide } from './format'
+import { walletAccountTicker } from './accountAssets'
 import { Currencies, Tx, Unit } from './types'
 
 export type SwapStatus = 'pending' | 'failed' | 'completed'
@@ -29,7 +30,10 @@ export function swapStatusLabel(tx: Tx): string {
 }
 
 export function swapRouteLabel(tx: Tx): string {
-  return [tx.prototypeSwap?.fromTicker, tx.prototypeSwap?.toTicker].filter(Boolean).join(' to ')
+  return [tx.prototypeSwap?.fromTicker, tx.prototypeSwap?.toTicker]
+    .map((ticker) => walletAccountTicker(ticker) ?? ticker)
+    .filter(Boolean)
+    .join(' to ')
 }
 
 export function formatSwapAssetAmount(tx: Tx, side: 'from' | 'to'): SwapDisplayAmount | undefined {
@@ -41,9 +45,10 @@ export function formatSwapAssetAmount(tx: Tx, side: 'from' | 'to'): SwapDisplayA
   const ticker = side === 'from' ? swap.fromTicker : swap.toTicker
 
   if (amount === undefined || decimals === undefined || !ticker) return undefined
+  const accountTicker = walletAccountTicker(ticker) ?? ticker
   return {
-    masked: prettyHide('hidden', ticker),
-    value: `${prettyCurrencyAssetAmount(amount, decimals, ticker)} ${ticker}`,
+    masked: prettyHide('hidden', accountTicker),
+    value: `${prettyCurrencyAssetAmount(amount, decimals, accountTicker)} ${accountTicker}`,
   }
 }
 

--- a/src/providers/flow.tsx
+++ b/src/providers/flow.tsx
@@ -2,6 +2,7 @@ import { BoltzSwap } from '@arkade-os/boltz-swap'
 import { ReactNode, createContext, useState } from 'react'
 import type { Asset, AssetDetails, ServiceWorkerWalletMode } from '@arkade-os/sdk'
 import { Tx } from '../lib/types'
+import type { FiatAccountSend } from '../lib/accountAssets'
 
 export interface InitInfo {
   password?: string
@@ -36,6 +37,7 @@ export interface RecvInfo {
 }
 
 export type SendInfo = {
+  account?: FiatAccountSend
   address?: string
   assets?: Asset[]
   arkAddress?: string

--- a/src/providers/navigation.tsx
+++ b/src/providers/navigation.tsx
@@ -18,6 +18,7 @@ import Activity from '../screens/Wallet/Activity'
 import Vtxos from '../screens/Settings/Vtxos'
 import Wallet from '../screens/Wallet/Index'
 import BitcoinDetail from '../screens/Wallet/BitcoinDetail'
+import AccountDetail from '../screens/Wallet/AccountDetail'
 import WalletSwap from '../screens/Wallet/Swap/Index'
 import Settings from '../screens/Settings/Index'
 
@@ -43,6 +44,7 @@ export type NavigationDirection = 'forward' | 'back' | 'none'
 
 export enum Pages {
   Activity,
+  AccountDetail,
   BitcoinDetail,
   AppBoltz,
   AppBoltzSettings,
@@ -91,6 +93,7 @@ export enum Tabs {
 
 const pageTab = {
   [Pages.Activity]: Tabs.Wallet,
+  [Pages.AccountDetail]: Tabs.Wallet,
   [Pages.BitcoinDetail]: Tabs.Wallet,
   [Pages.AppBoltz]: Tabs.Settings,
   [Pages.AppBoltzSettings]: Tabs.Settings,
@@ -153,6 +156,8 @@ export const pageComponent = (page: Pages): JSX.Element => {
   switch (page) {
     case Pages.Activity:
       return <Activity />
+    case Pages.AccountDetail:
+      return <AccountDetail />
     case Pages.BitcoinDetail:
       return <BitcoinDetail />
     case Pages.AppBoltz:

--- a/src/screens/Wallet/AccountDetail.tsx
+++ b/src/screens/Wallet/AccountDetail.tsx
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { FlowContext } from '../../providers/flow'
+import BitcoinDetail from './BitcoinDetail'
+
+export default function AccountDetail() {
+  const { assetInfo } = useContext(FlowContext)
+  return <BitcoinDetail assetId={assetInfo.assetId} />
+}

--- a/src/screens/Wallet/AssetsSection.tsx
+++ b/src/screens/Wallet/AssetsSection.tsx
@@ -30,9 +30,12 @@ export default function AssetsSection() {
   const handleAssetClick = (row: PortfolioRow) => {
     if (row.assetId === 'btc') {
       navigate(Pages.BitcoinDetail)
-    } else {
+    } else if (row.fiatCurrency) {
       setAssetInfo({ assetId: row.assetId, supply: BigInt(0) })
       navigate(Pages.AccountDetail)
+    } else {
+      setAssetInfo({ assetId: row.assetId, supply: BigInt(0) })
+      navigate(Pages.AppAssetDetail)
     }
   }
 

--- a/src/screens/Wallet/AssetsSection.tsx
+++ b/src/screens/Wallet/AssetsSection.tsx
@@ -28,21 +28,18 @@ export default function AssetsSection() {
   }
 
   const handleAssetClick = (row: PortfolioRow) => {
-    const assetId = detailAssetIdForRow(row, config.importedAssets, isRegistered)
-    if (!assetId) return
-
-    if (assetId === 'btc') {
+    if (row.assetId === 'btc') {
       navigate(Pages.BitcoinDetail)
     } else {
-      setAssetInfo({ assetId, supply: BigInt(0) })
-      navigate(Pages.AppAssetDetail)
+      setAssetInfo({ assetId: row.assetId, supply: BigInt(0) })
+      navigate(Pages.AccountDetail)
     }
   }
 
   return (
     <section className='home-section'>
       <div className='flex w-full items-center justify-between px-1'>
-        <span className='home-section-label'>Assets</span>
+        <span className='home-section-label'>Accounts</span>
       </div>
       <div className='home-section__content'>
         {visibleRows.map((row) => (
@@ -55,9 +52,7 @@ export default function AssetsSection() {
             decimals={row.decimals}
             balance={row.balance}
             fiatText={row.hasFiatPrice ? fiatLabel(row.fiatAmount) : undefined}
-            onClick={
-              detailAssetIdForRow(row, config.importedAssets, isRegistered) ? () => handleAssetClick(row) : undefined
-            }
+            onClick={() => handleAssetClick(row)}
           />
         ))}
       </div>
@@ -73,14 +68,4 @@ function isVisibleAssetRow(
   if (row.assetId === 'btc') return true
   if (importedAssets.includes(row.assetId) || isRegistered(row.assetId)) return true
   return Boolean(row.sourceAssetIds?.some((assetId) => importedAssets.includes(assetId) || isRegistered(assetId)))
-}
-
-function detailAssetIdForRow(
-  row: PortfolioRow,
-  importedAssets: string[],
-  isRegistered: (assetId: string) => boolean,
-): string | undefined {
-  if (row.assetId === 'btc') return 'btc'
-  if (importedAssets.includes(row.assetId) || isRegistered(row.assetId)) return row.assetId
-  return row.sourceAssetIds?.find((assetId) => importedAssets.includes(assetId) || isRegistered(assetId))
 }

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -32,6 +32,7 @@ import { FiatContext } from '../../providers/fiat'
 import { FlowContext, emptyRecvInfo, emptySendInfo } from '../../providers/flow'
 import { NavigationContext, Pages } from '../../providers/navigation'
 import { buildCrossRatePoints, fetchHistoricalMarketData } from '../../lib/marketData'
+import { accountChartColorToken } from '../../lib/accountAssets'
 
 const CHART_WINDOWS = [
   { label: '1H', secs: 3_600 },
@@ -104,7 +105,7 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
     ? prettyBitcoinAmount(safeBitcoinBalance, bitcoinUnit)
     : `${prettyCurrencyAssetAmount(rawBalance, row.decimals, row.ticker)} ${row.ticker}`
   const maskedBalance = isBitcoin ? prettyBitcoinHide(safeBitcoinBalance, bitcoinUnit) : `•••• ${row.ticker}`
-  const chartColor = useTokenColor(isBitcoin ? '--orange-500' : '--purple-700', config.theme)
+  const chartColor = useTokenColor(accountChartColorToken(row.ticker), config.theme)
   const chartTheme = useResolvedChartTheme(config.theme)
   const chartDisplayData = useMemo(
     () => smoothChartData(marketChart.data, chartWindow, chartInteracting),

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -1,12 +1,14 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { Liveline, type HoverPoint, type LivelinePoint } from 'liveline'
 import { ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import AssetAvatar from '../../components/AssetAvatar'
 import Content from '../../components/Content'
 import Header from '../../components/Header'
 import Padded from '../../components/Padded'
 import { PrivacyAmount } from '../../components/PrivacyAmount'
-import TokenLogo from '../../components/TokenLogo'
+import TokenLogo, { accountTickerForAssetTicker, tokenLogoTickerForTicker } from '../../components/TokenLogo'
 import TransactionsList from '../../components/TransactionsList'
+import { usePortfolioFiat, type PortfolioRow } from '../../hooks/usePortfolioFiat'
 import ReceiveIcon from '../../icons/Receive'
 import ScanIcon from '../../icons/Scan'
 import SendIcon from '../../icons/Send'
@@ -15,6 +17,7 @@ import { walletLoadInChild, walletLoadInContainer } from '../../lib/animations'
 import {
   prettyBitcoinAmount,
   prettyBitcoinHide,
+  prettyCurrencyAssetAmount,
   prettyFiatAmount,
   prettyFiatHide,
   prettyNumber,
@@ -22,14 +25,13 @@ import {
 import { fiatDecimalsFor } from '../../lib/fiat'
 import { hapticLight, hapticSubtle } from '../../lib/haptics'
 import { consoleError } from '../../lib/logs'
-import { Currencies, Themes } from '../../lib/types'
+import { Currencies, Themes, Unit } from '../../lib/types'
 import { useReducedMotion } from '../../hooks/useReducedMotion'
 import { ConfigContext } from '../../providers/config'
 import { FiatContext } from '../../providers/fiat'
 import { FlowContext, emptyRecvInfo, emptySendInfo } from '../../providers/flow'
 import { NavigationContext, Pages } from '../../providers/navigation'
-import { WalletContext } from '../../providers/wallet'
-import { fetchHistoricalMarketData } from '../../lib/marketData'
+import { buildCrossRatePoints, fetchHistoricalMarketData } from '../../lib/marketData'
 
 const CHART_WINDOWS = [
   { label: '1H', secs: 3_600 },
@@ -41,70 +43,128 @@ const CHART_WINDOWS = [
 ]
 
 const MIN_CHART_WINDOW_SECS = 30
-const bitcoinChartCache = new Map<string, LivelinePoint[]>()
+const marketChartCache = new Map<string, LivelinePoint[]>()
 
-export default function BitcoinDetail() {
+type MarketChartStatus = 'loading' | 'ready' | 'unavailable'
+
+const unavailableRow: PortfolioRow = {
+  assetId: '',
+  name: 'Account unavailable',
+  ticker: 'TKN',
+  decimals: 0,
+  balance: BigInt(0),
+  fiatAmount: 0,
+  satsEquivalent: 0,
+  hasFiatPrice: false,
+}
+
+export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string }) {
   const { config } = useContext(ConfigContext)
-  const { toFiatAmount } = useContext(FiatContext)
+  const { fromFiatAmount, toFiatAmount } = useContext(FiatContext)
   const { setRecvInfo, setSendInfo, setSwapFromAssetId } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
-  const { balance } = useContext(WalletContext)
+  const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
 
   const [chartWindow, setChartWindow] = useState(CHART_WINDOWS[2].secs)
   const [chartInteracting, setChartInteracting] = useState(false)
   const chartHapticState = useRef({ lastPointTime: 0, lastTriggerTime: 0 })
 
-  const marketFiat = config.currency === Currencies.BTC ? Currencies.USD : config.currency
-  const marketDecimals = fiatDecimalsFor(marketFiat)
+  const selectedRow = rows.find((candidate) => candidate.assetId === assetId)
+  const row = selectedRow ?? unavailableRow
+  const isBitcoin = row.assetId === 'btc'
+  const sourceFiat = isBitcoin ? Currencies.BTC : row.fiatCurrency
+  const marketFiat = isBitcoin && config.currency === Currencies.BTC ? Currencies.USD : config.currency
   const bitcoinUnit = config.unit
-  const currentUnitPrice = toFiatAmount(100_000_000, marketFiat)
-  const liveChartData = useBitcoinMarketChartData(marketFiat, chartWindow)
-  const chartUnitPrice = liveChartData.at(-1)?.value ?? currentUnitPrice
-  const fiatValue = (balance / 100_000_000) * currentUnitPrice
-  const formattedFiat = prettyFiatAmount(fiatValue, marketFiat, {
-    maximumFractionDigits: marketDecimals,
-    minimumFractionDigits: marketDecimals,
-  })
-  const chartColor = useTokenColor('--orange-500', config.theme)
+  const marketDecimals = fiatDecimalsFor(marketFiat, bitcoinUnit)
+  const currentUnitPrice = currentPriceForRow(isBitcoin, sourceFiat, marketFiat, fromFiatAmount, toFiatAmount)
+  const marketChart = useAccountMarketChartData(sourceFiat, marketFiat, chartWindow, bitcoinUnit)
+  const chartUnitPrice = marketChart.data.at(-1)?.value ?? currentUnitPrice ?? 0
+  const safeBitcoinBalance =
+    isBitcoin && typeof row.balance === 'number' && Number.isFinite(row.balance)
+      ? Math.max(0, Math.floor(row.balance))
+      : 0
+  const fiatValue = isBitcoin
+    ? currentUnitPrice === undefined
+      ? undefined
+      : (safeBitcoinBalance / 100_000_000) * currentUnitPrice
+    : row.hasFiatPrice
+      ? row.fiatAmount
+      : undefined
+  const formattedFiat =
+    fiatValue === undefined
+      ? undefined
+      : prettyFiatAmount(fiatValue, marketFiat, {
+          bitcoinUnit,
+          maximumFractionDigits: marketDecimals,
+          minimumFractionDigits: marketDecimals,
+        })
+  const rawBalance = typeof row.balance === 'bigint' ? row.balance : BigInt(Math.max(0, Math.floor(row.balance)))
+  const formattedBalance = isBitcoin
+    ? prettyBitcoinAmount(safeBitcoinBalance, bitcoinUnit)
+    : `${prettyCurrencyAssetAmount(rawBalance, row.decimals, row.ticker)} ${row.ticker}`
+  const maskedBalance = isBitcoin ? prettyBitcoinHide(safeBitcoinBalance, bitcoinUnit) : `•••• ${row.ticker}`
+  const chartColor = useTokenColor(isBitcoin ? '--orange-500' : '--purple-700', config.theme)
   const chartTheme = useResolvedChartTheme(config.theme)
-  const safeBalance = Number.isFinite(balance) ? Math.max(0, Math.floor(balance)) : 0
-  const chartData = useMemo(
-    () => (liveChartData.length ? liveChartData : buildFlatChartData(chartUnitPrice, chartWindow)),
-    [chartWindow, chartUnitPrice, liveChartData],
-  )
   const chartDisplayData = useMemo(
-    () => smoothChartData(chartData, chartWindow, chartInteracting),
-    [chartData, chartInteracting, chartWindow],
+    () => smoothChartData(marketChart.data, chartWindow, chartInteracting),
+    [chartInteracting, chartWindow, marketChart.data],
   )
-  const chartDelta = calculateDelta(chartData)
+  const chartDelta = calculateDelta(marketChart.data)
   const livelineWindow = useMemo(
     () => getLivelineWindowSecs(chartDisplayData, chartWindow),
     [chartDisplayData, chartWindow],
   )
-  const canRenderChart = typeof ResizeObserver !== 'undefined'
+  const canRenderChart =
+    marketChart.status === 'ready' && marketChart.data.length >= 2 && typeof ResizeObserver !== 'undefined'
+  const sourceAssetId = walletSourceAssetId(row)
+  const accountTicker = accountTickerForAssetTicker(row.ticker)
+  const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? row.ticker)
+  const activityAssetFilter = isBitcoin
+    ? 'btc'
+    : Array.from(new Set([row.assetId, ...(row.sourceAssetIds ?? [])].filter(Boolean)))
+  const priceText =
+    currentUnitPrice === undefined
+      ? 'Price unavailable'
+      : prettyFiatAmount(currentUnitPrice, marketFiat, {
+          bitcoinUnit,
+          maximumFractionDigits: marketDecimals,
+          minimumFractionDigits: marketDecimals,
+        })
 
   const handleSend = () => {
     hapticLight()
-    setSendInfo(emptySendInfo)
+    setSendInfo(
+      isBitcoin || !sourceAssetId
+        ? emptySendInfo
+        : { ...emptySendInfo, assets: [{ assetId: sourceAssetId, amount: BigInt(0) }] },
+    )
     navigate(Pages.SendForm)
   }
 
   const handleReceive = () => {
     hapticLight()
-    setRecvInfo(emptyRecvInfo)
+    setRecvInfo(
+      isBitcoin || !sourceAssetId
+        ? emptyRecvInfo
+        : { ...emptyRecvInfo, assetId: sourceAssetId, assetAmount: BigInt(0) },
+    )
     navigate(Pages.ReceiveQRCode)
   }
 
   const handleScan = () => {
     hapticLight()
-    setSendInfo({ ...emptySendInfo, scan: true })
+    setSendInfo(
+      isBitcoin || !sourceAssetId
+        ? { ...emptySendInfo, scan: true }
+        : { ...emptySendInfo, assets: [{ assetId: sourceAssetId, amount: BigInt(0) }], scan: true },
+    )
     navigate(Pages.SendForm)
   }
 
   const handleSwap = () => {
     hapticLight()
-    setSwapFromAssetId('btc')
+    setSwapFromAssetId(row.assetId)
     navigate(Pages.WalletSwap)
   }
 
@@ -137,6 +197,19 @@ export default function BitcoinDetail() {
     [prefersReduced],
   )
 
+  if (!selectedRow) {
+    return (
+      <>
+        <Header text='' back />
+        <Content>
+          <Padded>
+            <div className='asset-detail-page'>Account unavailable</div>
+          </Padded>
+        </Content>
+      </>
+    )
+  }
+
   return (
     <>
       <Header text='' back />
@@ -151,10 +224,14 @@ export default function BitcoinDetail() {
             <motion.section className='asset-detail-hero' variants={prefersReduced ? undefined : walletLoadInChild}>
               <motion.div className='asset-detail-identity' variants={prefersReduced ? undefined : walletLoadInChild}>
                 <span className='asset-detail-logo' aria-hidden='true'>
-                  <TokenLogo ticker='BTC' />
+                  {tokenLogoTicker ? (
+                    <TokenLogo ticker={tokenLogoTicker} />
+                  ) : (
+                    <AssetAvatar icon={row.icon} name={row.name} ticker={row.ticker} size={60} />
+                  )}
                 </span>
                 <div>
-                  <h1 className='asset-detail-name'>Bitcoin</h1>
+                  <h1 className='asset-detail-name'>{row.name}</h1>
                 </div>
               </motion.div>
 
@@ -165,25 +242,42 @@ export default function BitcoinDetail() {
               >
                 <AnimatePresence mode='popLayout' initial={false}>
                   <motion.div
-                    key={`${currentUnitPrice}-${marketFiat}`}
-                    className='asset-detail-price'
+                    key={`${priceText}-${marketFiat}`}
+                    className={`asset-detail-price${currentUnitPrice === undefined ? ' asset-detail-price--unavailable' : ''}`}
                     initial={prefersReduced ? false : { opacity: 0, y: 8, filter: 'blur(2px)' }}
                     animate={prefersReduced ? undefined : { opacity: 1, y: 0, filter: 'blur(0px)' }}
                     exit={prefersReduced ? undefined : { opacity: 0, y: -8, filter: 'blur(2px)' }}
                     transition={{ duration: 0.22, ease: [0.23, 1, 0.32, 1] }}
                   >
-                    {prettyFiatAmount(currentUnitPrice, marketFiat)}
+                    {priceText}
                   </motion.div>
                 </AnimatePresence>
-                <DeltaBadge value={chartDelta} />
+                {marketChart.status === 'ready' && marketChart.data.length >= 2 ? (
+                  <DeltaBadge value={chartDelta} />
+                ) : null}
               </motion.div>
             </motion.section>
 
             <motion.div className='asset-detail-actions' variants={prefersReduced ? undefined : walletLoadInChild}>
-              <AssetAction icon={<ReceiveIcon />} label='Receive' onClick={handleReceive} />
-              <AssetAction icon={<SendIcon />} label='Send' onClick={handleSend} disabled={balance === 0} />
+              <AssetAction
+                icon={<ReceiveIcon />}
+                label='Receive'
+                onClick={handleReceive}
+                disabled={!isBitcoin && !sourceAssetId}
+              />
+              <AssetAction
+                icon={<SendIcon />}
+                label='Send'
+                onClick={handleSend}
+                disabled={rawBalance === BigInt(0) || (!isBitcoin && !sourceAssetId)}
+              />
               <AssetAction icon={<SwapIcon />} label='Swap' onClick={handleSwap} />
-              <AssetAction icon={<ScanIcon />} label='Scan' onClick={handleScan} />
+              <AssetAction
+                icon={<ScanIcon />}
+                label='Scan'
+                onClick={handleScan}
+                disabled={!isBitcoin && !sourceAssetId}
+              />
             </motion.div>
 
             <motion.section
@@ -193,10 +287,13 @@ export default function BitcoinDetail() {
               <div
                 className='asset-detail-chart'
                 onPointerDown={() => {
+                  if (!canRenderChart) return
                   setChartScrubbing(true)
                   handleChartPress()
                 }}
-                onPointerEnter={() => setChartScrubbing(true)}
+                onPointerEnter={() => {
+                  if (canRenderChart) setChartScrubbing(true)
+                }}
                 onPointerLeave={() => setChartScrubbing(false)}
                 onPointerUp={() => setChartScrubbing(false)}
                 onPointerCancel={() => setChartScrubbing(false)}
@@ -211,7 +308,7 @@ export default function BitcoinDetail() {
                     badge={false}
                     badgeTail
                     badgeVariant='minimal'
-                    formatValue={(value) => prettyFiatAmount(value, marketFiat)}
+                    formatValue={(value) => prettyFiatAmount(value, marketFiat, { bitcoinUnit })}
                     grid={false}
                     paused={chartInteracting}
                     pulse={!prefersReduced}
@@ -232,7 +329,9 @@ export default function BitcoinDetail() {
                     cursor='default'
                   />
                 ) : (
-                  <div className='asset-detail-chart-fallback' aria-hidden='true' />
+                  <div className='asset-detail-chart-fallback' role='status'>
+                    {marketChart.status === 'loading' ? 'Loading price history…' : 'Price history unavailable'}
+                  </div>
                 )}
               </div>
               <div className='asset-detail-range-tabs' role='tablist' aria-label='Price chart range'>
@@ -260,15 +359,21 @@ export default function BitcoinDetail() {
               <div className='asset-detail-holding'>
                 <span>Balance</span>
                 <strong>
-                  <PrivacyAmount masked={prettyBitcoinHide(safeBalance, bitcoinUnit)}>
-                    <span className='asset-detail-holding-amount'>{prettyBitcoinAmount(safeBalance, bitcoinUnit)}</span>
+                  <PrivacyAmount masked={maskedBalance}>
+                    <span className='asset-detail-holding-amount'>{formattedBalance}</span>
                   </PrivacyAmount>
                 </strong>
               </div>
               <div className='asset-detail-holding'>
                 <span>Value</span>
                 <strong>
-                  <PrivacyAmount masked={prettyFiatHide(fiatValue, marketFiat)}>{formattedFiat}</PrivacyAmount>
+                  {formattedFiat === undefined || fiatValue === undefined ? (
+                    'Unavailable'
+                  ) : (
+                    <PrivacyAmount masked={prettyFiatHide(fiatValue, marketFiat, { bitcoinUnit })}>
+                      {formattedFiat}
+                    </PrivacyAmount>
+                  )}
                 </strong>
               </div>
             </motion.section>
@@ -277,7 +382,7 @@ export default function BitcoinDetail() {
               <div className='asset-detail-section-header'>
                 <strong>Recent activity</strong>
               </div>
-              <TransactionsList mode='static' assetIdFilter='btc' limit={5} />
+              <TransactionsList mode='static' assetIdFilter={activityAssetFilter} limit={5} />
             </motion.section>
           </motion.div>
         </Padded>
@@ -381,47 +486,112 @@ function useResolvedChartTheme(theme: Themes): 'light' | 'dark' {
   return resolved
 }
 
-function useBitcoinMarketChartData(currency: Currencies, windowSecs: number): LivelinePoint[] {
-  const [data, setData] = useState<LivelinePoint[]>([])
+function currentPriceForRow(
+  isBitcoin: boolean,
+  sourceFiat: Currencies | undefined,
+  marketFiat: Currencies,
+  fromFiatAmount: (amount: number, currency: Currencies) => number,
+  toFiatAmount: (satoshis: number, currency: Currencies) => number,
+): number | undefined {
+  if (isBitcoin) return toFiatAmount(100_000_000, marketFiat)
+  if (!sourceFiat) return undefined
+  if (sourceFiat === marketFiat) return 1
+
+  const converted = toFiatAmount(fromFiatAmount(1, sourceFiat), marketFiat)
+  return Number.isFinite(converted) && converted > 0 ? converted : undefined
+}
+
+function walletSourceAssetId(row: PortfolioRow): string | undefined {
+  const sourceAssetId = row.sourceAssetIds?.[0]
+  if (sourceAssetId) return sourceAssetId
+  return row.assetId && !row.assetId.startsWith('account:') ? row.assetId : undefined
+}
+
+function useAccountMarketChartData(
+  sourceFiat: Currencies | undefined,
+  marketFiat: Currencies,
+  windowSecs: number,
+  bitcoinUnit: Unit,
+): { data: LivelinePoint[]; status: MarketChartStatus } {
+  const [chart, setChart] = useState<{ data: LivelinePoint[]; status: MarketChartStatus }>({
+    data: [],
+    status: sourceFiat ? 'loading' : 'unavailable',
+  })
 
   useEffect(() => {
     const controller = new AbortController()
-    const cacheKey = bitcoinChartCacheKey(currency, windowSecs)
-    const cached = bitcoinChartCache.get(cacheKey)
+    const cacheKey = marketChartCacheKey(sourceFiat, marketFiat, windowSecs, bitcoinUnit)
+    const cached = marketChartCache.get(cacheKey)
 
-    if (currency === Currencies.BTC) {
-      setData([])
+    if (!sourceFiat) {
+      setChart({ data: [], status: 'unavailable' })
       return () => controller.abort()
     }
 
     if (cached) {
-      setData(cached)
+      setChart({ data: cached, status: 'ready' })
       return () => controller.abort()
     }
 
-    fetchHistoricalMarketData(windowSecs, currency, controller.signal)
+    if (sourceFiat === marketFiat) {
+      const points = buildConstantChartData(1, windowSecs)
+      marketChartCache.set(cacheKey, points)
+      setChart({ data: points, status: 'ready' })
+      return () => controller.abort()
+    }
+
+    setChart({ data: [], status: 'loading' })
+    fetchAccountMarketData(sourceFiat, marketFiat, windowSecs, bitcoinUnit, controller.signal)
       .then((points) => {
         if (controller.signal.aborted) return
-        bitcoinChartCache.set(cacheKey, points)
-        setData(points)
+        if (points.length < 2) {
+          setChart({ data: [], status: 'unavailable' })
+          return
+        }
+        marketChartCache.set(cacheKey, points)
+        setChart({ data: points, status: 'ready' })
       })
       .catch((err) => {
         if (controller.signal.aborted) return
-        consoleError(err, 'error fetching bitcoin market chart')
-        setData([])
+        consoleError(err, 'error fetching account market chart')
+        setChart({ data: [], status: 'unavailable' })
       })
 
     return () => controller.abort()
-  }, [currency, windowSecs])
+  }, [bitcoinUnit, marketFiat, sourceFiat, windowSecs])
 
-  return data
+  return chart
 }
 
-function buildFlatChartData(latestValue: number, windowSecs: number): LivelinePoint[] {
+async function fetchAccountMarketData(
+  sourceFiat: Currencies,
+  marketFiat: Currencies,
+  windowSecs: number,
+  bitcoinUnit: Unit,
+  signal: AbortSignal,
+): Promise<LivelinePoint[]> {
+  if (sourceFiat === Currencies.BTC) return fetchHistoricalMarketData(windowSecs, marketFiat, signal)
+
+  if (marketFiat === Currencies.BTC) {
+    const sourcePoints = await fetchHistoricalMarketData(windowSecs, sourceFiat, signal)
+    const bitcoinUnitScale = bitcoinUnit === Unit.BTC ? 1 : 100_000_000
+    return sourcePoints
+      .filter((point) => Number.isFinite(point.value) && point.value > 0)
+      .map((point) => ({ time: point.time, value: bitcoinUnitScale / point.value }))
+  }
+
+  const [sourcePoints, marketPoints] = await Promise.all([
+    fetchHistoricalMarketData(windowSecs, sourceFiat, signal),
+    fetchHistoricalMarketData(windowSecs, marketFiat, signal),
+  ])
+  return buildCrossRatePoints(sourcePoints, marketPoints)
+}
+
+function buildConstantChartData(latestValue: number, windowSecs: number): LivelinePoint[] {
   const now = Math.floor(Date.now() / 1000)
-  const fallbackWindowSecs = isAllChartWindow(windowSecs) ? 86_400 : windowSecs
+  const exactWindowSecs = isAllChartWindow(windowSecs) ? 86_400 : windowSecs
   return [
-    { time: now - fallbackWindowSecs, value: latestValue },
+    { time: now - exactWindowSecs, value: latestValue },
     { time: now, value: latestValue },
   ]
 }
@@ -512,8 +682,13 @@ function calculateDelta(data: LivelinePoint[]): number {
   return ((last - first) / first) * 100
 }
 
-function bitcoinChartCacheKey(currency: Currencies, windowSecs: number): string {
-  return `${currency}:${windowSecs}`
+function marketChartCacheKey(
+  sourceFiat: Currencies | undefined,
+  marketFiat: Currencies,
+  windowSecs: number,
+  bitcoinUnit: Unit,
+): string {
+  return `${sourceFiat ?? 'unpriced'}:${marketFiat}:${windowSecs}:${bitcoinUnit}`
 }
 
 function isAllChartWindow(windowSecs: number): boolean {

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -32,7 +32,7 @@ import { FiatContext } from '../../providers/fiat'
 import { FlowContext, emptyRecvInfo, emptySendInfo } from '../../providers/flow'
 import { NavigationContext, Pages } from '../../providers/navigation'
 import { buildCrossRatePoints, fetchHistoricalMarketData } from '../../lib/marketData'
-import { accountChartColorToken } from '../../lib/accountAssets'
+import { accountChartColorToken, primaryFiatAccountSource } from '../../lib/accountAssets'
 
 const CHART_WINDOWS = [
   { label: '1H', secs: 3_600 },
@@ -118,8 +118,20 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
   )
   const canRenderChart =
     marketChart.status === 'ready' && marketChart.data.length >= 2 && typeof ResizeObserver !== 'undefined'
-  const sourceAssetId = walletSourceAssetId(row)
   const accountTicker = accountTickerForAssetTicker(row.ticker)
+  const primarySource = primaryFiatAccountSource(row.sourceAssets, row.decimals)
+  const sourceAssetId = primarySource?.assetId ?? walletSourceAssetId(row)
+  const sendAccount =
+    !isBitcoin && accountTicker && accountTicker !== 'BTC' && row.sourceAssets?.length
+      ? {
+          assetId: row.assetId,
+          ticker: accountTicker,
+          balance: rawBalance,
+          decimals: row.decimals,
+          amount: BigInt(0),
+          sources: row.sourceAssets,
+        }
+      : undefined
   const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? row.ticker)
   const activityAssetFilter = isBitcoin
     ? 'btc'
@@ -136,9 +148,11 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
   const handleSend = () => {
     hapticLight()
     setSendInfo(
-      isBitcoin || !sourceAssetId
-        ? emptySendInfo
-        : { ...emptySendInfo, assets: [{ assetId: sourceAssetId, amount: BigInt(0) }] },
+      sendAccount
+        ? { ...emptySendInfo, account: sendAccount }
+        : isBitcoin || !sourceAssetId
+          ? emptySendInfo
+          : { ...emptySendInfo, assets: [{ assetId: sourceAssetId, amount: BigInt(0) }] },
     )
     navigate(Pages.SendForm)
   }
@@ -156,9 +170,11 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
   const handleScan = () => {
     hapticLight()
     setSendInfo(
-      isBitcoin || !sourceAssetId
-        ? { ...emptySendInfo, scan: true }
-        : { ...emptySendInfo, assets: [{ assetId: sourceAssetId, amount: BigInt(0) }], scan: true },
+      sendAccount
+        ? { ...emptySendInfo, account: sendAccount, scan: true }
+        : isBitcoin || !sourceAssetId
+          ? { ...emptySendInfo, scan: true }
+          : { ...emptySendInfo, assets: [{ assetId: sourceAssetId, amount: BigInt(0) }], scan: true },
     )
     navigate(Pages.SendForm)
   }
@@ -270,7 +286,7 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
                 icon={<SendIcon />}
                 label='Send'
                 onClick={handleSend}
-                disabled={rawBalance === BigInt(0) || (!isBitcoin && !sourceAssetId)}
+                disabled={rawBalance === BigInt(0) || (!isBitcoin && !sendAccount && !sourceAssetId)}
               />
               <AssetAction icon={<SwapIcon />} label='Swap' onClick={handleSwap} />
               <AssetAction

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -41,6 +41,7 @@ import { useReducedMotion } from '../../../hooks/useReducedMotion'
 import ButtonsOnBottom from '../../../components/ButtonsOnBottom'
 import { AssetOption, Unit } from '../../../lib/types'
 import { EASE_OUT_QUINT } from '../../../lib/animations'
+import { walletAssetPresentation } from '../../../lib/accountAssets'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 
@@ -375,13 +376,14 @@ export default function ReceiveQRCode() {
     setAmountTextValue('')
   }
 
+  const assetPresentation = walletAssetPresentation(assetMeta?.metadata, '')
   const assetOption: AssetOption = {
     assetId: assetId ?? '',
-    name: assetMeta?.metadata?.name ?? '',
-    ticker: assetMeta?.metadata?.ticker ?? '',
+    name: assetPresentation.name,
+    ticker: assetPresentation.ticker,
     balance: BigInt(0),
     decimals: assetMeta?.metadata?.decimals ?? 0,
-    icon: assetMeta?.metadata?.icon,
+    icon: assetPresentation.icon,
   }
 
   const data = { title: 'Receive', text: qrCodeValue }
@@ -413,7 +415,7 @@ export default function ReceiveQRCode() {
   }
 
   const amountLabel = hasAmount ? 'Edit amount' : 'Add amount'
-  const unitLabel = assetMeta?.metadata?.ticker ?? 'sats'
+  const unitLabel = assetMeta ? assetPresentation.ticker : 'sats'
 
   return (
     <>

--- a/src/screens/Wallet/Receive/Success.tsx
+++ b/src/screens/Wallet/Receive/Success.tsx
@@ -3,18 +3,19 @@ import WalletSuccessSplash from '../../../components/WalletSuccessSplash'
 import { NotificationsContext } from '../../../providers/notifications'
 import { FlowContext } from '../../../providers/flow'
 import { NavigationContext, Pages } from '../../../providers/navigation'
-import { prettyAmount, prettyFiatAmount } from '../../../lib/format'
+import { prettyAmount, prettyCurrencyAssetAmount, prettyFiatAmount } from '../../../lib/format'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 import { WalletContext } from '../../../providers/wallet'
 import { consoleError } from '../../../lib/logs'
 import type { AssetDetails } from '@arkade-os/sdk'
-import { prettyAssetAmount } from '../../../lib/assets'
+import { walletAssetPresentation } from '../../../lib/accountAssets'
 
 function formatAssetLabel(a: { assetId: string; amount: bigint }, details: AssetDetails | undefined) {
   const meta = details?.metadata
-  const amount = prettyAssetAmount(a.amount, meta?.decimals ?? 0)
-  const ticker = meta?.ticker ?? meta?.name ?? 'assets'
+  const presentation = walletAssetPresentation(meta, 'assets')
+  const ticker = presentation.ticker || presentation.name
+  const amount = prettyCurrencyAssetAmount(a.amount, meta?.decimals ?? 0, ticker)
   return `${amount} ${ticker}`
 }
 

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -21,7 +21,7 @@ import { SwapsContext } from '../../../providers/swaps'
 import Text from '../../../components/Text'
 import { isPendingChainSwap, isPendingSubmarineSwap } from '@arkade-os/boltz-swap'
 import { FeesContext } from '../../../providers/fees'
-import { walletAssetPresentation } from '../../../lib/accountAssets'
+import { walletAssetLabel, walletAssetPresentation } from '../../../lib/accountAssets'
 
 export default function SendDetails() {
   const { navigate } = useContext(NavigationContext)
@@ -36,11 +36,12 @@ export default function SendDetails() {
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
   const assetPresentation = sendInfo.account
     ? { name: sendInfo.account.ticker, ticker: sendInfo.account.ticker }
-    : walletAssetPresentation(assetMeta?.metadata)
+    : walletAssetPresentation(assetMeta?.metadata, assetId ?? 'Asset')
   const assetTicker = assetPresentation.ticker
   const assetName = assetPresentation.name
   const assetDecimals = sendInfo.account?.decimals ?? assetMeta?.metadata?.decimals ?? 8
-  const assetLabel = assetName === assetTicker ? assetTicker : `${assetName} (${assetTicker})`
+  const assetLabel = walletAssetLabel(assetPresentation)
+  const assetAmountUnit = assetTicker || assetName
   const assetAmountValue = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
   const [buttonLabel, setButtonLabel] = useState('')
@@ -210,7 +211,7 @@ export default function SendDetails() {
                     {assetLabel}
                   </Text>
                   <Text bold testId='send-details-asset-amount'>
-                    {prettyCurrencyAssetAmount(assetAmountValue, assetDecimals, assetTicker)} {assetTicker}
+                    {prettyCurrencyAssetAmount(assetAmountValue, assetDecimals, assetAmountUnit)} {assetAmountUnit}
                   </Text>
                 </FlexCol>
               ) : null}

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -9,7 +9,7 @@ import ErrorMessage from '../../../components/Error'
 import { WalletContext } from '../../../providers/wallet'
 import Header from '../../../components/Header'
 import { defaultFee } from '../../../lib/constants'
-import { prettyNumber } from '../../../lib/format'
+import { prettyCurrencyAssetAmount, prettyNumber } from '../../../lib/format'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import { collaborativeExitWithFees, sendAssets, sendOffChain } from '../../../lib/asp'
@@ -21,7 +21,7 @@ import { SwapsContext } from '../../../providers/swaps'
 import Text from '../../../components/Text'
 import { isPendingChainSwap, isPendingSubmarineSwap } from '@arkade-os/boltz-swap'
 import { FeesContext } from '../../../providers/fees'
-import { prettyAssetAmount } from '../../../lib/assets'
+import { walletAssetPresentation } from '../../../lib/accountAssets'
 
 export default function SendDetails() {
   const { navigate } = useContext(NavigationContext)
@@ -34,8 +34,11 @@ export default function SendDetails() {
 
   const assetId = sendInfo.assets?.[0]?.assetId
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
-  const assetTicker = assetMeta?.metadata?.ticker ?? ''
-  const assetName = assetMeta?.metadata?.name ?? 'Asset'
+  const assetPresentation = walletAssetPresentation(assetMeta?.metadata)
+  const assetTicker = assetPresentation.ticker
+  const assetName = assetPresentation.name
+  const assetDecimals = assetMeta?.metadata?.decimals ?? 8
+  const assetLabel = assetName === assetTicker ? assetTicker : `${assetName} (${assetTicker})`
   const assetAmountValue = sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
   const [buttonLabel, setButtonLabel] = useState('')
@@ -202,10 +205,10 @@ export default function SendDetails() {
               {isAssetSend ? (
                 <FlexCol gap='0.5rem'>
                   <Text color='neutral-500' smaller testId='send-details-asset-name'>
-                    {assetName} ({assetTicker})
+                    {assetLabel}
                   </Text>
                   <Text bold testId='send-details-asset-amount'>
-                    {prettyAssetAmount(assetAmountValue, assetMeta?.metadata?.decimals ?? 8)} {assetTicker}
+                    {prettyCurrencyAssetAmount(assetAmountValue, assetDecimals, assetTicker)} {assetTicker}
                   </Text>
                 </FlexCol>
               ) : null}

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -27,19 +27,21 @@ export default function SendDetails() {
   const { navigate } = useContext(NavigationContext)
   const { sendInfo, setSendInfo } = useContext(FlowContext)
   const { calcOnchainOutputFee } = useContext(FeesContext)
-  const isAssetSend = Boolean(sendInfo.assets?.length)
+  const isAssetSend = Boolean(sendInfo.account || sendInfo.assets?.length)
   const { lnSwapsAllowed, utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { payInvoice, payBtc } = useContext(SwapsContext)
   const { assetMetadataCache, balance, svcWallet } = useContext(WalletContext)
 
   const assetId = sendInfo.assets?.[0]?.assetId
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
-  const assetPresentation = walletAssetPresentation(assetMeta?.metadata)
+  const assetPresentation = sendInfo.account
+    ? { name: sendInfo.account.ticker, ticker: sendInfo.account.ticker }
+    : walletAssetPresentation(assetMeta?.metadata)
   const assetTicker = assetPresentation.ticker
   const assetName = assetPresentation.name
-  const assetDecimals = assetMeta?.metadata?.decimals ?? 8
+  const assetDecimals = sendInfo.account?.decimals ?? assetMeta?.metadata?.decimals ?? 8
   const assetLabel = assetName === assetTicker ? assetTicker : `${assetName} (${assetTicker})`
-  const assetAmountValue = sendInfo.assets?.[0]?.amount ?? BigInt(0)
+  const assetAmountValue = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
   const [buttonLabel, setButtonLabel] = useState('')
   const [details, setDetails] = useState<DetailsProps>()

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -49,7 +49,8 @@ import SheetModal from '../../../components/SheetModal'
 import { AnimatePresence, motion } from 'framer-motion'
 import { overlaySlideUp, overlayStyle } from '../../../lib/animations'
 import { useReducedMotion } from '../../../hooks/useReducedMotion'
-import TokenLogo, { TokenLogoTicker } from '../../../components/TokenLogo'
+import TokenLogo, { tokenLogoTickerForTicker } from '../../../components/TokenLogo'
+import { walletAssetPresentation } from '../../../lib/accountAssets'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -67,13 +68,7 @@ const brantaClient = new BrantaService({
 })
 
 function AssetIcon({ asset }: { asset: AssetOption | null }) {
-  const ticker = asset?.ticker?.toUpperCase()
-  const tokenTicker =
-    ticker === 'USD' || ticker === 'USDT' || ticker === 'USDC' || ticker === 'CHF' || ticker === 'BRL'
-      ? (ticker as TokenLogoTicker)
-      : asset
-        ? null
-        : 'BTC'
+  const tokenTicker = asset ? tokenLogoTickerForTicker(asset.ticker) : 'BTC'
 
   if (tokenTicker) {
     return (
@@ -211,12 +206,13 @@ export default function SendForm() {
             consoleError(err, `error fetching metadata for ${ab.assetId}`)
           }
         }
+        const presentation = walletAssetPresentation(meta?.metadata, `${ab.assetId.slice(0, 8)}...`)
         options.push({
           assetId: ab.assetId,
           balance: ab.amount,
-          name: meta?.metadata?.name ?? `${ab.assetId.slice(0, 8)}...`,
-          ticker: meta?.metadata?.ticker ?? '',
-          icon: meta?.metadata?.icon,
+          name: presentation.name,
+          ticker: presentation.ticker,
+          icon: presentation.icon,
           decimals: meta?.metadata?.decimals ?? 8,
         })
       }
@@ -271,12 +267,13 @@ export default function SendForm() {
                 consoleError(err, `error fetching metadata for ${assetId}`)
               }
             }
+            const presentation = walletAssetPresentation(meta?.metadata, `${assetId.slice(0, 8)}...`)
             found = {
               assetId,
               balance: BigInt(0),
-              name: meta?.metadata?.name ?? `${assetId.slice(0, 8)}...`,
-              ticker: meta?.metadata?.ticker ?? '',
-              icon: meta?.metadata?.icon,
+              name: presentation.name,
+              ticker: presentation.ticker,
+              icon: presentation.icon,
               decimals: meta?.metadata?.decimals ?? 8,
             }
           }

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { BrantaService, type Payment } from '@branta-ops/branta/v2'
 import Button from '../../../components/Button'
 import ErrorMessage from '../../../components/Error'
@@ -50,7 +50,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { overlaySlideUp, overlayStyle } from '../../../lib/animations'
 import { useReducedMotion } from '../../../hooks/useReducedMotion'
 import TokenLogo, { tokenLogoTickerForTicker } from '../../../components/TokenLogo'
-import { walletAssetPresentation } from '../../../lib/accountAssets'
+import { allocateFiatAccountAssets, walletAssetPresentation } from '../../../lib/accountAssets'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -142,7 +142,21 @@ export default function SendForm() {
   const timeoutRef = useRef<NodeJS.Timeout>()
 
   const prefersReducedMotion = useReducedMotion()
-  const isAssetSend = selectedAsset !== null
+  const accountAsset = useMemo<AssetOption | null>(
+    () =>
+      sendInfo.account
+        ? {
+            assetId: sendInfo.account.assetId,
+            balance: sendInfo.account.balance,
+            decimals: sendInfo.account.decimals,
+            name: sendInfo.account.ticker,
+            ticker: sendInfo.account.ticker,
+          }
+        : null,
+    [sendInfo.account],
+  )
+  const activeAsset = accountAsset ?? selectedAsset
+  const isAssetSend = activeAsset !== null
 
   const DUST_AMOUNT = 330
   const RECIPIENT_DEBOUNCE_MS = 800
@@ -223,11 +237,15 @@ export default function SendForm() {
 
   // initialize selected asset from pre-set sendInfo.assets (e.g. from Asset Detail page)
   useEffect(() => {
+    if (sendInfo.account) {
+      setSelectedAsset(null)
+      return
+    }
     if (!sendInfo.assets?.length || assetOptions.length === 0) return
     const presetAssetId = sendInfo.assets[0].assetId
     const found = assetOptions.find((a) => a.assetId === presetAssetId)
     if (found && !selectedAsset) setSelectedAsset(found)
-  }, [assetOptions, sendInfo.assets])
+  }, [assetOptions, sendInfo.account, sendInfo.assets])
 
   // update available balance
   useEffect(() => {
@@ -289,6 +307,7 @@ export default function SendForm() {
           })
         }
         setSendInfo({
+          account: sendInfo.account,
           address,
           arkAddress,
           assets: sendInfo.assets,
@@ -497,9 +516,9 @@ export default function SendForm() {
 
   // manage button label and errors
   useEffect(() => {
-    if (isAssetSend && selectedAsset) {
-      const assetAmt = sendInfo.assets?.[0]?.amount ?? 0
-      setLabel(assetAmt > selectedAsset.balance ? 'Insufficient asset balance' : 'Continue')
+    if (isAssetSend && activeAsset) {
+      const assetAmount = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
+      setLabel(assetAmount > activeAsset.balance ? 'Insufficient asset balance' : 'Continue')
       return
     }
     const satoshis = sendInfo.satoshis ?? 0
@@ -518,7 +537,7 @@ export default function SendForm() {
                   ? 'Amount below min limit'
                   : 'Continue',
     )
-  }, [sendInfo.satoshis, sendInfo.assets, liquidBalance, selectedAsset])
+  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.account, liquidBalance, activeAsset])
 
   // manage server unreachable error
   useEffect(() => {
@@ -598,7 +617,15 @@ export default function SendForm() {
     setValueSats(undefined)
     setAmountTextValue(value)
     if (isAssetSend) {
-      if (selectedAsset) {
+      if (sendInfo.account) {
+        const accountAmount = unitsToCents(value, sendInfo.account.decimals)
+        setSendInfo({
+          ...sendInfo,
+          account: { ...sendInfo.account, amount: accountAmount },
+          assets: allocateFiatAccountAssets(accountAmount, sendInfo.account.decimals, sendInfo.account.sources),
+          satoshis: 0,
+        })
+      } else if (selectedAsset) {
         const decimals = selectedAsset?.decimals
         const cents = unitsToCents(value, decimals)
         setSendInfo({
@@ -635,12 +662,13 @@ export default function SendForm() {
       }
       setSendInfo({
         ...sendInfo,
+        account: undefined,
         address: '',
         assets: [{ assetId: asset.assetId, amount: BigInt(0) }],
         satoshis: 0,
       })
     } else {
-      setSendInfo({ ...sendInfo, assets: undefined, satoshis: 0 })
+      setSendInfo({ ...sendInfo, account: undefined, assets: undefined, satoshis: 0 })
     }
     setAmountTextValue('')
   }
@@ -697,7 +725,15 @@ export default function SendForm() {
   }
 
   const applySendAll = () => {
-    if (isAssetSend && selectedAsset) {
+    if (sendInfo.account) {
+      setSendInfo({
+        ...sendInfo,
+        account: { ...sendInfo.account, amount: sendInfo.account.balance },
+        assets: sendInfo.account.sources.map(({ assetId, balance }) => ({ assetId, amount: balance })),
+        satoshis: 0,
+      })
+      setAmountTextValue(centsToUnits(sendInfo.account.balance, sendInfo.account.decimals))
+    } else if (isAssetSend && selectedAsset) {
       const { assetId, balance, decimals } = selectedAsset
       const assets = [{ assetId, amount: balance }]
       setSendInfo({ ...sendInfo, assets, satoshis: 0 })
@@ -721,11 +757,11 @@ export default function SendForm() {
   }
 
   const Available = () => {
-    if (isAssetSend && selectedAsset) {
+    if (isAssetSend && activeAsset) {
       return (
         <div onClick={handleSendAll} style={{ cursor: 'pointer' }}>
           <Text color='neutral-500' smaller>
-            {`${prettyAssetAmount(selectedAsset.balance, selectedAsset.decimals)} ${selectedAsset.ticker} available`}
+            {`${prettyAssetAmount(activeAsset.balance, activeAsset.decimals)} ${activeAsset.ticker} available`}
           </Text>
         </div>
       )
@@ -748,11 +784,11 @@ export default function SendForm() {
 
   const { address, arkAddress, lnUrl, invoice, satoshis } = sendInfo
 
-  const assetAmt = sendInfo.assets?.[0]?.amount ?? BigInt(0)
+  const assetAmt = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
   const buttonDisabled = isAssetSend
     ? !(arkAddress && assetAmt > 0) ||
-      (selectedAsset ? assetAmt > selectedAsset.balance : true) ||
+      (activeAsset ? assetAmt > activeAsset.balance : true) ||
       Boolean(recipientError) ||
       aspInfo.unreachable ||
       tryingToSelfSend ||
@@ -770,9 +806,9 @@ export default function SendForm() {
       satoshis < 1 ||
       processing
 
-  const selectedAssetLabel = selectedAsset ? `${selectedAsset.name} (${selectedAsset.ticker})` : 'Bitcoin'
-  const selectedAssetBalance = selectedAsset
-    ? `${prettyAssetAmount(selectedAsset.balance, selectedAsset.decimals)} ${selectedAsset.ticker} available`
+  const selectedAssetLabel = activeAsset ? `${activeAsset.name} (${activeAsset.ticker})` : 'Bitcoin'
+  const selectedAssetBalance = activeAsset
+    ? `${prettyAssetAmount(activeAsset.balance, activeAsset.decimals)} ${activeAsset.ticker} available`
     : `${
         useFiat
           ? prettyFiatAmount(toFiat(liquidBalance), config.currency, { bitcoinUnit: config.unit })
@@ -783,7 +819,7 @@ export default function SendForm() {
   const sendOverlayStyle = { ...overlayStyle, position: 'fixed' as const, zIndex: 20 }
 
   const Keys = () => (
-    <Keyboard asset={selectedAsset ?? undefined} back={() => setKeys(false)} onSave={handleKeyboardAmountSave} />
+    <Keyboard asset={activeAsset ?? undefined} back={() => setKeys(false)} onSave={handleKeyboardAmountSave} />
   )
 
   if (keys && !amountIsReadOnly) {
@@ -935,7 +971,7 @@ export default function SendForm() {
                       data-testid='asset-selector'
                     >
                       <span className='send-asset-trigger__main'>
-                        <AssetIcon asset={selectedAsset} />
+                        <AssetIcon asset={activeAsset} />
                         <span className='send-asset-trigger__copy'>
                           <span className='send-asset-trigger__name'>{selectedAssetLabel}</span>
                           <span className='send-asset-trigger__balance'>{selectedAssetBalance}</span>
@@ -947,7 +983,7 @@ export default function SendForm() {
                     </DropdownMenuTrigger>
                     <DropdownMenuContent className='send-asset-menu' align='start' side='bottom' sideOffset={8}>
                       <FlexCol gap='0.25rem'>
-                        {selectedAsset ? (
+                        {activeAsset ? (
                           <DropdownMenuItem className='send-asset-option' onClick={() => handleSelectAsset(null)}>
                             <span className='send-asset-option__main'>
                               <AssetIcon asset={null} />
@@ -966,7 +1002,11 @@ export default function SendForm() {
                           </DropdownMenuItem>
                         ) : null}
                         {assetOptions
-                          .filter((asset) => asset.assetId !== selectedAsset?.assetId)
+                          .filter(
+                            (asset) =>
+                              asset.assetId !== activeAsset?.assetId &&
+                              !sendInfo.account?.sources.some((source) => source.assetId === asset.assetId),
+                          )
                           .map((asset) => (
                             <DropdownMenuItem
                               key={asset.assetId}
@@ -1007,7 +1047,7 @@ export default function SendForm() {
                   onChange={handleAmountChange}
                   min={lnUrlResponse?.minSendable}
                   max={lnUrlResponse?.maxSendable}
-                  asset={selectedAsset ?? undefined}
+                  asset={activeAsset ?? undefined}
                   focus={focus === 'amount' && !isMobileBrowser}
                 />
               </FlexCol>

--- a/src/screens/Wallet/Send/Success.tsx
+++ b/src/screens/Wallet/Send/Success.tsx
@@ -13,13 +13,13 @@ import Text from '../../../components/Text'
 import WalletSuccessSplash from '../../../components/WalletSuccessSplash'
 import SuccessIcon from '../../../icons/Success'
 import SpinnerIcon from '../../../icons/Spinner'
-import { prettyAmount, prettyFiatAmount } from '../../../lib/format'
+import { prettyAmount, prettyCurrencyAssetAmount, prettyFiatAmount } from '../../../lib/format'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 import { WalletContext } from '../../../providers/wallet'
 import { SwapsContext } from '../../../providers/swaps'
 import AssetCard from '../../../components/AssetCard'
-import { prettyAssetAmount } from '../../../lib/assets'
+import { walletAssetPresentation } from '../../../lib/accountAssets'
 import { consoleError } from '../../../lib/logs'
 import { BoltzSwap, BoltzSwapStatus, hasSubmarineStatusReached, isSubmarineFailedStatus } from '@arkade-os/boltz-swap'
 
@@ -56,9 +56,10 @@ export default function SendSuccess() {
   const isAssetSend = Boolean(sendInfo.assets?.length)
   const assetId = sendInfo.assets?.[0]?.assetId
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
-  const assetName = assetMeta?.metadata?.name ?? 'Unknown Asset'
-  const assetTicker = assetMeta?.metadata?.ticker ?? ''
-  const assetIcon = assetMeta?.metadata?.icon
+  const assetPresentation = walletAssetPresentation(assetMeta?.metadata, 'Unknown asset')
+  const assetName = assetPresentation.name
+  const assetTicker = assetPresentation.ticker
+  const assetIcon = assetPresentation.icon
   const assetAmountValue = sendInfo.assets?.[0]?.amount ?? BigInt(0)
   const assetDecimals = assetMeta?.metadata?.decimals ?? 8
 
@@ -121,7 +122,7 @@ export default function SendSuccess() {
 
   const totalSats = sendInfo.total ?? 0
   const displayAmount = isAssetSend
-    ? `${prettyAssetAmount(assetAmountValue, assetDecimals)} ${assetTicker}`
+    ? `${prettyCurrencyAssetAmount(assetAmountValue, assetDecimals, assetTicker)} ${assetTicker}`
     : useFiat
       ? prettyFiatAmount(toFiat(totalSats), config.currency, { bitcoinUnit: config.unit })
       : prettyAmount(totalSats)

--- a/src/screens/Wallet/Send/Success.tsx
+++ b/src/screens/Wallet/Send/Success.tsx
@@ -53,15 +53,17 @@ export default function SendSuccess() {
   const { navigate } = useContext(NavigationContext)
   const { getSwapHistory, swapManager } = useContext(SwapsContext)
 
-  const isAssetSend = Boolean(sendInfo.assets?.length)
-  const assetId = sendInfo.assets?.[0]?.assetId
+  const isAssetSend = Boolean(sendInfo.account || sendInfo.assets?.length)
+  const assetId = sendInfo.account?.assetId ?? sendInfo.assets?.[0]?.assetId
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
-  const assetPresentation = walletAssetPresentation(assetMeta?.metadata, 'Unknown asset')
+  const assetPresentation = sendInfo.account
+    ? { name: sendInfo.account.ticker, ticker: sendInfo.account.ticker }
+    : walletAssetPresentation(assetMeta?.metadata, 'Unknown asset')
   const assetName = assetPresentation.name
   const assetTicker = assetPresentation.ticker
   const assetIcon = assetPresentation.icon
-  const assetAmountValue = sendInfo.assets?.[0]?.amount ?? BigInt(0)
-  const assetDecimals = assetMeta?.metadata?.decimals ?? 8
+  const assetAmountValue = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
+  const assetDecimals = sendInfo.account?.decimals ?? assetMeta?.metadata?.decimals ?? 8
 
   // Lightning sends resolve optimistically once the swap is funded; track the
   // settlement happening in the background and reflect it live on screen.

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -5,7 +5,7 @@ import Button from '../../../components/Button'
 import Content from '../../../components/Content'
 import Header from '../../../components/Header'
 import Padded from '../../../components/Padded'
-import TokenLogo, { type TokenLogoTicker } from '../../../components/TokenLogo'
+import TokenLogo, { tokenLogoTickerForTicker } from '../../../components/TokenLogo'
 import WalletSuccessSplash from '../../../components/WalletSuccessSplash'
 import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '../../../components/ui/drawer'
 import ArrowUpDownIcon from '../../../icons/ArrowUpDown'
@@ -1148,14 +1148,6 @@ function formatAssetBalance(asset: SwapAsset): string {
   return `${prettyCurrencyAssetAmount(rawBalance, asset.decimals, asset.ticker)} ${asset.ticker}`
 }
 
-function getTokenLogoTicker(ticker: string | undefined): TokenLogoTicker | undefined {
-  const normalized = ticker?.trim().toUpperCase()
-  if (
-    normalized === 'BTC' ||
-    normalized === 'USD' ||
-    normalized === 'USDT' ||
-    normalized === 'USDC' ||
-    normalized === 'CHF'
-  )
-    return normalized
+function getTokenLogoTicker(ticker: string | undefined) {
+  return tokenLogoTickerForTicker(ticker)
 }

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -98,16 +98,14 @@ export default function Transaction() {
 
   if (!tx) return <></>
 
-  const accountValueSatoshis = tx.assets?.reduce<number | undefined>((total, asset) => {
+  const accountAssetValues = tx.assets?.map((asset) => {
     const metadata = assetMetadataCache.get(asset.assetId)?.metadata
-    const value = fiatAccountAssetSatoshis(
-      BigInt(asset.amount),
-      metadata?.decimals ?? 8,
-      metadata?.ticker,
-      fromFiatAmount,
-    )
-    return value === undefined ? total : (total ?? 0) + value
-  }, undefined)
+    return fiatAccountAssetSatoshis(BigInt(asset.amount), metadata?.decimals ?? 8, metadata?.ticker, fromFiatAmount)
+  })
+  const accountValueSatoshis =
+    accountAssetValues?.length && accountAssetValues.every((value) => value !== undefined)
+      ? accountAssetValues.reduce((total, value) => total + value, 0)
+      : undefined
 
   const status = expiredBoardingTx
     ? 'Expired'

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -26,10 +26,13 @@ import { LimitsContext } from '../../providers/limits'
 import { getInputsToSettle } from '../../lib/asp'
 import SwapTransactionSummary from '../../components/SwapTransactionSummary'
 import { formatSwapAssetAmount, swapStatusLabel } from '../../lib/swapDisplay'
+import { FiatContext } from '../../providers/fiat'
+import { fiatAccountAssetSatoshis } from '../../lib/accountAssets'
 
 export default function Transaction() {
   const { utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { txInfo } = useContext(FlowContext)
+  const { fromFiatAmount } = useContext(FiatContext)
   const { aspInfo, calcBestMarketHour } = useContext(AspContext)
   const { assetMetadataCache, settlePreconfirmed, vtxos, vtxoManager, wallet, svcWallet } = useContext(WalletContext)
 
@@ -95,6 +98,17 @@ export default function Transaction() {
 
   if (!tx) return <></>
 
+  const accountValueSatoshis = tx.assets?.reduce<number | undefined>((total, asset) => {
+    const metadata = assetMetadataCache.get(asset.assetId)?.metadata
+    const value = fiatAccountAssetSatoshis(
+      BigInt(asset.amount),
+      metadata?.decimals ?? 8,
+      metadata?.ticker,
+      fromFiatAmount,
+    )
+    return value === undefined ? total : (total ?? 0) + value
+  }, undefined)
+
   const status = expiredBoardingTx
     ? 'Expired'
     : unconfirmedBoardingTx
@@ -105,6 +119,9 @@ export default function Transaction() {
           ? 'Settled'
           : 'Preconfirmed'
 
+  const fees = tx.type === 'sent' ? defaultFee : 0
+  const accountTransferSatoshis = accountValueSatoshis === undefined ? undefined : Math.abs(accountValueSatoshis)
+  const transferSatoshis = accountTransferSatoshis ?? (tx.type === 'sent' ? tx.amount - defaultFee : tx.amount)
   const when = tx.createdAt ? prettyAgo(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed'
   const date = tx.createdAt ? prettyDate(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed'
   const txid = tx.boardingTxid || tx.redeemTxid || tx.roundTxid || ''
@@ -126,11 +143,11 @@ export default function Transaction() {
         assetId: tx.assets?.[0]?.assetId,
         date,
         direction: issuanceTx ? 'Issuance' : burnTx ? 'Burn' : tx.type === 'sent' ? 'Sent' : 'Received',
-        fees: tx.type === 'sent' ? defaultFee : 0,
+        fees,
         isOffchainTx: !tx.boardingTxid && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
-        satoshis: tx.type === 'sent' ? tx.amount - defaultFee : tx.amount,
+        satoshis: transferSatoshis,
         status,
-        total: tx.amount,
+        total: accountTransferSatoshis === undefined ? tx.amount : transferSatoshis + fees,
         txid,
         type: boardingTx ? 'Boarding' : 'Offchain',
         wallet,

--- a/src/test/components/transactions-list.test.tsx
+++ b/src/test/components/transactions-list.test.tsx
@@ -67,4 +67,60 @@ describe('TransactionsList', () => {
     expect(screen.queryByText(/67.89 BET/)).not.toBeInTheDocument()
     expect(container.querySelectorAll('.swap-route-icon__fallback')).toHaveLength(2)
   })
+
+  it('falls back to the transaction amount when any asset lacks account pricing', () => {
+    const tx: Tx = {
+      amount: 330,
+      boardingTxid: '',
+      createdAt: 1_700_000_000,
+      explorable: undefined,
+      preconfirmed: false,
+      redeemTxid: '',
+      roundTxid: 'mixed-asset-transaction',
+      settled: true,
+      type: 'received',
+      assets: [
+        { assetId: 'usdt-asset', amount: BigInt(10_000) },
+        { assetId: 'unknown-asset', amount: BigInt(50) },
+      ],
+    }
+    const fiatContextValue = {
+      ...mockFiatContextValue,
+      fromFiatAmount: (amount: number) => amount * 100,
+      toFiat: (satoshis?: number) => (satoshis ?? 0) / 100,
+    }
+    const walletContextValue = {
+      ...mockWalletContextValue,
+      txs: [tx],
+      assetMetadataCache: new Map([
+        [
+          'usdt-asset',
+          {
+            metadata: {
+              decimals: 2,
+              name: 'Tether USD',
+              ticker: 'USDT',
+            },
+          },
+        ],
+      ]),
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <ConfigContext.Provider value={mockConfigContextValue}>
+          <FiatContext.Provider value={fiatContextValue}>
+            <FlowContext.Provider value={mockFlowContextValue}>
+              <WalletContext.Provider value={walletContextValue as any}>
+                <TransactionsList mode='static' />
+              </WalletContext.Provider>
+            </FlowContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByText('€3.30')).toBeInTheDocument()
+    expect(screen.queryByText('€100.00')).not.toBeInTheDocument()
+  })
 })

--- a/src/test/hooks/usePortfolioFiat.test.tsx
+++ b/src/test/hooks/usePortfolioFiat.test.tsx
@@ -128,4 +128,38 @@ describe('usePortfolioFiat', () => {
     expect(result.current.totalFiat).toBe(7500)
     expect(result.current.totalSats).toBe(7500)
   })
+
+  it('presents DEPIX balances as a BRL account', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FiatContext.Provider
+        value={{
+          ...mockFiatContextValue,
+          fromFiatAmount: (amount: number, currency: Currencies) => (currency === Currencies.BRL ? amount * 500 : 0),
+          toFiat: (sats?: number) => sats ?? 0,
+        }}
+      >
+        <WalletContext.Provider
+          value={{
+            ...mockWalletContextValue,
+            assetBalances: [{ assetId: 'depix-asset', amount: BigInt(12_345) }],
+            assetMetadataCache: new Map([['depix-asset', assetDetails('DEPIX', 'Decentralized Pix')]]),
+          }}
+        >
+          {children}
+        </WalletContext.Provider>
+      </FiatContext.Provider>
+    )
+
+    const { result } = renderHook(() => usePortfolioFiat(), { wrapper })
+    const brlRow = result.current.rows.find((row) => row.assetId === 'account:brl')
+
+    expect(brlRow).toMatchObject({
+      name: 'BRL',
+      ticker: 'BRL',
+      balance: BigInt(12_345),
+      fiatCurrency: Currencies.BRL,
+      sourceAssetIds: ['depix-asset'],
+    })
+    expect(result.current.rows.some((row) => row.ticker === 'DEPIX')).toBe(false)
+  })
 })

--- a/src/test/hooks/usePortfolioFiat.test.tsx
+++ b/src/test/hooks/usePortfolioFiat.test.tsx
@@ -8,9 +8,9 @@ import { usePortfolioFiat } from '../../hooks/usePortfolioFiat'
 import { mockFiatContextValue, mockWalletContextValue } from '../screens/mocks'
 
 describe('usePortfolioFiat', () => {
-  const assetDetails = (ticker: string, name = ticker) => ({
+  const assetDetails = (ticker: string, name = ticker, decimals = 2) => ({
     metadata: {
-      decimals: 2,
+      decimals,
       name,
       ticker,
     },
@@ -90,6 +90,40 @@ describe('usePortfolioFiat', () => {
     expect(usdRow?.sourceAssetIds).toEqual(['usdt-asset', 'usdc-asset'])
     expect(result.current.totalFiat).toBe(18510)
     expect(result.current.totalSats).toBe(18510)
+  })
+
+  it('preserves combined sub-cent remainders across account assets', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FiatContext.Provider
+        value={{
+          ...mockFiatContextValue,
+          fromFiatAmount: (amount: number, currency: Currencies) => (currency === Currencies.BRL ? amount * 1000 : 0),
+          toFiat: (sats?: number) => sats ?? 0,
+        }}
+      >
+        <WalletContext.Provider
+          value={{
+            ...mockWalletContextValue,
+            assetBalances: [
+              { assetId: 'depix-a', amount: BigInt(5) },
+              { assetId: 'depix-b', amount: BigInt(5) },
+            ],
+            assetMetadataCache: new Map([
+              ['depix-a', assetDetails('DEPIX', 'DEPIX A', 3)],
+              ['depix-b', assetDetails('DEPIX', 'DEPIX B', 3)],
+            ]),
+          }}
+        >
+          {children}
+        </WalletContext.Provider>
+      </FiatContext.Provider>
+    )
+
+    const { result } = renderHook(() => usePortfolioFiat(), { wrapper })
+    const brlRow = result.current.rows.find((row) => row.assetId === 'account:brl')
+
+    expect(brlRow?.balance).toBe(BigInt(1))
+    expect(brlRow?.fiatAmount).toBe(10)
   })
 
   it('applies prototype asset balance deltas to fiat account rows', () => {

--- a/src/test/lib/accountAssets.test.ts
+++ b/src/test/lib/accountAssets.test.ts
@@ -1,7 +1,24 @@
 import { describe, expect, it } from 'vitest'
-import { walletAccountTicker, walletAssetPresentation } from '../../lib/accountAssets'
+import { accountChartColorToken, walletAccountTicker, walletAssetPresentation } from '../../lib/accountAssets'
 
 describe('wallet account asset presentation', () => {
+  it.each([
+    ['BTC', '--account-chart-btc'],
+    ['USD', '--account-chart-usd'],
+    ['CHF', '--account-chart-chf'],
+    ['BRL', '--account-chart-brl'],
+    ['CNY', '--account-chart-cny'],
+    ['EUR', '--account-chart-eur'],
+    ['GBP', '--account-chart-gbp'],
+    ['JPY', '--account-chart-jpy'],
+  ])('uses the %s flag identity color for account charts', (ticker, colorToken) => {
+    expect(accountChartColorToken(ticker)).toBe(colorToken)
+  })
+
+  it('uses the brand chart color for an unrecognized asset', () => {
+    expect(accountChartColorToken('OTHER')).toBe('--account-chart-default')
+  })
+
   it.each(['USD', 'USDT', 'USDC', 'AUSD'])('maps %s to USD', (ticker) => {
     expect(walletAccountTicker(ticker)).toBe('USD')
   })

--- a/src/test/lib/accountAssets.test.ts
+++ b/src/test/lib/accountAssets.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { walletAccountTicker, walletAssetPresentation } from '../../lib/accountAssets'
+
+describe('wallet account asset presentation', () => {
+  it.each(['USD', 'USDT', 'USDC', 'AUSD'])('maps %s to USD', (ticker) => {
+    expect(walletAccountTicker(ticker)).toBe('USD')
+  })
+
+  it.each(['BRL', 'DPIX', 'DEPIX'])('maps %s to BRL', (ticker) => {
+    expect(walletAccountTicker(ticker)).toBe('BRL')
+  })
+
+  it('removes issuer branding from wallet-facing metadata', () => {
+    expect(
+      walletAssetPresentation({
+        name: 'Tether USD',
+        ticker: 'USDT',
+        icon: 'https://issuer.example/tether.svg',
+      }),
+    ).toEqual({ name: 'USD', ticker: 'USD' })
+  })
+})

--- a/src/test/lib/accountAssets.test.ts
+++ b/src/test/lib/accountAssets.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { accountChartColorToken, walletAccountTicker, walletAssetPresentation } from '../../lib/accountAssets'
+import {
+  accountChartColorToken,
+  allocateFiatAccountAssets,
+  primaryFiatAccountSource,
+  walletAccountTicker,
+  walletAssetPresentation,
+} from '../../lib/accountAssets'
 
 describe('wallet account asset presentation', () => {
   it.each([
@@ -35,5 +41,26 @@ describe('wallet account asset presentation', () => {
         icon: 'https://issuer.example/tether.svg',
       }),
     ).toEqual({ name: 'USD', ticker: 'USD' })
+  })
+
+  it('allocates an account send across multiple backing assets', () => {
+    const sources = [
+      { assetId: 'usdt', balance: BigInt(6_000), decimals: 2 },
+      { assetId: 'usdc', balance: BigInt(4_000_000), decimals: 4 },
+    ]
+
+    expect(allocateFiatAccountAssets(BigInt(8_000), 2, sources)).toEqual([
+      { assetId: 'usdt', amount: BigInt(6_000) },
+      { assetId: 'usdc', amount: BigInt(200_000) },
+    ])
+  })
+
+  it('uses the largest backing balance as the default receive rail', () => {
+    const sources = [
+      { assetId: 'smaller', balance: BigInt(2_500), decimals: 2 },
+      { assetId: 'larger', balance: BigInt(5_000_000), decimals: 4 },
+    ]
+
+    expect(primaryFiatAccountSource(sources, 2)?.assetId).toBe('larger')
   })
 })

--- a/src/test/lib/accountAssets.test.ts
+++ b/src/test/lib/accountAssets.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   accountChartColorToken,
+  aggregateFiatAccountMinorUnits,
   allocateFiatAccountAssets,
   primaryFiatAccountSource,
   walletAccountTicker,
+  walletAssetLabel,
   walletAssetPresentation,
 } from '../../lib/accountAssets'
 
@@ -43,6 +45,12 @@ describe('wallet account asset presentation', () => {
     ).toEqual({ name: 'USD', ticker: 'USD' })
   })
 
+  it('uses the fallback asset name without empty ticker parentheses', () => {
+    const presentation = walletAssetPresentation(undefined, 'asset-id')
+
+    expect(walletAssetLabel(presentation)).toBe('asset-id')
+  })
+
   it('allocates an account send across multiple backing assets', () => {
     const sources = [
       { assetId: 'usdt', balance: BigInt(6_000), decimals: 2 },
@@ -53,6 +61,15 @@ describe('wallet account asset presentation', () => {
       { assetId: 'usdt', amount: BigInt(6_000) },
       { assetId: 'usdc', amount: BigInt(200_000) },
     ])
+  })
+
+  it('aggregates backing assets before reducing to account precision', () => {
+    const sources = [
+      { assetId: 'first', balance: BigInt(5), decimals: 3 },
+      { assetId: 'second', balance: BigInt(5), decimals: 3 },
+    ]
+
+    expect(aggregateFiatAccountMinorUnits(sources, 2)).toBe(BigInt(1))
   })
 
   it('uses the largest backing balance as the default receive rail', () => {

--- a/src/test/lib/format.test.ts
+++ b/src/test/lib/format.test.ts
@@ -65,12 +65,14 @@ describe('format utilities', () => {
     })
 
     it('should keep the trailing code for currencies without a symbol', () => {
+      expect(prettyFiatAmount(51506, Currencies.BRL)).toBe('51,506.00 BRL')
       expect(prettyFiatAmount(2500, Currencies.CHF)).toBe('2,500.00 CHF')
       expect(prettyFiatAmount(12345, Currencies.CNY)).toBe('12,345.00 CNY')
     })
 
     it('should format fiat currencies with their standard minor units', () => {
       const cases: [Currencies, string, string][] = [
+        [Currencies.BRL, '10.00 BRL', '10.80 BRL'],
         [Currencies.EUR, '€10.00', '€10.80'],
         [Currencies.USD, '$10.00', '$10.80'],
         [Currencies.CHF, '10.00 CHF', '10.80 CHF'],
@@ -182,6 +184,7 @@ describe('format utilities', () => {
     })
 
     it('should keep the trailing code when masking fiat without a symbol', () => {
+      expect(prettyFiatHide(100, Currencies.BRL)).toBe('········ BRL')
       expect(prettyFiatHide(100, Currencies.CHF)).toBe('········ CHF')
       expect(prettyFiatHide(100, Currencies.CNY)).toBe('········ CNY')
     })

--- a/src/test/screens/wallet/account-detail.test.tsx
+++ b/src/test/screens/wallet/account-detail.test.tsx
@@ -23,6 +23,7 @@ vi.mock('liveline', () => ({
 describe('Account detail screen', () => {
   it('shows a USD account without exposing its underlying USDT asset', async () => {
     const sourceAssetId = 'usdt-asset'
+    const secondSourceAssetId = 'usdc-asset'
     const navigate = vi.fn()
     const setSendInfo = vi.fn()
     const fetchMock = vi.fn()
@@ -39,7 +40,7 @@ describe('Account detail screen', () => {
           config: {
             ...mockConfigContextValue.config,
             currency: Currencies.USD,
-            importedAssets: [sourceAssetId],
+            importedAssets: [sourceAssetId, secondSourceAssetId],
           },
         }}
       >
@@ -56,7 +57,10 @@ describe('Account detail screen', () => {
                 value={
                   {
                     ...mockWalletContextValue,
-                    assetBalances: [{ assetId: sourceAssetId, amount: BigInt(10_000) }],
+                    assetBalances: [
+                      { assetId: sourceAssetId, amount: BigInt(10_000) },
+                      { assetId: secondSourceAssetId, amount: BigInt(5_000) },
+                    ],
                     assetMetadataCache: new Map([
                       [
                         sourceAssetId,
@@ -66,6 +70,17 @@ describe('Account detail screen', () => {
                             icon: 'https://issuer.example/tether.svg',
                             name: 'Tether USD',
                             ticker: 'USDT',
+                          },
+                        },
+                      ],
+                      [
+                        secondSourceAssetId,
+                        {
+                          metadata: {
+                            decimals: 2,
+                            icon: 'https://issuer.example/usdc.svg',
+                            name: 'USD Coin',
+                            ticker: 'USDC',
                           },
                         },
                       ],
@@ -90,11 +105,12 @@ describe('Account detail screen', () => {
 
     expect(screen.getByRole('heading', { name: 'USD' })).toBeInTheDocument()
     expect(screen.getByText('$1.00')).toBeInTheDocument()
-    expect(screen.getByText('100.00 USD')).toBeInTheDocument()
-    expect(screen.getByText('$100.00')).toBeInTheDocument()
+    expect(screen.getByText('150.00 USD')).toBeInTheDocument()
+    expect(screen.getByText('$150.00')).toBeInTheDocument()
     expect(screen.getByText('$25.00')).toBeInTheDocument()
     expect(screen.getByTestId('liveline-chart')).toBeInTheDocument()
     expect(screen.queryByText('USDT')).not.toBeInTheDocument()
+    expect(screen.queryByText('USDC')).not.toBeInTheDocument()
     expect(screen.queryByText('Tether USD')).not.toBeInTheDocument()
     expect(fetchMock).not.toHaveBeenCalled()
 
@@ -102,7 +118,18 @@ describe('Account detail screen', () => {
 
     await waitFor(() => {
       expect(setSendInfo).toHaveBeenCalledWith(
-        expect.objectContaining({ assets: [{ assetId: sourceAssetId, amount: BigInt(0) }] }),
+        expect.objectContaining({
+          account: expect.objectContaining({
+            assetId: 'account:usd',
+            amount: BigInt(0),
+            balance: BigInt(15_000),
+            ticker: 'USD',
+            sources: [
+              { assetId: sourceAssetId, balance: BigInt(10_000), decimals: 2 },
+              { assetId: secondSourceAssetId, balance: BigInt(5_000), decimals: 2 },
+            ],
+          }),
+        }),
       )
       expect(navigate).toHaveBeenCalledWith(Pages.SendForm)
     })

--- a/src/test/screens/wallet/account-detail.test.tsx
+++ b/src/test/screens/wallet/account-detail.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import AccountDetail from '../../../screens/Wallet/AccountDetail'
+import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import { FlowContext } from '../../../providers/flow'
+import { NavigationContext, Pages } from '../../../providers/navigation'
+import { WalletContext } from '../../../providers/wallet'
+import { Currencies } from '../../../lib/types'
+import {
+  mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockNavigationContextValue,
+  mockTxInfo,
+  mockWalletContextValue,
+} from '../mocks'
+
+vi.mock('liveline', () => ({
+  Liveline: () => <div data-testid='liveline-chart' />,
+}))
+
+describe('Account detail screen', () => {
+  it('shows a USD account without exposing its underlying USDT asset', async () => {
+    const sourceAssetId = 'usdt-asset'
+    const navigate = vi.fn()
+    const setSendInfo = vi.fn()
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn(() => ({ observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() })),
+    )
+
+    render(
+      <ConfigContext.Provider
+        value={{
+          ...mockConfigContextValue,
+          config: {
+            ...mockConfigContextValue.config,
+            currency: Currencies.USD,
+            importedAssets: [sourceAssetId],
+          },
+        }}
+      >
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <FlowContext.Provider
+            value={{
+              ...mockFlowContextValue,
+              assetInfo: { assetId: 'account:usd', supply: BigInt(0) },
+              setSendInfo,
+            }}
+          >
+            <NavigationContext.Provider value={{ ...mockNavigationContextValue, navigate }}>
+              <WalletContext.Provider
+                value={
+                  {
+                    ...mockWalletContextValue,
+                    assetBalances: [{ assetId: sourceAssetId, amount: BigInt(10_000) }],
+                    assetMetadataCache: new Map([
+                      [
+                        sourceAssetId,
+                        {
+                          metadata: {
+                            decimals: 2,
+                            icon: 'https://issuer.example/tether.svg',
+                            name: 'Tether USD',
+                            ticker: 'USDT',
+                          },
+                        },
+                      ],
+                    ]),
+                    txs: [
+                      {
+                        ...mockTxInfo,
+                        amount: 0,
+                        assets: [{ assetId: sourceAssetId, amount: BigInt(2_500) }],
+                      },
+                    ],
+                  } as any
+                }
+              >
+                <AccountDetail />
+              </WalletContext.Provider>
+            </NavigationContext.Provider>
+          </FlowContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'USD' })).toBeInTheDocument()
+    expect(screen.getByText('$1.00')).toBeInTheDocument()
+    expect(screen.getByText('100.00 USD')).toBeInTheDocument()
+    expect(screen.getByText('$100.00')).toBeInTheDocument()
+    expect(screen.getByTestId('liveline-chart')).toBeInTheDocument()
+    expect(screen.queryByText('USDT')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tether USD')).not.toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(setSendInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ assets: [{ assetId: sourceAssetId, amount: BigInt(0) }] }),
+      )
+      expect(navigate).toHaveBeenCalledWith(Pages.SendForm)
+    })
+  })
+})

--- a/src/test/screens/wallet/account-detail.test.tsx
+++ b/src/test/screens/wallet/account-detail.test.tsx
@@ -92,6 +92,7 @@ describe('Account detail screen', () => {
     expect(screen.getByText('$1.00')).toBeInTheDocument()
     expect(screen.getByText('100.00 USD')).toBeInTheDocument()
     expect(screen.getByText('$100.00')).toBeInTheDocument()
+    expect(screen.getByText('$25.00')).toBeInTheDocument()
     expect(screen.getByTestId('liveline-chart')).toBeInTheDocument()
     expect(screen.queryByText('USDT')).not.toBeInTheDocument()
     expect(screen.queryByText('Tether USD')).not.toBeInTheDocument()

--- a/src/test/screens/wallet/account-market-data.test.ts
+++ b/src/test/screens/wallet/account-market-data.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { buildCrossRatePoints } from '../../../lib/marketData'
+
+describe('account market data', () => {
+  it('derives fiat cross-rates only from time-aligned market observations', () => {
+    const points = buildCrossRatePoints(
+      [
+        { time: 1_000, value: 50_000 },
+        { time: 2_000, value: 51_000 },
+      ],
+      [
+        { time: 1_010, value: 250_000 },
+        { time: 2_010, value: 255_000 },
+      ],
+    )
+
+    expect(points).toEqual([
+      { time: 1_000, value: 5 },
+      { time: 2_000, value: 5 },
+    ])
+  })
+
+  it('does not combine observations from non-overlapping periods', () => {
+    const points = buildCrossRatePoints(
+      [
+        { time: 1_000, value: 50_000 },
+        { time: 2_000, value: 51_000 },
+      ],
+      [
+        { time: 20_000, value: 250_000 },
+        { time: 21_000, value: 255_000 },
+      ],
+    )
+
+    expect(points).toEqual([])
+  })
+})

--- a/src/test/screens/wallet/bitcoin-detail.test.tsx
+++ b/src/test/screens/wallet/bitcoin-detail.test.tsx
@@ -33,9 +33,11 @@ describe('Bitcoin detail screen', () => {
       vi.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
-          prices: [
-            [Date.now() - 3_600_000, 77_000],
-            [Date.now(), 78_000],
+          when: Date.now(),
+          from: 'bitcoin',
+          data: [
+            { time: Math.floor(Date.now() / 1000) - 3_600, value: 77_000 },
+            { time: Math.floor(Date.now() / 1000), value: 78_000 },
           ],
         }),
       }),
@@ -55,7 +57,9 @@ describe('Bitcoin detail screen', () => {
       </ConfigContext.Provider>,
     )
 
-    expect(screen.getByTestId('liveline-chart')).toHaveAttribute('data-paused', 'false')
+    await waitFor(() => {
+      expect(screen.getByTestId('liveline-chart')).toHaveAttribute('data-paused', 'false')
+    })
 
     const chart = container.querySelector('.asset-detail-chart')
     expect(chart).not.toBeNull()
@@ -180,5 +184,32 @@ describe('Bitcoin detail screen', () => {
     })
 
     expect(screen.queryByText('$40,000.00')).not.toBeInTheDocument()
+  })
+
+  it('shows an unavailable state instead of inventing chart data', async () => {
+    vi.stubGlobal('ResizeObserver', vi.fn())
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('feed unavailable')))
+
+    render(
+      <ConfigContext.Provider
+        value={{
+          ...mockConfigContextValue,
+          config: { ...mockConfigContextValue.config, currency: Currencies.CNY },
+        }}
+      >
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <FlowContext.Provider value={mockFlowContextValue}>
+            <NavigationContext.Provider value={mockNavigationContextValue}>
+              <WalletContext.Provider value={mockWalletContextValue}>
+                <BitcoinDetail />
+              </WalletContext.Provider>
+            </NavigationContext.Provider>
+          </FlowContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('Price history unavailable')).toBeInTheDocument())
+    expect(screen.queryByTestId('liveline-chart')).not.toBeInTheDocument()
   })
 })

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -23,7 +23,7 @@ describe('Wallet screen', () => {
     expect(screen.getByTestId('home-action-swap')).toBeEnabled()
     await user.click(screen.getByTestId('home-action-swap'))
     expect(navigate).toHaveBeenCalledWith(Pages.WalletSwap)
-    expect(screen.getByText('Assets')).toBeInTheDocument()
+    expect(screen.getByText('Accounts')).toBeInTheDocument()
     expect(screen.getByText('Bitcoin')).toBeInTheDocument()
     expect(screen.getByText('Recent activity')).toBeInTheDocument()
     expect(screen.getByText('Do more with your money')).toBeInTheDocument()

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -84,4 +84,38 @@ describe('Wallet screen', () => {
     expect(screen.getByText('CHF')).toBeInTheDocument()
     expect(screen.getByText('10.00 CHF')).toBeInTheDocument()
   })
+
+  it('keeps non-fiat assets on the asset administration detail screen', async () => {
+    const user = userEvent.setup()
+    const navigate = vi.fn()
+    const assetId = 'custom-asset'
+
+    render(
+      <NavigationContext.Provider value={{ ...mockNavigationContextValue, navigate }}>
+        <ConfigContext.Provider
+          value={{
+            ...mockConfigContextValue,
+            config: { ...mockConfigContextValue.config, importedAssets: [assetId] },
+          }}
+        >
+          <WalletContext.Provider
+            value={
+              {
+                ...mockWalletContextValue,
+                assetBalances: [{ assetId, amount: BigInt(1_000) }],
+                assetMetadataCache: new Map([
+                  [assetId, { metadata: { decimals: 2, name: 'Custom asset', ticker: 'TKN' } }],
+                ]),
+              } as any
+            }
+          >
+            <Wallet />
+          </WalletContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    await user.click(screen.getByTestId(/^asset-row-TKN-/))
+    expect(navigate).toHaveBeenCalledWith(Pages.AppAssetDetail)
+  })
 })

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -250,4 +250,51 @@ describe('Send screen', () => {
 
     await waitFor(() => expect(setSendInfo).toHaveBeenCalledWith(expect.objectContaining({ satoshis: 10000 })))
   })
+
+  it('splits an aggregated USD account send across its backing assets', async () => {
+    const setSendInfo = vi.fn()
+    const account = {
+      assetId: 'account:usd',
+      ticker: 'USD' as const,
+      balance: BigInt(10_000),
+      decimals: 2,
+      amount: BigInt(0),
+      sources: [
+        { assetId: 'usdt', balance: BigInt(6_000), decimals: 2 },
+        { assetId: 'usdc', balance: BigInt(4_000_000), decimals: 4 },
+      ],
+    }
+
+    renderSendForm({
+      flowContext: {
+        ...mockFlowContextValue,
+        sendInfo: { ...emptySendInfo, account },
+        setSendInfo,
+      },
+      walletContext: {
+        ...mockWalletContextValue,
+        svcWallet: {
+          ...mockSvcWallet,
+          getAddress: () => 'tark1mockoffchain',
+          getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+          getBalance: () => Promise.resolve({ available: 1_000_000 }),
+        } as any,
+      },
+    })
+
+    const amountInput = document.querySelector('input[name="send-amount"]') as HTMLInputElement
+    fireEvent.change(amountInput, { target: { value: '80' } })
+
+    await waitFor(() =>
+      expect(setSendInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({ amount: BigInt(8_000) }),
+          assets: [
+            { assetId: 'usdt', amount: BigInt(6_000) },
+            { assetId: 'usdc', amount: BigInt(200_000) },
+          ],
+        }),
+      ),
+    )
+  })
 })

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -113,7 +113,7 @@ describe('Wallet swap flow', () => {
     expect(setSwapFromAssetId).toHaveBeenCalledWith(undefined)
   })
 
-  it('keeps custom asset logos separate from the flexible asset copy', () => {
+  it('presents DEPIX as the BRL account without issuer branding', () => {
     const { container } = renderSwap(
       { swapFromAssetId: assetId, setSwapFromAssetId: vi.fn() },
       {
@@ -124,11 +124,14 @@ describe('Wallet swap flow', () => {
     )
 
     const assetHeader = container.querySelector('.swap-input-card__asset')
-    const logo = assetHeader?.querySelector('img')?.parentElement
+    const logo = assetHeader?.querySelector('svg')?.parentElement
 
     expect(logo).toHaveStyle({ width: '36px', height: '36px' })
     expect(logo).not.toHaveClass('swap-input-card__asset-copy')
     expect(assetHeader?.lastElementChild).toHaveClass('swap-input-card__asset-copy')
+    expect(assetHeader).toHaveTextContent('BRL')
+    expect(assetHeader).not.toHaveTextContent('DEPIX')
+    expect(assetHeader?.querySelector('img')).not.toBeInTheDocument()
   })
 
   it('explains that the review rate can update', async () => {

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -504,4 +504,59 @@ describe('Transaction screen', () => {
       expect(screen.queryByText('Tether USD')).not.toBeInTheDocument()
     },
   )
+
+  it('falls back to the transaction amount when a mixed asset cannot be valued as an account', () => {
+    const txInfo = {
+      ...mockTxInfo,
+      amount: 330,
+      assets: [
+        { assetId: 'usdt-asset', amount: BigInt(10_000) },
+        { assetId: 'unknown-asset', amount: BigInt(50) },
+      ],
+      type: 'received',
+    }
+    const walletContextValue = {
+      ...mockWalletContextValue,
+      txs: [txInfo],
+      assetMetadataCache: new Map([
+        [
+          'usdt-asset',
+          {
+            metadata: {
+              decimals: 2,
+              name: 'Tether USD',
+              ticker: 'USDT',
+            },
+          },
+        ],
+      ]),
+    }
+    const fiatContextValue = {
+      ...mockFiatContextValue,
+      fromFiatAmount: (amount: number) => amount * 100,
+      toFiat: (satoshis?: number) => (satoshis ?? 0) / 100,
+    }
+
+    render(
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={fiatContextValue}>
+          <NavigationContext.Provider value={mockNavigationContextValue}>
+            <AspContext.Provider value={mockAspContextValue}>
+              <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo }}>
+                <WalletContext.Provider value={walletContextValue as any}>
+                  <LimitsContext.Provider value={mockLimitsContextValue}>
+                    <Transaction />
+                  </LimitsContext.Provider>
+                </WalletContext.Provider>
+              </FlowContext.Provider>
+            </AspContext.Provider>
+          </NavigationContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    expect(screen.getByTestId('Amount')).toHaveTextContent('€3.30')
+    expect(screen.getByTestId('Total')).toHaveTextContent('€3.30')
+    expect(screen.queryByText('€100.00')).not.toBeInTheDocument()
+  })
 })

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -426,4 +426,82 @@ describe('Transaction screen', () => {
     expect(screen.getByText('USD to BRL')).toBeInTheDocument()
     expect(screen.queryByText(/USDT|DEPIX/)).not.toBeInTheDocument()
   })
+
+  it.each([
+    {
+      assetAmount: BigInt(10_000),
+      assetLabel: '100.00 USD',
+      direction: 'Received',
+      total: '$100.00',
+      type: 'received',
+    },
+    {
+      assetAmount: BigInt(-10_000),
+      assetLabel: '-100.00 USD',
+      direction: 'Sent',
+      total: '$100.00',
+      type: 'sent',
+    },
+  ])(
+    'values a $direction USD transaction from its absolute account amount instead of its bitcoin dust amount',
+    ({ assetAmount, assetLabel, direction, total, type }) => {
+      const assetId = 'usdt-asset'
+      const txInfo = {
+        ...mockTxInfo,
+        amount: 330,
+        assets: [{ assetId, amount: assetAmount }],
+        type,
+      }
+      const walletContextValue = {
+        ...mockWalletContextValue,
+        txs: [txInfo],
+        assetMetadataCache: new Map([
+          [
+            assetId,
+            {
+              metadata: {
+                decimals: 2,
+                name: 'Tether USD',
+                ticker: 'USDT',
+              },
+            },
+          ],
+        ]),
+      }
+      const fiatContextValue = {
+        ...mockFiatContextValue,
+        fromFiatAmount: (amount: number) => amount * 100,
+        toFiat: (satoshis?: number) => (satoshis ?? 0) / 100,
+      }
+
+      render(
+        <ConfigContext.Provider
+          value={{
+            ...mockConfigContextValue,
+            config: { ...mockConfigContextValue.config, currency: Currencies.USD },
+          }}
+        >
+          <FiatContext.Provider value={fiatContextValue}>
+            <NavigationContext.Provider value={mockNavigationContextValue}>
+              <AspContext.Provider value={mockAspContextValue}>
+                <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo }}>
+                  <WalletContext.Provider value={walletContextValue as any}>
+                    <LimitsContext.Provider value={mockLimitsContextValue}>
+                      <Transaction />
+                    </LimitsContext.Provider>
+                  </WalletContext.Provider>
+                </FlowContext.Provider>
+              </AspContext.Provider>
+            </NavigationContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>,
+      )
+
+      expect(screen.getByText(direction)).toBeInTheDocument()
+      expect(screen.getByText(assetLabel)).toBeInTheDocument()
+      expect(screen.getByTestId('Amount')).toHaveTextContent('$100.00')
+      expect(screen.getByTestId('Total')).toHaveTextContent(total)
+      expect(screen.queryByText('Tether USD')).not.toBeInTheDocument()
+    },
+  )
 })

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -396,4 +396,34 @@ describe('Transaction screen', () => {
     expect(screen.queryByText('123.45 ALP')).not.toBeInTheDocument()
     expect(screen.queryByText('67.89 BET')).not.toBeInTheDocument()
   })
+
+  it('hides issuer tickers in wallet-facing swap details', () => {
+    const txInfo = {
+      ...mockTxInfo,
+      type: 'swap',
+      isPrototype: true,
+      prototypeSwap: {
+        fromTicker: 'USDT',
+        toTicker: 'DEPIX',
+        status: 'completed' as const,
+      },
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <AspContext.Provider value={mockAspContextValue}>
+          <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo }}>
+            <WalletContext.Provider value={mockWalletContextValue}>
+              <LimitsContext.Provider value={mockLimitsContextValue}>
+                <Transaction />
+              </LimitsContext.Provider>
+            </WalletContext.Provider>
+          </FlowContext.Provider>
+        </AspContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByText('USD to BRL')).toBeInTheDocument()
+    expect(screen.queryByText(/USDT|DEPIX/)).not.toBeInTheDocument()
+  })
 })

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -75,6 +75,17 @@
   --yellow-900: #423810;
   --yellow-950: #221c08;
 
+  /* Account chart identity — exact primary colors from each currency flag. */
+  --account-chart-btc: var(--orange-500);
+  --account-chart-usd: #3c3b6e;
+  --account-chart-chf: #d52b1e;
+  --account-chart-brl: #009b3a;
+  --account-chart-cny: #de2910;
+  --account-chart-eur: #003399;
+  --account-chart-gbp: #012169;
+  --account-chart-jpy: #bc002d;
+  --account-chart-default: var(--purple-700);
+
   /* Convenience aliases (backward compat with existing code) */
   --purple: var(--purple-700);
   --purple10: color-mix(in srgb, var(--purple-700) 8%, transparent);


### PR DESCRIPTION
## Summary

- present USDT, USDC, and AUSD as a single wallet-facing USD account
- present DPIX and DEPIX as BRL with the Brazilian flag and BRL denomination support
- replace the wallet Assets section with Accounts while retaining raw issuer assets in Arkade Mint/admin surfaces
- route fiat accounts into the bitcoin-style detail experience with price, actions, real historical cross-rate charts, balance, value, and filtered activity
- value fiat activity and transaction details from asset amounts instead of bitcoin dust amounts
- display Brazilian real amounts with the ISO code `BRL`, never `R$`
- color supported account charts from the primary identity color of their currency flag

This is intentionally stacked on the head branch of draft PR #727 rather than `master`.

## Issue tracking

- Refs #759
- Refs #760
- Refs #763

These issues should be closed when this stack reaches the default branch; merging this PR into the non-default #727 branch will not close them automatically.

## Visual QA

Verified with a restored Mutinynet wallet containing bitcoin and 10,000 USD:

- account overview shows `51,502.00 BRL` and never `R$`
- USD detail shows a live USD/BRL cross-rate chart in US-flag navy (`#3c3b6e`)
- account balance, value, filtered activity, and transaction Amount/Total remain consistent
- desktop, laptop, tablet, and mobile widths have no horizontal overflow
- screenshots are included in the Codex task handoff

## Testing

- `bun run test -- --exclude src/test/screens/settings/delegates.test.tsx` — 347 passed, 3 skipped
- focused account/format/detail suite — 59 passed
- `bunx tsc --noEmit`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- browser console check — no errors
- independent Codex code review — approved
- `/simplify` — no changes required

The excluded delegates test is a pre-existing deterministic failure inherited from the #727 parent branch and is unrelated to this diff.

## Affected areas

- fiat currency formatting and conversion
- account aggregation and issuer abstraction
- wallet overview, send, receive, swap, activity, and transaction presentation
- account detail navigation, charting, holdings, and activity filtering
- account flags and chart identity tokens
- regression tests for formatting, chart colors, market data, account presentation, and transaction values


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Brazilian Real (BRL) support for currency selection, pricing, conversions, formatting, and account aggregation.
  * Added account detail views accessible from wallet account cards.
  * Improved wallet asset presentation with clearer names, tickers, icons, and currency-based chart colors.
  * Enhanced transaction and swap displays to show account-level fiat values and cleaner labels.
* **Bug Fixes**
  * Added clearer unavailable-price and price-history states.
  * Improved market chart handling and account-specific activity filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->