### PR TITLE
fix(assets): require verified identity for fiat metadata

### DIFF
--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -6,6 +6,7 @@ import { PrivacyAmount, maskedFiat } from './PrivacyAmount'
 import { prettyBitcoinAmount, prettyBitcoinHide, prettyCurrencyAssetAmount } from '../lib/format'
 import { useContext } from 'react'
 import { ConfigContext } from '../providers/config'
+import { WalletContext } from '../providers/wallet'
 
 interface AssetCardProps {
   assetId: string
@@ -36,6 +37,7 @@ export default function AssetCard({
   onClick,
 }: AssetCardProps) {
   const { config } = useContext(ConfigContext)
+  const { isAssetVerified } = useContext(WalletContext)
   const assetName = name || truncatedAssetId(assetId) || 'Asset'
   const tokenTick = ticker ?? 'TKN'
   const rawBalance =
@@ -45,7 +47,8 @@ export default function AssetCard({
         ? BigInt(balance)
         : BigInt(0)
   const bitcoinUnit = config.unit
-  const isBitcoin = tokenTick.toUpperCase() === 'BTC'
+  const isBitcoin = assetId === ''
+  const hasTrustedIdentity = isBitcoin || isAssetVerified(assetId)
   const prettyBalance = isBitcoin
     ? prettyBitcoinAmount(Number(rawBalance), bitcoinUnit)
     : prettyCurrencyAssetAmount(rawBalance, decimals ?? 8, tokenTick)
@@ -60,7 +63,7 @@ export default function AssetCard({
       }
     : undefined
 
-  const tokenLogoTicker = tokenLogoTickerForTicker(tokenTick)
+  const tokenLogoTicker = tokenLogoTickerForTicker(tokenTick, hasTrustedIdentity)
   const renderedAvatar = tokenLogoTicker ? (
     <span className='asset-card__logo' aria-hidden='true'>
       <TokenLogo ticker={tokenLogoTicker} />

--- a/src/components/TokenLogo.tsx
+++ b/src/components/TokenLogo.tsx
@@ -1,6 +1,10 @@
 export type TokenLogoTicker = 'BTC' | 'USD' | 'USDT' | 'USDC' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
 
-export function tokenLogoTickerForTicker(ticker: string | undefined): TokenLogoTicker | undefined {
+export function tokenLogoTickerForTicker(
+  ticker: string | undefined,
+  trustedIdentity: boolean,
+): TokenLogoTicker | undefined {
+  if (!trustedIdentity) return
   const normalized = ticker?.trim().toUpperCase()
   if (
     normalized === 'BTC' ||

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -41,7 +41,7 @@ const TransactionLine = ({
 }) => {
   const { config } = useContext(ConfigContext)
   const { toFiat } = useContext(FiatContext)
-  const { assetMetadataCache } = useContext(WalletContext)
+  const { assetMetadataCache, isAssetVerified } = useContext(WalletContext)
 
   const prefix = tx.type === 'sent' ? '-' : '+'
   const date = tx.createdAt ? prettyDate(tx.createdAt) : tx.boardingTxid ? 'Unconfirmed' : 'Unknown'
@@ -110,11 +110,17 @@ const TransactionLine = ({
           const ticker = accountInfo?.ticker ?? meta?.ticker
           const icon = meta?.icon
           const decimals = accountInfo?.decimals ?? meta?.decimals ?? 8
-          const accountTicker = accountTickerForAssetTicker(ticker)
+          const trustedIdentity = Boolean(accountInfo) || isAssetVerified(a.assetId)
+          const accountTicker = trustedIdentity ? accountTickerForAssetTicker(ticker) : undefined
           const label = accountInfo?.label ?? accountTicker ?? ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`
           return (
             <FlexRow key={a.assetId} gap='0.375rem' end>
-              <TransactionAssetAvatar icon={icon} ticker={accountTicker ?? ticker} assetId={a.assetId} />
+              <TransactionAssetAvatar
+                icon={icon}
+                ticker={accountTicker ?? ticker}
+                assetId={a.assetId}
+                trustedIdentity={trustedIdentity}
+              />
               <span className='activity-row__amount'>
                 <PrivacyAmount masked={prettyHide(a.amount, label)}>
                   {`${prettyCurrencyAssetAmount(a.amount, decimals, accountTicker ?? ticker)} ${label}`}
@@ -328,23 +334,30 @@ function matchesAssetFilter(tx: Tx, assetIdFilter?: string | string[]): boolean 
 }
 
 function SwapRouteIcon({ fromTicker, toTicker }: { fromTicker?: string; toTicker?: string }) {
-  const from = accountTickerForAssetTicker(fromTicker) ?? 'BTC'
-  const to = accountTickerForAssetTicker(toTicker) ?? 'USD'
-
   return (
     <span className='activity-swap-route-icon' aria-hidden='true'>
       <span>
-        <TokenLogo ticker={from} />
+        <AssetAvatar ticker={fromTicker} name='From asset' size={26} />
       </span>
       <span>
-        <TokenLogo ticker={to} />
+        <AssetAvatar ticker={toTicker} name='To asset' size={26} />
       </span>
     </span>
   )
 }
 
-function TransactionAssetAvatar({ assetId, icon, ticker }: { assetId: string; icon?: string; ticker?: string }) {
-  const tokenLogoTicker = tokenLogoTickerForTicker(accountTickerForAssetTicker(ticker) ?? ticker)
+function TransactionAssetAvatar({
+  assetId,
+  icon,
+  ticker,
+  trustedIdentity,
+}: {
+  assetId: string
+  icon?: string
+  ticker?: string
+  trustedIdentity: boolean
+}) {
+  const tokenLogoTicker = tokenLogoTickerForTicker(accountTickerForAssetTicker(ticker) ?? ticker, trustedIdentity)
   if (tokenLogoTicker) {
     return (
       <span className='transaction-asset-logo' aria-hidden='true'>

--- a/src/hooks/usePortfolioFiat.ts
+++ b/src/hooks/usePortfolioFiat.ts
@@ -31,12 +31,12 @@ export interface PortfolioFiat {
 }
 
 export function usePortfolioFiat(): PortfolioFiat {
-  const { assetBalances, assetMetadataCache, balance } = useContext(WalletContext)
+  const { assetBalances, assetMetadataCache, balance, isAssetVerified } = useContext(WalletContext)
   const { fromFiatAmount, toFiat } = useContext(FiatContext)
   const assetRows = assetBalances.map((asset) => {
     const meta = assetMetadataCache.get(asset.assetId)?.metadata
     const decimals = meta?.decimals ?? 8
-    const fiat = fiatForTicker(meta?.ticker)
+    const fiat = isAssetVerified(asset.assetId) ? fiatForTicker(meta?.ticker) : undefined
     const fiatAmount = fiat ? Decimal.div(asset.amount.toString(), Decimal.pow(10, decimals)).toNumber() : 0
     const satsEquivalent = fiat ? fromFiatAmount(fiatAmount, fiat) : 0
 

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext, useEffect, useRef, useState } from 'react'
+import { ReactNode, createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import {
   ArkNote,
   ServiceWorkerWallet,
@@ -100,6 +100,7 @@ interface WalletContextProps {
   assetMetadataCache: Map<string, CachedAssetDetails>
   setCacheEntry: (assetId: string, details: AssetDetails) => CachedAssetDetails
   iconApprovalManager: AssetIconApprovalManager
+  isAssetVerified: (assetId: string) => boolean
   dataReady: boolean
   loadError: string | null
   dismissLoadError: () => void
@@ -127,6 +128,7 @@ export const WalletContext = createContext<WalletContextProps>({
   assetMetadataCache: new Map(),
   setCacheEntry: () => ({ cachedAt: 0 }) as CachedAssetDetails,
   iconApprovalManager: new AssetIconApprovalManager(),
+  isAssetVerified: () => false,
   dataReady: false,
   loadError: null,
   dismissLoadError: () => {},
@@ -160,6 +162,8 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const hasLoadedOnce = useRef(false)
   const assetMetadataCache = useRef<Map<string, CachedAssetDetails>>(readAssetMetadataFromStorage() ?? new Map())
   const iconApprovalManager = useRef(new AssetIconApprovalManager()).current
+  const [verifiedAssetIds, setVerifiedAssetIds] = useState<Set<string>>(new Set())
+  const isAssetVerified = useCallback((assetId: string) => verifiedAssetIds.has(assetId), [verifiedAssetIds])
   const verifiedAssetsFetched = useRef(false)
   const statusPingInterval = useRef<ReturnType<typeof setInterval>>()
   const reloadTimerRef = useRef<ReturnType<typeof setTimeout>>()
@@ -364,6 +368,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
           throw new Error('Invalid verified assets response')
         }
         iconApprovalManager.setVerifiedAssets(data)
+        setVerifiedAssetIds(new Set(data))
       })
       .catch((err) => consoleError(err, 'Failed to fetch verified assets'))
   }, [initialized])
@@ -883,6 +888,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         assetMetadataCache: assetMetadataCache.current,
         setCacheEntry,
         iconApprovalManager,
+        isAssetVerified,
         dataReady,
         loadError,
         dismissLoadError,

--- a/src/screens/Settings/Fiat.tsx
+++ b/src/screens/Settings/Fiat.tsx
@@ -37,7 +37,7 @@ export default function Fiat() {
                   Currencies.USD,
                 ]}
                 renderStart={(currency) => {
-                  const ticker = tokenLogoTickerForTicker(currency)
+                  const ticker = tokenLogoTickerForTicker(currency, true)
                   return ticker ? <TokenLogo ticker={ticker} /> : null
                 }}
                 selected={config.currency}

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -49,7 +49,7 @@ import SheetModal from '../../../components/SheetModal'
 import { AnimatePresence, motion } from 'framer-motion'
 import { overlaySlideUp, overlayStyle } from '../../../lib/animations'
 import { useReducedMotion } from '../../../hooks/useReducedMotion'
-import TokenLogo, { TokenLogoTicker } from '../../../components/TokenLogo'
+import TokenLogo, { tokenLogoTickerForTicker } from '../../../components/TokenLogo'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -67,13 +67,9 @@ const brantaClient = new BrantaService({
 })
 
 function AssetIcon({ asset }: { asset: AssetOption | null }) {
+  const { isAssetVerified } = useContext(WalletContext)
   const ticker = asset?.ticker?.toUpperCase()
-  const tokenTicker =
-    ticker === 'USD' || ticker === 'USDT' || ticker === 'USDC' || ticker === 'CHF' || ticker === 'BRL'
-      ? (ticker as TokenLogoTicker)
-      : asset
-        ? null
-        : 'BTC'
+  const tokenTicker = asset ? tokenLogoTickerForTicker(ticker, isAssetVerified(asset.assetId)) : 'BTC'
 
   if (tokenTicker) {
     return (

--- a/src/screens/Wallet/Swap/Components.tsx
+++ b/src/screens/Wallet/Swap/Components.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'framer-motion'
-import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from 'react'
 import AssetAvatar from '../../../components/AssetAvatar'
 import Button from '../../../components/Button'
 import TokenLogo, { tokenLogoTickerForTicker } from '../../../components/TokenLogo'
@@ -14,6 +14,7 @@ import { useReducedMotion } from '../../../hooks/useReducedMotion'
 import FlexRow from '../../../components/FlexRow'
 import FlexCol from '../../../components/FlexCol'
 import Text, { TextSecondary } from '../../../components/Text'
+import { WalletContext } from '../../../providers/wallet'
 
 /** The wallet-wide asset row shape; the swap screens add nothing to it. */
 export type SwapAsset = AssetOption
@@ -122,8 +123,13 @@ function SwapAssetRow({ asset, active, onClick }: { asset: SwapAsset; active?: b
 }
 
 function TokenAvatar({ asset, size }: { asset: SwapAsset; size: number }) {
+  const { isAssetVerified } = useContext(WalletContext)
   // the btc row's ticker follows the display unit (sats/₿); the logo must not
-  const tokenLogoTicker = tokenLogoTickerForTicker(asset.assetId === BTC_ASSET_ID ? 'BTC' : asset.ticker)
+  const isBitcoin = asset.assetId === BTC_ASSET_ID
+  const tokenLogoTicker = tokenLogoTickerForTicker(
+    isBitcoin ? 'BTC' : asset.ticker,
+    isBitcoin || isAssetVerified(asset.assetId),
+  )
   // wrapped so the avatar keeps a fixed box regardless of the parent's flex rules
   return (
     <span className='swap-token-avatar' style={{ width: size, height: size }}>

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -29,7 +29,8 @@ export default function Transaction() {
   const { utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { txInfo } = useContext(FlowContext)
   const { aspInfo, calcBestMarketHour } = useContext(AspContext)
-  const { assetMetadataCache, settlePreconfirmed, vtxos, vtxoManager, wallet, svcWallet } = useContext(WalletContext)
+  const { assetMetadataCache, isAssetVerified, settlePreconfirmed, vtxos, vtxoManager, wallet, svcWallet } =
+    useContext(WalletContext)
 
   const tx = txInfo
   const issuanceTx = tx ? isIssuance(tx) : false
@@ -147,9 +148,10 @@ export default function Transaction() {
                 const name = meta?.name
                 const icon = meta?.icon
                 const decimals = meta?.decimals ?? 8
-                const accountTicker = accountTickerForAssetTicker(ticker)
+                const trustedIdentity = isAssetVerified(a.assetId)
+                const accountTicker = trustedIdentity ? accountTickerForAssetTicker(ticker) : undefined
                 const label = accountTicker ?? name ?? `${a.assetId.slice(0, 8)}...`
-                const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? ticker)
+                const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? ticker, trustedIdentity)
                 return (
                   <div key={a.assetId} className='transaction-detail-asset'>
                     <span className='transaction-detail-asset__logo'>

--- a/src/test/components/AssetCard.test.tsx
+++ b/src/test/components/AssetCard.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AssetCard from '../../components/AssetCard'
+import { ConfigContext } from '../../providers/config'
+import { FlowContext } from '../../providers/flow'
+import { NavigationContext } from '../../providers/navigation'
+import { WalletContext } from '../../providers/wallet'
+import {
+  mockConfigContextValue,
+  mockFlowContextValue,
+  mockNavigationContextValue,
+  mockWalletContextValue,
+} from '../screens/mocks'
+
+function renderAssetCard(isAssetVerified: (assetId: string) => boolean) {
+  return render(
+    <ConfigContext.Provider value={mockConfigContextValue}>
+      <WalletContext.Provider value={{ ...mockWalletContextValue, isAssetVerified }}>
+        <FlowContext.Provider value={mockFlowContextValue}>
+          <NavigationContext.Provider value={mockNavigationContextValue}>
+            <AssetCard assetId='spoofed-usdt' balance={BigInt(100_000)} decimals={2} name='Fake tether' ticker='USDT' />
+          </NavigationContext.Provider>
+        </FlowContext.Provider>
+      </WalletContext.Provider>
+    </ConfigContext.Provider>,
+  )
+}
+
+describe('AssetCard', () => {
+  it('does not infer a branded logo from an unverified asset ticker', () => {
+    const { container } = renderAssetCard(() => false)
+
+    expect(container.querySelector('.asset-card__logo')).not.toBeInTheDocument()
+    expect(container).toHaveTextContent('U')
+  })
+
+  it('shows the branded logo when the asset identity is verified', () => {
+    const { container } = renderAssetCard((assetId) => assetId === 'spoofed-usdt')
+
+    expect(container.querySelector('.asset-card__logo')).toBeInTheDocument()
+  })
+})

--- a/src/test/components/TransactionsList.test.tsx
+++ b/src/test/components/TransactionsList.test.tsx
@@ -1,0 +1,100 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import TransactionsList from '../../components/TransactionsList'
+import { ConfigContext } from '../../providers/config'
+import { FiatContext } from '../../providers/fiat'
+import { FlowContext } from '../../providers/flow'
+import { NavigationContext } from '../../providers/navigation'
+import { WalletContext } from '../../providers/wallet'
+import {
+  mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockNavigationContextValue,
+  mockTxId,
+  mockWalletContextValue,
+} from '../screens/mocks'
+
+describe('TransactionsList', () => {
+  it('does not infer a branded activity icon from an unverified asset ticker', () => {
+    const assetId = 'spoofed-eur'
+    const tx = {
+      amount: 0,
+      assets: [{ assetId, amount: BigInt(100_000) }],
+      boardingTxid: '',
+      createdAt: Math.floor(Date.now() / 1000),
+      explorable: mockTxId,
+      preconfirmed: false,
+      redeemTxid: mockTxId,
+      roundTxid: '',
+      settled: true,
+      type: 'received',
+    }
+    const { container } = render(
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <FlowContext.Provider value={mockFlowContextValue}>
+            <NavigationContext.Provider value={mockNavigationContextValue}>
+              <WalletContext.Provider
+                value={{
+                  ...mockWalletContextValue,
+                  txs: [tx],
+                  assetMetadataCache: new Map([
+                    [
+                      assetId,
+                      {
+                        assetId,
+                        supply: BigInt(100_000),
+                        cachedAt: Date.now(),
+                        metadata: { decimals: 2, name: 'Fake euros', ticker: 'EUR' },
+                      },
+                    ],
+                  ]),
+                }}
+              >
+                <TransactionsList mode='static' />
+              </WalletContext.Provider>
+            </NavigationContext.Provider>
+          </FlowContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    expect(container.querySelector('.transaction-asset-logo')).not.toBeInTheDocument()
+    expect(container.querySelector('.activity-row__amount')).toHaveTextContent('EUR')
+  })
+
+  it('does not infer branded swap-route icons from ticker strings', () => {
+    const tx = {
+      amount: 0,
+      boardingTxid: '',
+      createdAt: Math.floor(Date.now() / 1000),
+      explorable: mockTxId,
+      preconfirmed: false,
+      prototypeSwap: { fromTicker: 'EUR', toTicker: 'USD' },
+      redeemTxid: mockTxId,
+      roundTxid: '',
+      settled: true,
+      type: 'swap',
+    }
+    const { container } = render(
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <FlowContext.Provider value={mockFlowContextValue}>
+            <NavigationContext.Provider value={mockNavigationContextValue}>
+              <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [tx] }}>
+                <TransactionsList mode='static' />
+              </WalletContext.Provider>
+            </NavigationContext.Provider>
+          </FlowContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    const routeIcon = container.querySelector('.activity-swap-route-icon')
+    expect(routeIcon).toBeInTheDocument()
+    expect(routeIcon?.querySelector('svg')).not.toBeInTheDocument()
+    expect(routeIcon).toHaveTextContent('E')
+    expect(routeIcon).toHaveTextContent('U')
+  })
+})

--- a/src/test/hooks/usePortfolioFiat.test.tsx
+++ b/src/test/hooks/usePortfolioFiat.test.tsx
@@ -21,6 +21,7 @@ describe('usePortfolioFiat', () => {
           value={{
             ...mockWalletContextValue,
             balance: 1000,
+            isAssetVerified: (assetId: string) => assetId === 'chf-asset',
             assetBalances: [{ assetId: 'chf-asset', amount: BigInt(2000) }],
             assetMetadataCache: new Map([
               [
@@ -52,5 +53,47 @@ describe('usePortfolioFiat', () => {
     expect(chfRow?.hasFiatPrice).toBe(true)
     expect(result.current.totalFiat).toBe(41000)
     expect(result.current.totalSats).toBe(41000)
+  })
+
+  it('does not price an unverified asset from its self-declared ticker', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FiatContext.Provider
+        value={{
+          ...mockFiatContextValue,
+          fromFiatAmount: (amount: number) => amount * 2000,
+          toFiat: (sats?: number) => sats ?? 0,
+        }}
+      >
+        <WalletContext.Provider
+          value={{
+            ...mockWalletContextValue,
+            balance: 1000,
+            assetBalances: [{ assetId: 'spoofed-eur', amount: BigInt(100_000_000) }],
+            assetMetadataCache: new Map([
+              [
+                'spoofed-eur',
+                {
+                  metadata: { decimals: 2, name: 'Fake euros', ticker: 'EUR' },
+                  assetId: 'spoofed-eur',
+                  supply: BigInt(100_000_000),
+                  cachedAt: Date.now(),
+                },
+              ],
+            ]),
+          }}
+        >
+          {children}
+        </WalletContext.Provider>
+      </FiatContext.Provider>
+    )
+
+    const { result } = renderHook(() => usePortfolioFiat(), { wrapper })
+    const spoofedRow = result.current.rows.find((row) => row.assetId === 'spoofed-eur')
+
+    expect(spoofedRow?.hasFiatPrice).toBe(false)
+    expect(spoofedRow?.fiatAmount).toBe(0)
+    expect(spoofedRow?.satsEquivalent).toBe(0)
+    expect(result.current.totalFiat).toBe(1000)
+    expect(result.current.totalSats).toBe(1000)
   })
 })

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -167,6 +167,7 @@ export const mockWalletContextValue = {
   txs: [mockTxInfo],
   vtxos: { spendable: [], spent: [] },
   iconApprovalManager: new AssetIconApprovalManager(),
+  isAssetVerified: () => false,
   dataReady: false,
   loadError: null,
   dismissLoadError: () => {},


### PR DESCRIPTION
## Summary

- require a verified asset ID before mapping self-declared tickers to branded currency or token logos
- exclude unverified assets from fiat conversion and the portfolio total, preventing spoofed tickers from inflating wallet value
- apply the trust check consistently across asset cards, activity, transaction details, send, and swap surfaces
- render neutral letter avatars when swap history provides only ticker strings without a trustworthy asset identity
- add regression coverage for spoofed fiat and token tickers

## Security impact

Asset metadata is issuer-controlled. This change stops the wallet from treating ticker text as identity and instead requires the asset ID to be present in the verified-assets registry before applying branded presentation or fiat pricing.

Native bitcoin and app-owned synthetic currency accounts retain their expected logos because their identities are determined by the application rather than arbitrary asset metadata.

## Verification

- `VITE_DEV_MNEMONIC= bun run test --run src/test/hooks/usePortfolioFiat.test.tsx src/test/components/AssetCard.test.tsx src/test/components/TransactionsList.test.tsx src/test/screens/wallet/transaction.test.tsx src/test/screens/wallet/send.test.tsx src/test/screens/wallet/swap.test.tsx` — 28 tests passed
- `bun run lint` — passed
- `bun run build:worker` — passed
- `bunx vite build` — passed with the existing chunk-size and mixed mnemonic-import warnings
- independent code review — approved with no remaining findings
- Mutinynet manual verification in Arc Work: a newly minted `100,000,000.00 EUR` asset rendered with a neutral `E` avatar while the wallet total remained bitcoin-only

## Visual evidence

![Arc Work verification: unverified EUR asset uses a neutral avatar and does not affect the wallet total](https://github.com/user-attachments/assets/3ad6abfd-c315-476d-8304-86e8fda6753d)

Also documented in the [linked issue comment](https://github.com/arkade-os/wallet/issues/791#issuecomment-5004953150).

## Affected areas

- asset cards and token-logo selection
- verified-asset registry state in the wallet provider
- portfolio fiat conversion and total calculation
- activity rows and transaction details
- send and swap asset avatars
- regression tests and shared wallet mocks

Depends on #784

Closes #791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trusted-asset verification to token logos, avatars, transaction displays, sending, swapping, and portfolio pricing.
  * Unverified assets no longer receive branded logos or fiat pricing based solely on ticker names.
  * Bitcoin and verified assets continue to display supported logos and relevant pricing.

* **Tests**
  * Added coverage for verified and unverified asset branding, swap icons, and fiat pricing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->