### PR TITLE
fix header glitch

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1287,11 +1287,14 @@ iframe {
   z-index: 50;
   background-color: var(--bg);
   isolation: isolate;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
   padding-top: env(safe-area-inset-top, 0px);
 }
 
 .home-header > div {
   z-index: 1;
+  background-color: inherit;
 }
 
 .home-header::after {


### PR DESCRIPTION
Actionable Findings
* Sticky Header Behaviour: The header (`.home-header`) is configured as `sticky`. As the user scrolls, elements from the `.home-stack` (including the Bitcoin logo in the asset list) move vertically and pass behind the header's coordinate space.
* Transparency Issue: While the outer header wrapper has a solid background color (`rgb(16, 16, 16)`), the inner container is transparent. If any child elements or margins of the header lack a solid background, scrolling content may become visible through gaps.
* Arkade Logo Content: The Arkade logo is an SVG contained within a `44x44px` flex container. It is positioned at `left: 254px`, which aligns closely with the Bitcoin logo's horizontal position at `left: 266px`.

Code Fixes
* Only CSS adjustments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual rendering of the home header, including more consistent background behavior and display across supported browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->