### PR TITLE
Filter coins locked to expired server signers from settlement

### DIFF
--- a/src/components/DeprecatedSignerBadge.tsx
+++ b/src/components/DeprecatedSignerBadge.tsx
@@ -1,0 +1,18 @@
+import { type SignerStatus } from '@arkade-os/sdk'
+import Text from './Text'
+
+export default function DeprecatedSignerBadge({ status }: { status: SignerStatus | null }) {
+  if (status === 'EXPIRED')
+    return (
+      <Text tiny color='red'>
+        deprecated signer · past cutoff
+      </Text>
+    )
+  if (status === 'MIGRATABLE' || status === 'DUE_NOW')
+    return (
+      <Text tiny color='orange'>
+        deprecated signer
+      </Text>
+    )
+  return null
+}

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -17,6 +17,7 @@ import { Addresses, Tx, Vtxo } from './types'
 import { AspInfo } from '../providers/asp'
 import { consoleError } from './logs'
 import { getConfirmedAndNotExpiredUtxos } from './utxo'
+import { buildSignerSet, partitionByExpiredSigner } from './signer'
 import * as Sentry from '@sentry/react'
 import { hex } from '@scure/base'
 import { toXOnlyHex } from './keys'
@@ -70,8 +71,24 @@ export const aspErrorText = (info: AspInfo, fallback: string): string =>
     ? 'Your wallet is outdated and needs to be updated to be compatible with the latest Arkade version.'
     : fallback
 
-export const collaborativeExit = async (wallet: IWallet, amount: number, address: string): Promise<string> => {
-  const vtxos = await wallet.getVtxos()
+// Error for coin selections that would only cover the target amount by
+// spending coins locked to an expired (past-cutoff) server signer, which arkd
+// refuses to cosign. Those coins renew automatically after they expire.
+const insufficientFundsError = (excluded: ExtendedVirtualCoin[]): Error =>
+  new Error(
+    excluded.length > 0
+      ? `Insufficient available funds: ${excluded.length} coin(s) are locked to an expired server signer ` +
+        'and will become available after they renew automatically'
+      : 'Insufficient funds',
+  )
+
+export const collaborativeExit = async (
+  wallet: IWallet,
+  amount: number,
+  address: string,
+  aspInfo?: AspInfo,
+): Promise<string> => {
+  const { keep: vtxos, excluded } = partitionByExpiredSigner(await wallet.getVtxos(), buildSignerSet(aspInfo))
   const selectedVtxos = []
   let selectedAmount = 0
 
@@ -81,7 +98,7 @@ export const collaborativeExit = async (wallet: IWallet, amount: number, address
     selectedAmount += vtxo.value
   }
 
-  if (selectedAmount < amount) throw new Error('Insufficient funds')
+  if (selectedAmount < amount) throw insufficientFundsError(excluded)
 
   const outputs = [{ address, amount: BigInt(amount) }]
 
@@ -103,6 +120,7 @@ export const collaborativeExit = async (wallet: IWallet, amount: number, address
       selectedAmount,
       changeAmount,
       selectedVtxos: serializeForSentry(selectedVtxos),
+      excludedCount: excluded.length,
     })
     throw error
   }
@@ -113,8 +131,9 @@ export const collaborativeExitWithFees = async (
   inputAmount: number,
   outputAmount: number,
   address: string,
+  aspInfo?: AspInfo,
 ): Promise<string> => {
-  const vtxos = await wallet.getVtxos()
+  const { keep: vtxos, excluded } = partitionByExpiredSigner(await wallet.getVtxos(), buildSignerSet(aspInfo))
   const selectedVtxos = []
   let selectedAmount = 0
 
@@ -127,7 +146,7 @@ export const collaborativeExitWithFees = async (
     selectedAmount += vtxo.value
   }
 
-  if (selectedAmount < inputAmount) throw new Error('Insufficient funds')
+  if (selectedAmount < inputAmount) throw insufficientFundsError(excluded)
 
   const outputs = [{ address, amount: BigInt(outputAmount) }]
 
@@ -150,6 +169,7 @@ export const collaborativeExitWithFees = async (
       selectedAmount,
       changeAmount,
       selectedVtxos: serializeForSentry(selectedVtxos),
+      excludedCount: excluded.length,
     })
     throw error
   }
@@ -277,10 +297,28 @@ export const getInputsToSettle = async (
   wallet: IWallet,
   vtxoManager: IVtxoManager,
   thresholdMs?: number,
-): Promise<{ inputs: ExtendedCoin[]; vtxos: ExtendedVirtualCoin[]; boardingUtxos: ExtendedCoin[] }> => {
-  const vtxos = thresholdMs ? await vtxoManager.getExpiringVtxos(thresholdMs) : []
-  const boardingUtxos = await getConfirmedAndNotExpiredUtxos(wallet)
-  return { inputs: [...boardingUtxos, ...vtxos], vtxos, boardingUtxos }
+  aspInfo?: AspInfo,
+): Promise<{
+  inputs: ExtendedCoin[]
+  vtxos: ExtendedVirtualCoin[]
+  boardingUtxos: ExtendedCoin[]
+  excluded: ExtendedCoin[]
+}> => {
+  const allVtxos = thresholdMs ? await vtxoManager.getExpiringVtxos(thresholdMs) : []
+  const allBoardingUtxos = await getConfirmedAndNotExpiredUtxos(wallet)
+  // A coin locked to a past-cutoff (EXPIRED) deprecated signer can't be
+  // cosigned and would make arkd reject the whole intent, so it must not be
+  // bundled with the cosignable ones. Excluded coins recover automatically
+  // after the server sweeps their batch at expiry.
+  const signerSet = buildSignerSet(aspInfo)
+  const { keep: vtxos, excluded: excludedVtxos } = partitionByExpiredSigner(allVtxos, signerSet)
+  const { keep: boardingUtxos, excluded: excludedUtxos } = partitionByExpiredSigner(allBoardingUtxos, signerSet)
+  return {
+    inputs: [...boardingUtxos, ...vtxos],
+    vtxos,
+    boardingUtxos,
+    excluded: [...excludedUtxos, ...excludedVtxos],
+  }
 }
 
 export const settleVtxos = async (
@@ -288,10 +326,18 @@ export const settleVtxos = async (
   vtxoManager: IVtxoManager,
   dustAmount: bigint,
   thresholdMs?: number,
+  aspInfo?: AspInfo,
 ): Promise<void> => {
-  const { inputs } = await getInputsToSettle(wallet, vtxoManager, thresholdMs)
+  const { inputs, excluded } = await getInputsToSettle(wallet, vtxoManager, thresholdMs, aspInfo)
 
-  if (inputs.length === 0) throw new Error('No UTXOs or VTXOs eligible to settle')
+  if (inputs.length === 0) {
+    throw new Error(
+      excluded.length > 0
+        ? `All ${excluded.length} eligible coin(s) are locked to an expired server signer; ` +
+          'they will renew automatically after they expire'
+        : 'No UTXOs or VTXOs eligible to settle',
+    )
+  }
 
   const amount = inputs.reduce((sum, input) => sum + input.value, 0)
 
@@ -312,6 +358,8 @@ export const settleVtxos = async (
       dustAmount: dustAmount.toString(),
       thresholdMs,
       inputs: serializeForSentry(inputs),
+      excludedCount: excluded.length,
+      excluded: serializeForSentry(excluded.map(({ txid, vout, value }) => ({ txid, vout, value }))),
     })
     throw error
   }
@@ -322,9 +370,10 @@ export const renewCoins = async (
   vtxoManager: IVtxoManager,
   dustAmount: bigint,
   thresholdMs?: number,
+  aspInfo?: AspInfo,
 ): Promise<void> => {
-  const { inputs } = await getInputsToSettle(wallet, vtxoManager, thresholdMs)
-  if (inputs.length > 0) await settleVtxos(wallet, vtxoManager, dustAmount, thresholdMs)
+  const { inputs } = await getInputsToSettle(wallet, vtxoManager, thresholdMs, aspInfo)
+  if (inputs.length > 0) await settleVtxos(wallet, vtxoManager, dustAmount, thresholdMs, aspInfo)
 }
 
 export const delegateVtxos = async (wallet: ServiceWorkerWallet): Promise<void> => {

--- a/src/lib/signer.ts
+++ b/src/lib/signer.ts
@@ -1,0 +1,151 @@
+import {
+  classifyAgainstSignerSet,
+  decodeTapscript,
+  MultisigTapscript,
+  signerSetFromInfo,
+  VtxoScript,
+  type SignerSet,
+  type SignerStatus,
+  type TapLeafScript,
+} from '@arkade-os/sdk'
+import { hex } from '@scure/base'
+import { AspInfo } from '../providers/asp'
+import { toXOnlyHex } from './keys'
+
+/**
+ * Minimal coin shape accepted by the helpers below, satisfied by
+ * ExtendedCoin, ExtendedVirtualCoin and Vtxo alike.
+ */
+export type SignerCoin = {
+  tapTree?: Uint8Array
+  forfeitTapLeafScript?: TapLeafScript
+}
+
+export type CoinSignerInfo = {
+  serverPubKey: string // x-only, 64 hex chars
+  status: SignerStatus | null // null when the signer set is unavailable
+}
+
+/**
+ * Trailing digits shown in the UI. The x-only tail is identical to the
+ * compressed-key tail arkd prints in INVALID_VTXO_SCRIPT errors, so users can
+ * match rows against server error messages.
+ */
+export const signerKeyTail = (xOnlyHex: string): string => xOnlyHex.slice(-8)
+
+/** Null-safe signer set builder (signerSetFromInfo throws on blank signerPubkey). */
+export const buildSignerSet = (aspInfo?: AspInfo | null): SignerSet | null => {
+  if (!aspInfo?.signerPubkey) return null
+  try {
+    return signerSetFromInfo(aspInfo)
+  } catch {
+    return null
+  }
+}
+
+// A TapLeafScript's second element is the raw script plus a trailing leaf
+// version byte (mirrors the SDK's internal scriptFromTapLeafScript).
+const scriptFromTapLeaf = (leaf: TapLeafScript): Uint8Array => leaf[1].subarray(0, leaf[1].length - 1)
+
+/**
+ * Collect x-only hex pubkeys from plain-multisig (forfeit-shaped) leaves.
+ * Primary source is the coin's own forfeitTapLeafScript — exactly the leaf
+ * whose server key must cosign a settle. Fallback: scan all tapTree leaves.
+ */
+const forfeitKeyLists = (coin: SignerCoin): string[][] => {
+  const lists: string[][] = []
+  const pushIfMultisig = (script: Uint8Array) => {
+    try {
+      const tapscript = decodeTapscript(script)
+      if (MultisigTapscript.is(tapscript)) {
+        lists.push(tapscript.params.pubkeys.map((pk) => toXOnlyHex(hex.encode(pk))))
+      }
+    } catch {
+      // non-ark or unparseable leaf — skip
+    }
+  }
+  if (coin.forfeitTapLeafScript) pushIfMultisig(scriptFromTapLeaf(coin.forfeitTapLeafScript))
+  if (lists.length === 0 && coin.tapTree) {
+    for (const script of VtxoScript.decode(coin.tapTree).scripts) pushIfMultisig(script)
+  }
+  return lists
+}
+
+/**
+ * Extract the server signer pubkey (x-only hex) embedded in a coin's script.
+ * Preference order: the key that classifies as a known (active or deprecated)
+ * signer, then any key that is not the user's own, then the last pubkey of the
+ * first forfeit leaf (DefaultVtxo encodes [user, server]).
+ * Returns null on any decode failure — never throws.
+ */
+export const extractServerPubKey = (
+  coin: SignerCoin,
+  signerSet?: SignerSet | null,
+  userPubKeyHex?: string,
+): string | null => {
+  try {
+    const lists = forfeitKeyLists(coin)
+    if (lists.length === 0) return null
+    const allKeys = lists.flat()
+    if (signerSet) {
+      for (const key of allKeys) {
+        try {
+          if (classifyAgainstSignerSet(key, signerSet).status !== 'UNKNOWN_SIGNER') return key
+        } catch {
+          // malformed key — keep looking
+        }
+      }
+    }
+    const userXOnly = userPubKeyHex ? toXOnlyHex(userPubKeyHex) : undefined
+    if (userXOnly) {
+      const notUser = allKeys.find((key) => key !== userXOnly)
+      if (notUser) return notUser
+    }
+    const first = lists[0]
+    return first[first.length - 1] ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract and classify a coin's embedded server signer against the operator's
+ * advertised signer set. Returns null when the key cannot be extracted;
+ * status is null when no signer set is available.
+ */
+export const classifyCoin = (
+  coin: SignerCoin,
+  signerSet: SignerSet | null,
+  userPubKeyHex?: string,
+): CoinSignerInfo | null => {
+  const serverPubKey = extractServerPubKey(coin, signerSet, userPubKeyHex)
+  if (!serverPubKey) return null
+  if (!signerSet) return { serverPubKey, status: null }
+  try {
+    return { serverPubKey, status: classifyAgainstSignerSet(serverPubKey, signerSet).status }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Split coins into cosignable vs excluded. Only EXPIRED (past-cutoff
+ * deprecated signer) coins are excluded: arkd refuses to cosign them, and the
+ * SDK recovers them automatically after the server sweeps their batch.
+ * MIGRATABLE/DUE_NOW coins can still be cosigned pre-cutoff and stay in;
+ * UNKNOWN_SIGNER stays in (fail-open). Without a signer set nothing is
+ * filtered, matching previous behavior.
+ */
+export const partitionByExpiredSigner = <T extends SignerCoin>(
+  coins: T[],
+  signerSet: SignerSet | null,
+): { keep: T[]; excluded: T[] } => {
+  if (!signerSet) return { keep: coins, excluded: [] }
+  const keep: T[] = []
+  const excluded: T[] = []
+  for (const coin of coins) {
+    if (classifyCoin(coin, signerSet)?.status === 'EXPIRED') excluded.push(coin)
+    else keep.push(coin)
+  }
+  return { keep, excluded }
+}

--- a/src/lib/signer.ts
+++ b/src/lib/signer.ts
@@ -1,12 +1,14 @@
 import {
   classifyAgainstSignerSet,
   decodeTapscript,
+  isRecoverable,
   MultisigTapscript,
   signerSetFromInfo,
   VtxoScript,
   type SignerSet,
   type SignerStatus,
   type TapLeafScript,
+  type VirtualCoin,
 } from '@arkade-os/sdk'
 import { hex } from '@scure/base'
 import { AspInfo } from '../providers/asp'
@@ -14,11 +16,14 @@ import { toXOnlyHex } from './keys'
 
 /**
  * Minimal coin shape accepted by the helpers below, satisfied by
- * ExtendedCoin, ExtendedVirtualCoin and Vtxo alike.
+ * ExtendedCoin, ExtendedVirtualCoin and Vtxo alike. The virtual-coin fields
+ * are optional because boarding utxos don't carry them.
  */
 export type SignerCoin = {
   tapTree?: Uint8Array
   forfeitTapLeafScript?: TapLeafScript
+  virtualStatus?: { state: string }
+  isSpent?: boolean
 }
 
 export type CoinSignerInfo = {
@@ -128,12 +133,18 @@ export const classifyCoin = (
   }
 }
 
+// A swept-but-unspent vtxo. Its recovery settle carries no forfeit and no
+// deprecated key, so it stays settleable even under an EXPIRED signer.
+const isRecoverableCoin = (coin: SignerCoin): boolean =>
+  Boolean(coin.virtualStatus) && isRecoverable(coin as VirtualCoin)
+
 /**
- * Split coins into cosignable vs excluded. Only EXPIRED (past-cutoff
- * deprecated signer) coins are excluded: arkd refuses to cosign them, and the
- * SDK recovers them automatically after the server sweeps their batch.
- * MIGRATABLE/DUE_NOW coins can still be cosigned pre-cutoff and stay in;
- * UNKNOWN_SIGNER stays in (fail-open). Without a signer set nothing is
+ * Split coins into settleable vs excluded. Excluded means EXPIRED (past-cutoff
+ * deprecated signer) and not yet swept: arkd refuses to cosign those, and they
+ * become recoverable once the server sweeps their batch at expiry. Swept
+ * (recoverable) coins stay in — their recovery settle needs no deprecated-key
+ * cosign. MIGRATABLE/DUE_NOW coins can still be cosigned pre-cutoff and stay
+ * in; UNKNOWN_SIGNER stays in (fail-open). Without a signer set nothing is
  * filtered, matching previous behavior.
  */
 export const partitionByExpiredSigner = <T extends SignerCoin>(
@@ -144,7 +155,7 @@ export const partitionByExpiredSigner = <T extends SignerCoin>(
   const keep: T[] = []
   const excluded: T[] = []
   for (const coin of coins) {
-    if (classifyCoin(coin, signerSet)?.status === 'EXPIRED') excluded.push(coin)
+    if (classifyCoin(coin, signerSet)?.status === 'EXPIRED' && !isRecoverableCoin(coin)) excluded.push(coin)
     else keep.push(coin)
   }
   return { keep, excluded }

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -838,7 +838,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
 
   const settlePreconfirmed = async () => {
     if (!svcWallet || !vtxoManager) throw new Error('Service worker not initialized')
-    await settleVtxos(svcWallet, vtxoManager, aspInfo.dust, wallet.thresholdMs)
+    await settleVtxos(svcWallet, vtxoManager, aspInfo.dust, wallet.thresholdMs, aspInfo)
     notifyTxSettled()
   }
 

--- a/src/screens/Apps/Lendasat/Index.tsx
+++ b/src/screens/Apps/Lendasat/Index.tsx
@@ -14,6 +14,7 @@ import { collaborativeExit, getReceivingAddresses } from '../../../lib/asp'
 import { Transaction } from '@arkade-os/sdk'
 import { isArkAddress, isBTCAddress } from '../../../lib/address'
 import { NavigationContext, Pages } from '@/providers/navigation'
+import { AspContext } from '../../../providers/asp'
 
 const { bytesToHex, hexToBytes } = utils
 
@@ -24,6 +25,7 @@ secp.hashes.hmacSha256 = (key, msg) => hmac(sha256, key, msg)
 export default function AppLendasat() {
   const { wallet, svcWallet } = useContext(WalletContext)
   const { navigate } = useContext(NavigationContext)
+  const { aspInfo } = useContext(AspContext)
 
   const [arkAddress, setArkAddress] = useState<string | null>(null)
   const [boardingAddress, setBoardingAddress] = useState<string | null>(null)
@@ -81,7 +83,7 @@ export default function AppLendasat() {
                   throw new Error('Unable to send bitcoin')
                 }
               } else if (isBTCAddress(address)) {
-                return await collaborativeExit(svcWallet, amount, address)
+                return await collaborativeExit(svcWallet, amount, address, aspInfo)
               } else {
                 throw Error(`Unsupported address ${address}`)
               }

--- a/src/screens/Apps/Satora/Index.tsx
+++ b/src/screens/Apps/Satora/Index.tsx
@@ -4,6 +4,7 @@ import Header from '../../../components/Header'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import { WalletContext } from '../../../providers/wallet'
+import { AspContext } from '../../../providers/asp'
 import { WalletProvider, type LoanAsset, AddressType } from '@lendasat/lendasat-wallet-bridge'
 import { collaborativeExit, getReceivingAddresses } from '../../../lib/asp'
 import { isArkAddress, isBTCAddress } from '../../../lib/address'
@@ -13,6 +14,7 @@ const DEFAULT_SWAP_PATH = '/arkade:BTC/polygon:USDC'
 
 export default function AppSatora() {
   const { svcWallet } = useContext(WalletContext)
+  const { aspInfo } = useContext(AspContext)
   const [arkAddress, setArkAddress] = useState<string | null>(null)
 
   const iframeRef = useRef<HTMLIFrameElement>(null)
@@ -85,7 +87,7 @@ export default function AppSatora() {
                   throw new Error('Unable to send bitcoin')
                 }
               } else if (isBTCAddress(address)) {
-                return await collaborativeExit(svcWallet, amount, address)
+                return await collaborativeExit(svcWallet, amount, address, aspInfo)
               } else {
                 throw Error(`Unsupported address ${address}`)
               }

--- a/src/screens/Settings/Contracts.tsx
+++ b/src/screens/Settings/Contracts.tsx
@@ -3,7 +3,6 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   Contract,
   encodeArkContract,
-  signerSetFromInfo,
   classifyAgainstSignerSet,
   type SignerSet,
   type SignerStatus,
@@ -32,6 +31,8 @@ import { copyToClipboard } from '../../lib/clipboard'
 import { hapticSubtle } from '../../lib/haptics'
 import { useToast } from '../../components/Toast'
 import { consoleError } from '../../lib/logs'
+import { buildSignerSet } from '../../lib/signer'
+import DeprecatedSignerBadge from '../../components/DeprecatedSignerBadge'
 
 // A boarding contract lives on-chain, so its `script` is a P2TR scriptPubKey
 // (OP_1 PUSH32 <x-only output key> = `5120<64 hex>`). Re-encode that witness
@@ -128,22 +129,6 @@ function CopyRow({ label, value, link }: { label: string; value: string; link?: 
   )
 }
 
-function DeprecatedSignerBadge({ status }: { status: SignerStatus | null }) {
-  if (status === 'EXPIRED')
-    return (
-      <Text tiny color='red'>
-        deprecated signer · past cutoff
-      </Text>
-    )
-  if (status === 'MIGRATABLE' || status === 'DUE_NOW')
-    return (
-      <Text tiny color='orange'>
-        deprecated signer
-      </Text>
-    )
-  return null
-}
-
 function Chip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
   return (
     <div
@@ -227,16 +212,7 @@ export default function Contracts() {
   const network = aspInfo?.network ?? ''
 
   // Build the operator's signer set once; each card classifies against it.
-  // Guard the empty/unreachable default — signerSetFromInfo throws on a blank
-  // signer pubkey.
-  const signerSet = useMemo<SignerSet | null>(() => {
-    if (!aspInfo?.signerPubkey) return null
-    try {
-      return signerSetFromInfo(aspInfo)
-    } catch {
-      return null
-    }
-  }, [aspInfo])
+  const signerSet = useMemo<SignerSet | null>(() => buildSignerSet(aspInfo), [aspInfo])
 
   useEffect(() => {
     if (!svcWallet) return

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useEffect, useState } from 'react'
+import { ReactNode, useContext, useEffect, useMemo, useState } from 'react'
 import Button from '../../components/Button'
 import ButtonsOnBottom from '../../components/ButtonsOnBottom'
 import Padded from '../../components/Padded'
@@ -27,6 +27,8 @@ import { consoleError } from '../../lib/logs'
 import * as Sentry from '@sentry/react'
 import Grid from '../../components/Grid'
 import { prettyAssetAmount } from '../../lib/assets'
+import { buildSignerSet, classifyCoin, signerKeyTail, CoinSignerInfo } from '../../lib/signer'
+import DeprecatedSignerBadge from '../../components/DeprecatedSignerBadge'
 
 export default function Vtxos() {
   const { aspInfo, calcBestMarketHour } = useContext(AspContext)
@@ -41,6 +43,7 @@ export default function Vtxos() {
   const [allVtxos, setAllVtxos] = useState<ExtendedVirtualCoin[]>([])
   const [duration, setDuration] = useState(0)
   const [error, setError] = useState('')
+  const [excludedCount, setExcludedCount] = useState(0)
   const [hasInputsToSettle, setHasInputsToSettle] = useState(false)
   const [hideUtxos, setHideUtxos] = useState(false)
   const [label, setLabel] = useState(defaultLabel)
@@ -52,6 +55,10 @@ export default function Vtxos() {
   const [success, setSuccess] = useState(false)
   const [hasVtxosToSettle, setHasVtxosToSettle] = useState(false)
   const [hasBoardingUtxosToSettle, setHasBoardingUtxosToSettle] = useState(false)
+
+  // The operator's advertised signer set; each coin row classifies its own
+  // embedded server key against it to flag deprecated signers.
+  const signerSet = useMemo(() => buildSignerSet(aspInfo), [aspInfo])
 
   // Update error state if aspInfo.unreachable changes
   useEffect(() => {
@@ -117,11 +124,17 @@ export default function Vtxos() {
     let cancelled = false
     const fetchInputs = async () => {
       try {
-        const { boardingUtxos, inputs, vtxos } = await getInputsToSettle(svcWallet, vtxoManager, wallet.thresholdMs)
+        const { boardingUtxos, inputs, vtxos, excluded } = await getInputsToSettle(
+          svcWallet,
+          vtxoManager,
+          wallet.thresholdMs,
+          aspInfo,
+        )
         if (cancelled) return
         setHasBoardingUtxosToSettle(boardingUtxos.length > 0)
         setHasInputsToSettle(inputs.length > 0)
         setHasVtxosToSettle(vtxos.length > 0)
+        setExcludedCount(excluded.length)
         const amount = inputs.reduce((a, v) => a + v.value, 0) || 0
         setAboveDust(amount > aspInfo.dust)
       } catch (err) {
@@ -150,7 +163,7 @@ export default function Vtxos() {
   const handleRollover = async () => {
     try {
       setRollingover(true)
-      await settleVtxos(svcWallet, vtxoManager, aspInfo.dust, wallet.thresholdMs)
+      await settleVtxos(svcWallet, vtxoManager, aspInfo.dust, wallet.thresholdMs, aspInfo)
       await reloadWallet()
       setRollingover(false)
       setSuccess(true)
@@ -209,11 +222,13 @@ export default function Vtxos() {
   const CoinLine = ({
     amount,
     assets,
+    signer,
     tags,
     expiry,
   }: {
     amount: string
     assets?: string[]
+    signer?: CoinSignerInfo | null
     tags: React.ReactNode
     expiry: string
   }) => {
@@ -236,6 +251,14 @@ export default function Vtxos() {
                     {a}
                   </Text>
                 ))}
+                {signer ? (
+                  <FlexRow gap='0.35rem'>
+                    <Text tiny color='neutral-500'>
+                      …{signerKeyTail(signer.serverPubKey)}
+                    </Text>
+                    <DeprecatedSignerBadge status={signer.status} />
+                  </FlexRow>
+                ) : null}
               </FlexCol>
             </div>
             <div>{tags}</div>
@@ -251,6 +274,7 @@ export default function Vtxos() {
   const VtxoLine = ({ vtxo }: { vtxo: Vtxo }) => {
     const now = Date.now()
     const expired = vtxo.virtualStatus?.batchExpiry ? now > vtxo.virtualStatus.batchExpiry : false
+    const signer = classifyCoin(vtxo, signerSet, wallet.pubkey)
     const satsAmount = config.showBalance ? prettyNumber(vtxo.value) : prettyHide(vtxo.value)
     const assetsAmounts = vtxo.assets?.length
       ? vtxo.assets.map((a) => {
@@ -274,11 +298,12 @@ export default function Vtxos() {
                 : null}
       </FlexRow>
     )
-    return <CoinLine amount={`${satsAmount} sats`} assets={assetsAmounts} tags={tags} expiry={expiry} />
+    return <CoinLine amount={`${satsAmount} sats`} assets={assetsAmounts} signer={signer} tags={tags} expiry={expiry} />
   }
 
   const UtxoLine = ({ utxo }: { utxo: ExtendedCoin }) => {
     const expiration = Number(aspInfo.boardingExitDelay)
+    const signer = classifyCoin(utxo, signerSet, wallet.pubkey)
     const amount = config.showBalance ? prettyNumber(utxo.value) : prettyHide(utxo.value)
     const expiry = utxo.status.block_time ? prettyAgo(utxo.status.block_time + expiration) : ''
     const tags = (
@@ -286,7 +311,7 @@ export default function Vtxos() {
         {!utxo.status.block_time ? Tags.unconfirmed : utxo.value < aspInfo.dust ? Tags.subdust : null}
       </FlexRow>
     )
-    return <CoinLine amount={`${amount} sats`} tags={tags} expiry={expiry} />
+    return <CoinLine amount={`${amount} sats`} signer={signer} tags={tags} expiry={expiry} />
   }
 
   return (
@@ -305,6 +330,11 @@ export default function Vtxos() {
               <Info color='purple' icon={<LoadingIcon small />} title='Renewing'>
                 <Text wrap>Renewing your virtual coins. This may take a few moments.</Text>
               </Info>
+            ) : null}
+            {excludedCount > 0 ? (
+              <WarningBox
+                text={`${excludedCount} coin${excludedCount > 1 ? 's were' : ' was'} skipped: locked to an expired server signer. They will be swept at expiry and recover to the new signer automatically — no action needed.`}
+              />
             ) : null}
             {listableVtxos.length + allUtxos.length === 0 ? (
               <EmptyCoinsList />

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -21,6 +21,7 @@ import { SwapsContext } from '../../../providers/swaps'
 import Text from '../../../components/Text'
 import { isPendingChainSwap, isPendingSubmarineSwap } from '@arkade-os/boltz-swap'
 import { FeesContext } from '../../../providers/fees'
+import { AspContext } from '../../../providers/asp'
 import { prettyAssetAmount } from '../../../lib/assets'
 
 export default function SendDetails() {
@@ -31,6 +32,7 @@ export default function SendDetails() {
   const { lnSwapsAllowed, utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { payInvoice, payBtc } = useContext(SwapsContext)
   const { assetMetadataCache, balance, svcWallet } = useContext(WalletContext)
+  const { aspInfo } = useContext(AspContext)
 
   const assetId = sendInfo.assets?.[0]?.assetId
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
@@ -161,7 +163,7 @@ export default function SendDetails() {
       } else {
         if (!details.total) return handleError('Missing total amount')
         if (!details.satoshis) return handleError('Missing satoshis amount')
-        collaborativeExitWithFees(svcWallet, details.total, details.satoshis, address)
+        collaborativeExitWithFees(svcWallet, details.total, details.satoshis, address, aspInfo)
           .then((txId: string) => handleTxid(txId))
           .catch(handleError)
       }

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -69,7 +69,7 @@ export default function Transaction() {
 
   useEffect(() => {
     if (!aspInfo || !svcWallet || !vtxoManager) return
-    getInputsToSettle(svcWallet, vtxoManager, wallet.thresholdMs).then(({ inputs }) => {
+    getInputsToSettle(svcWallet, vtxoManager, wallet.thresholdMs, aspInfo).then(({ inputs }) => {
       setHasInputsToSettle(inputs.length > 0)
       const totalAmount = inputs.reduce((a, v) => a + v.value, 0) || 0
       setAmountAboveDust(totalAmount > aspInfo.dust)

--- a/src/test/lib/aspSettle.test.ts
+++ b/src/test/lib/aspSettle.test.ts
@@ -46,6 +46,12 @@ const makeBoardingUtxo = (txid: string, value: number, serverPubKey: Uint8Array)
 const currentVtxo = makeVtxo('current-vtxo', 5000, activeServerKey)
 const expiredVtxo = makeVtxo('expired-vtxo', 7000, deprecatedServerKey)
 const expiredUtxo = makeBoardingUtxo('expired-utxo', 9000, deprecatedServerKey)
+// swept but unspent: recoverable, so settleable even under an expired signer
+const recoverableVtxo = {
+  ...makeVtxo('recoverable-vtxo', 3000, deprecatedServerKey),
+  virtualStatus: { state: 'swept' },
+  isSpent: false,
+}
 
 const makeWallet = () =>
   ({
@@ -70,6 +76,14 @@ describe('getInputsToSettle', () => {
     expect(inputs).toEqual([currentVtxo])
     expect(vtxos).toEqual([currentVtxo])
     expect(boardingUtxos).toEqual([])
+    expect(excluded).toEqual([expiredUtxo, expiredVtxo])
+  })
+
+  it('keeps recoverable (swept) coins under an expired signer in the batch', async () => {
+    const wallet = makeWallet()
+    const vtxoManager = makeVtxoManager([currentVtxo, expiredVtxo, recoverableVtxo])
+    const { inputs, excluded } = await getInputsToSettle(wallet, vtxoManager, 1000, aspInfo)
+    expect(inputs).toEqual([currentVtxo, recoverableVtxo])
     expect(excluded).toEqual([expiredUtxo, expiredVtxo])
   })
 
@@ -102,6 +116,16 @@ describe('settleVtxos', () => {
     expect(wallet.settle).toHaveBeenCalledTimes(1)
     expect(wallet.settle).toHaveBeenCalledWith(
       { inputs: [currentVtxo], outputs: [{ address: 'ark1qtest', amount: BigInt(5000) }] },
+      expect.any(Function),
+    )
+  })
+
+  it('includes recoverable expired-signer coins in the settled amount', async () => {
+    const wallet = makeWallet()
+    const vtxoManager = makeVtxoManager([currentVtxo, expiredVtxo, recoverableVtxo])
+    await settleVtxos(wallet, vtxoManager, BigInt(1000), 1000, aspInfo)
+    expect(wallet.settle).toHaveBeenCalledWith(
+      { inputs: [currentVtxo, recoverableVtxo], outputs: [{ address: 'ark1qtest', amount: BigInt(8000) }] },
       expect.any(Function),
     )
   })

--- a/src/test/lib/aspSettle.test.ts
+++ b/src/test/lib/aspSettle.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Keep the real SDK (real DefaultVtxo scripts exercise the signer extraction)
+// and only neutralize the boarding-expiry check, which needs a chain tip.
+vi.mock('@arkade-os/sdk', async (importOriginal) => {
+  const actual = (await importOriginal()) as any
+  return {
+    ...actual,
+    hasBoardingTxExpired: vi.fn(() => false),
+  }
+})
+
+import { DefaultVtxo } from '@arkade-os/sdk'
+import { hex } from '@scure/base'
+import { secp256k1 } from '@noble/curves/secp256k1.js'
+import { collaborativeExit, emptyAspInfo, getInputsToSettle, settleVtxos } from '../../lib/asp'
+
+const xOnlyKey = (fill: number) => secp256k1.getPublicKey(new Uint8Array(32).fill(fill), true).slice(1)
+const userKey = xOnlyKey(1)
+const activeServerKey = xOnlyKey(2)
+const deprecatedServerKey = xOnlyKey(3)
+
+const pastCutoff = BigInt(Math.floor(Date.now() / 1000) - 3600)
+
+const aspInfo = {
+  ...emptyAspInfo,
+  signerPubkey: '02' + hex.encode(activeServerKey),
+  deprecatedSigners: [{ pubkey: '02' + hex.encode(deprecatedServerKey), cutoffDate: pastCutoff }],
+}
+
+const makeScriptFields = (serverPubKey: Uint8Array) => {
+  const script = new DefaultVtxo.Script({
+    pubKey: userKey,
+    serverPubKey,
+    csvTimelock: { value: BigInt(144), type: 'blocks' },
+  })
+  return { tapTree: script.encode(), forfeitTapLeafScript: script.forfeit() }
+}
+
+const makeVtxo = (txid: string, value: number, serverPubKey: Uint8Array) =>
+  ({ txid, vout: 0, value, virtualStatus: { state: 'settled' }, ...makeScriptFields(serverPubKey) }) as any
+
+const makeBoardingUtxo = (txid: string, value: number, serverPubKey: Uint8Array) =>
+  ({ txid, vout: 0, value, status: { confirmed: true }, ...makeScriptFields(serverPubKey) }) as any
+
+const currentVtxo = makeVtxo('current-vtxo', 5000, activeServerKey)
+const expiredVtxo = makeVtxo('expired-vtxo', 7000, deprecatedServerKey)
+const expiredUtxo = makeBoardingUtxo('expired-utxo', 9000, deprecatedServerKey)
+
+const makeWallet = () =>
+  ({
+    getBoardingUtxos: vi.fn().mockResolvedValue([expiredUtxo]),
+    getVtxos: vi.fn().mockResolvedValue([expiredVtxo, currentVtxo]),
+    getAddress: vi.fn().mockResolvedValue('ark1qtest'),
+    getBoardingAddress: vi.fn().mockResolvedValue('bc1ptest'),
+    settle: vi.fn().mockResolvedValue('txid'),
+  }) as any
+
+const makeVtxoManager = (vtxos: any[]) => ({ getExpiringVtxos: vi.fn().mockResolvedValue(vtxos) }) as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getInputsToSettle', () => {
+  it('excludes coins locked to an expired deprecated signer when aspInfo is given', async () => {
+    const wallet = makeWallet()
+    const vtxoManager = makeVtxoManager([currentVtxo, expiredVtxo])
+    const { inputs, vtxos, boardingUtxos, excluded } = await getInputsToSettle(wallet, vtxoManager, 1000, aspInfo)
+    expect(inputs).toEqual([currentVtxo])
+    expect(vtxos).toEqual([currentVtxo])
+    expect(boardingUtxos).toEqual([])
+    expect(excluded).toEqual([expiredUtxo, expiredVtxo])
+  })
+
+  it('does not filter without aspInfo (backward compatible)', async () => {
+    const wallet = makeWallet()
+    const vtxoManager = makeVtxoManager([currentVtxo, expiredVtxo])
+    const { inputs, excluded } = await getInputsToSettle(wallet, vtxoManager, 1000)
+    expect(inputs).toEqual([expiredUtxo, currentVtxo, expiredVtxo])
+    expect(excluded).toEqual([])
+  })
+
+  it('does not filter deprecated signers before their cutoff', async () => {
+    const wallet = makeWallet()
+    const vtxoManager = makeVtxoManager([currentVtxo, expiredVtxo])
+    const migratableAspInfo = {
+      ...aspInfo,
+      deprecatedSigners: [{ pubkey: '02' + hex.encode(deprecatedServerKey), cutoffDate: pastCutoff + BigInt(7200) }],
+    }
+    const { inputs, excluded } = await getInputsToSettle(wallet, vtxoManager, 1000, migratableAspInfo)
+    expect(inputs).toEqual([expiredUtxo, currentVtxo, expiredVtxo])
+    expect(excluded).toEqual([])
+  })
+})
+
+describe('settleVtxos', () => {
+  it('settles only the cosignable inputs', async () => {
+    const wallet = makeWallet()
+    const vtxoManager = makeVtxoManager([currentVtxo, expiredVtxo])
+    await settleVtxos(wallet, vtxoManager, BigInt(1000), 1000, aspInfo)
+    expect(wallet.settle).toHaveBeenCalledTimes(1)
+    expect(wallet.settle).toHaveBeenCalledWith(
+      { inputs: [currentVtxo], outputs: [{ address: 'ark1qtest', amount: BigInt(5000) }] },
+      expect.any(Function),
+    )
+  })
+
+  it('throws a descriptive error when every coin is excluded', async () => {
+    const wallet = makeWallet()
+    const vtxoManager = makeVtxoManager([expiredVtxo])
+    await expect(settleVtxos(wallet, vtxoManager, BigInt(1000), 1000, aspInfo)).rejects.toThrow(
+      /2 eligible coin\(s\) are locked to an expired server signer/,
+    )
+    expect(wallet.settle).not.toHaveBeenCalled()
+  })
+
+  it('applies the dust check to the filtered amount', async () => {
+    const wallet = makeWallet()
+    const vtxoManager = makeVtxoManager([currentVtxo, expiredVtxo])
+    await expect(settleVtxos(wallet, vtxoManager, BigInt(6000), 1000, aspInfo)).rejects.toThrow(
+      'Total amount is below dust threshold',
+    )
+    expect(wallet.settle).not.toHaveBeenCalled()
+  })
+})
+
+describe('collaborativeExit', () => {
+  it('never selects coins locked to an expired deprecated signer', async () => {
+    const wallet = makeWallet()
+    await collaborativeExit(wallet, 5000, 'bc1pdest', aspInfo)
+    expect(wallet.settle).toHaveBeenCalledWith({
+      inputs: [currentVtxo],
+      outputs: [{ address: 'bc1pdest', amount: BigInt(5000) }],
+    })
+  })
+
+  it('explains insufficient funds caused by excluded coins', async () => {
+    const wallet = makeWallet()
+    await expect(collaborativeExit(wallet, 6000, 'bc1pdest', aspInfo)).rejects.toThrow(
+      /1 coin\(s\) are locked to an expired server signer/,
+    )
+  })
+
+  it('keeps the plain insufficient funds error without exclusions', async () => {
+    const wallet = makeWallet()
+    await expect(collaborativeExit(wallet, 20000, 'bc1pdest')).rejects.toThrow('Insufficient funds')
+  })
+})

--- a/src/test/lib/signer.test.ts
+++ b/src/test/lib/signer.test.ts
@@ -141,6 +141,31 @@ describe('partitionByExpiredSigner', () => {
     expect(excluded).toEqual([expiredCoin])
   })
 
+  it('keeps recoverable (swept) coins even under an expired signer', () => {
+    const recoverableCoin = {
+      ...makeCoin(deprecatedServerKey),
+      virtualStatus: { state: 'swept' },
+      isSpent: false,
+    }
+    const { keep, excluded } = partitionByExpiredSigner(
+      [recoverableCoin, expiredCoin],
+      buildSignerSet(makeAspInfo(pastCutoff)),
+    )
+    expect(keep).toEqual([recoverableCoin])
+    expect(excluded).toEqual([expiredCoin])
+  })
+
+  it('still excludes spent swept coins under an expired signer', () => {
+    const spentSweptCoin = {
+      ...makeCoin(deprecatedServerKey),
+      virtualStatus: { state: 'swept' },
+      isSpent: true,
+    }
+    const { keep, excluded } = partitionByExpiredSigner([spentSweptCoin], buildSignerSet(makeAspInfo(pastCutoff)))
+    expect(keep).toEqual([])
+    expect(excluded).toEqual([spentSweptCoin])
+  })
+
   it('keeps migratable (pre-cutoff) deprecated coins', () => {
     const { keep, excluded } = partitionByExpiredSigner(
       [currentCoin, expiredCoin],

--- a/src/test/lib/signer.test.ts
+++ b/src/test/lib/signer.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import { DefaultVtxo } from '@arkade-os/sdk'
+import { hex } from '@scure/base'
+import { secp256k1 } from '@noble/curves/secp256k1.js'
+import { emptyAspInfo } from '../../lib/asp'
+import {
+  buildSignerSet,
+  classifyCoin,
+  extractServerPubKey,
+  partitionByExpiredSigner,
+  signerKeyTail,
+  SignerCoin,
+} from '../../lib/signer'
+
+// x-only pubkeys must be valid curve points, so derive them from fixed privkeys
+const xOnlyKey = (fill: number) => secp256k1.getPublicKey(new Uint8Array(32).fill(fill), true).slice(1)
+const userKey = xOnlyKey(1)
+const activeServerKey = xOnlyKey(2)
+const deprecatedServerKey = xOnlyKey(3)
+
+const activeServerHex = hex.encode(activeServerKey)
+const deprecatedServerHex = hex.encode(deprecatedServerKey)
+
+const nowSeconds = Math.floor(Date.now() / 1000)
+const futureCutoff = BigInt(nowSeconds + 3600)
+const pastCutoff = BigInt(nowSeconds - 3600)
+
+const makeScript = (serverPubKey: Uint8Array) =>
+  new DefaultVtxo.Script({
+    pubKey: userKey,
+    serverPubKey,
+    csvTimelock: { value: BigInt(144), type: 'blocks' },
+  })
+
+const makeCoin = (serverPubKey: Uint8Array): SignerCoin => {
+  const script = makeScript(serverPubKey)
+  return { tapTree: script.encode(), forfeitTapLeafScript: script.forfeit() }
+}
+
+// arkd advertises compressed (33-byte) keys; the helpers must normalize.
+const makeAspInfo = (cutoffDate: bigint) => ({
+  ...emptyAspInfo,
+  signerPubkey: '02' + activeServerHex,
+  deprecatedSigners: [{ pubkey: '02' + deprecatedServerHex, cutoffDate }],
+})
+
+describe('signerKeyTail', () => {
+  it('returns the last 8 hex chars', () => {
+    expect(signerKeyTail(activeServerHex)).toBe(activeServerHex.slice(-8))
+    expect(signerKeyTail(activeServerHex)).toHaveLength(8)
+  })
+})
+
+describe('buildSignerSet', () => {
+  it('returns null on a blank signer pubkey', () => {
+    expect(buildSignerSet(emptyAspInfo)).toBeNull()
+    expect(buildSignerSet(undefined)).toBeNull()
+    expect(buildSignerSet(null)).toBeNull()
+  })
+
+  it('builds a set from a populated aspInfo', () => {
+    const set = buildSignerSet(makeAspInfo(futureCutoff))
+    expect(set?.active).toBe(activeServerHex)
+    expect(set?.deprecated.get(deprecatedServerHex)).toBe(futureCutoff)
+  })
+})
+
+describe('extractServerPubKey', () => {
+  const signerSet = buildSignerSet(makeAspInfo(futureCutoff))
+
+  it('extracts the server key from the forfeit tap leaf', () => {
+    const script = makeScript(activeServerKey)
+    const coin: SignerCoin = { forfeitTapLeafScript: script.forfeit() }
+    expect(extractServerPubKey(coin, signerSet)).toBe(activeServerHex)
+  })
+
+  it('extracts the server key from the tapTree when no forfeit leaf is present', () => {
+    const script = makeScript(deprecatedServerKey)
+    const coin: SignerCoin = { tapTree: script.encode() }
+    expect(extractServerPubKey(coin, signerSet)).toBe(deprecatedServerHex)
+  })
+
+  it('falls back to excluding the user key when the signer set is unavailable', () => {
+    const coin = makeCoin(activeServerKey)
+    // compressed user key exercises the toXOnlyHex normalization
+    expect(extractServerPubKey(coin, null, '03' + hex.encode(userKey))).toBe(activeServerHex)
+  })
+
+  it('falls back to the last forfeit pubkey without signer set or user key', () => {
+    const coin = makeCoin(activeServerKey)
+    expect(extractServerPubKey(coin, null)).toBe(activeServerHex)
+  })
+
+  it('returns null on garbage input without throwing', () => {
+    expect(extractServerPubKey({ tapTree: new Uint8Array([1, 2, 3]) })).toBeNull()
+    expect(extractServerPubKey({})).toBeNull()
+  })
+})
+
+describe('classifyCoin', () => {
+  it('classifies a coin under the active signer as CURRENT', () => {
+    const info = classifyCoin(makeCoin(activeServerKey), buildSignerSet(makeAspInfo(futureCutoff)))
+    expect(info).toEqual({ serverPubKey: activeServerHex, status: 'CURRENT' })
+  })
+
+  it('classifies a deprecated signer before its cutoff as MIGRATABLE', () => {
+    const info = classifyCoin(makeCoin(deprecatedServerKey), buildSignerSet(makeAspInfo(futureCutoff)))
+    expect(info?.status).toBe('MIGRATABLE')
+  })
+
+  it('classifies a deprecated signer without cutoff as DUE_NOW', () => {
+    const info = classifyCoin(makeCoin(deprecatedServerKey), buildSignerSet(makeAspInfo(BigInt(0))))
+    expect(info?.status).toBe('DUE_NOW')
+  })
+
+  it('classifies a deprecated signer past its cutoff as EXPIRED', () => {
+    const info = classifyCoin(makeCoin(deprecatedServerKey), buildSignerSet(makeAspInfo(pastCutoff)))
+    expect(info?.status).toBe('EXPIRED')
+  })
+
+  it('returns a null status when the signer set is unavailable', () => {
+    const info = classifyCoin(makeCoin(activeServerKey), null, '02' + hex.encode(userKey))
+    expect(info).toEqual({ serverPubKey: activeServerHex, status: null })
+  })
+
+  it('returns null when the key cannot be extracted', () => {
+    expect(classifyCoin({ tapTree: new Uint8Array([1, 2, 3]) }, buildSignerSet(makeAspInfo(pastCutoff)))).toBeNull()
+  })
+})
+
+describe('partitionByExpiredSigner', () => {
+  const currentCoin = makeCoin(activeServerKey)
+  const expiredCoin = makeCoin(deprecatedServerKey)
+
+  it('keeps current coins and excludes past-cutoff deprecated ones', () => {
+    const { keep, excluded } = partitionByExpiredSigner(
+      [currentCoin, expiredCoin],
+      buildSignerSet(makeAspInfo(pastCutoff)),
+    )
+    expect(keep).toEqual([currentCoin])
+    expect(excluded).toEqual([expiredCoin])
+  })
+
+  it('keeps migratable (pre-cutoff) deprecated coins', () => {
+    const { keep, excluded } = partitionByExpiredSigner(
+      [currentCoin, expiredCoin],
+      buildSignerSet(makeAspInfo(futureCutoff)),
+    )
+    expect(keep).toEqual([currentCoin, expiredCoin])
+    expect(excluded).toEqual([])
+  })
+
+  it('keeps coins whose key cannot be extracted (fail-open)', () => {
+    const undecodable = { tapTree: new Uint8Array([1, 2, 3]) }
+    const { keep, excluded } = partitionByExpiredSigner([undecodable], buildSignerSet(makeAspInfo(pastCutoff)))
+    expect(keep).toEqual([undecodable])
+    expect(excluded).toEqual([])
+  })
+
+  it('filters nothing without a signer set', () => {
+    const { keep, excluded } = partitionByExpiredSigner([currentCoin, expiredCoin], null)
+    expect(keep).toEqual([currentCoin, expiredCoin])
+    expect(excluded).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds filtering logic to prevent coins locked to expired (past-cutoff) deprecated server signers from being included in settlement transactions. These coins cannot be cosigned by the server and would cause the settlement to fail. Instead, they are excluded from the batch and will renew automatically after the server sweeps them at expiry.

## Key Changes

- **New `src/lib/signer.ts` module**: Provides utilities for extracting and classifying server signer keys embedded in coin scripts:
  - `extractServerPubKey()`: Extracts the server's x-only public key from a coin's tapscript, with fallback logic for missing signer sets
  - `classifyCoin()`: Classifies a coin's embedded signer against the operator's advertised signer set
  - `partitionByExpiredSigner()`: Splits coins into settleable vs excluded based on signer status
  - `buildSignerSet()`: Null-safe wrapper around SDK's `signerSetFromInfo()`
  - `signerKeyTail()`: Returns trailing 8 hex chars for UI display

- **Updated `src/lib/asp.ts`**:
  - `getInputsToSettle()`: Now filters coins and returns an `excluded` array; accepts optional `aspInfo` parameter
  - `settleVtxos()`: Passes `aspInfo` to filtering logic and provides descriptive error messages when all coins are excluded
  - `collaborativeExit()` and `collaborativeExitWithFees()`: Filter coins and provide context-aware error messages distinguishing between insufficient funds and funds locked to expired signers
  - Added `insufficientFundsError()` helper for consistent error messaging

- **UI updates**:
  - `src/screens/Settings/Vtxos.tsx`: Tracks excluded coin count and displays it in settlement UI
  - `src/screens/Settings/Contracts.tsx`: Uses new `buildSignerSet()` helper
  - `src/components/DeprecatedSignerBadge.tsx`: Extracted as reusable component for flagging deprecated signers
  - Updated app screens (`Lendasat`, `Satora`, `Send/Details`) to pass `aspInfo` to settlement functions

- **Comprehensive test coverage**:
  - `src/test/lib/signer.test.ts`: 190 lines testing all signer extraction and classification logic
  - `src/test/lib/aspSettle.test.ts`: 173 lines testing settlement filtering with various coin states (current, expired, recoverable, etc.)

## Implementation Details

- **Fail-open design**: Coins whose keys cannot be extracted are kept in the settlement batch rather than excluded, preventing accidental loss of funds
- **Recoverable coins**: Swept-but-unspent coins under expired signers remain settleable since their recovery settle requires no deprecated-key cosign
- **Backward compatibility**: Settlement functions work without `aspInfo` (no filtering applied), matching previous behavior
- **Error messaging**: Users receive clear explanations when insufficient funds are caused by expired-signer exclusions vs. actual lack of balance
- **Signer set memoization**: UI components memoize the signer set to avoid redundant parsing on each render

https://claude.ai/code/session_01Pd3dTmdfnBG2o5rzTN3hrG