### PR TITLE
fix: copy pnpm-workspace.yaml in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV VITE_ARK_SERVER=$VITE_ARK_SERVER \
 RUN corepack enable && corepack prepare pnpm@10.25.0 --activate
 
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .


### PR DESCRIPTION
Docker frozen install failed because pnpm-workspace.yaml (holding the overrides added in #783) wasn't copied into the build stage.