### PR TITLE
feat(wallet): port PR 727 UI onto asset swaps

### DIFF
--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -14,7 +14,9 @@ import Table, { TableData } from './Table'
 import StatusIcon from '../icons/Status'
 import HashIcon from '../icons/Hash'
 import InfoIcon from '../icons/Info'
+import ArrowUpDownIcon from '../icons/ArrowUpDown'
 import { Wallet } from '../lib/types'
+import { SwapDisplayAmount } from '../lib/swapDisplay'
 import {
   openInNewTab,
   openOffchainTxInNewTab,
@@ -32,13 +34,17 @@ export interface DetailsProps {
   direction?: string
   expiry?: string
   fees?: number
+  feesLabel?: string
   invoice?: string
   isOffchainTx?: boolean
   satoshis?: number
   status?: string
+  swapFrom?: SwapDisplayAmount
   swapId?: string
+  swapTo?: SwapDisplayAmount
   total?: number
   txid?: string
+  txidLabel?: string
   type?: string
   wallet?: Wallet
   when?: string
@@ -59,12 +65,16 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     destination,
     expiry,
     fees,
+    feesLabel,
     invoice,
     isOffchainTx,
     satoshis,
     status,
+    swapFrom,
     swapId,
+    swapTo,
     txid,
+    txidLabel,
     type,
     total,
     wallet,
@@ -80,6 +90,11 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
         : prettyFiatHide(fiat, config.currency, { bitcoinUnit: config.unit })
     }
     return config.showBalance ? prettyBitcoinAmount(amount, config.unit) : prettyBitcoinHide(amount, config.unit)
+  }
+
+  const formatSensitiveDetail = (detail?: SwapDisplayAmount) => {
+    if (!detail) return undefined
+    return config.showBalance ? detail.value : detail.masked
   }
 
   // Only show explorer link if URL is available (e.g., mainnet for vmempool)
@@ -105,12 +120,14 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
       : undefined
 
   const data: TableData = [
+    ['From', formatSensitiveDetail(swapFrom), <ArrowUpDownIcon key='swap-from-icon' />],
+    ['To', formatSensitiveDetail(swapTo), <ArrowUpDownIcon key='swap-to-icon' />],
     ['Address', address, <TypeIcon key='address-icon' />],
     ['Arknote', arknote, <NotesIcon key='notes-icon' small />],
     ['Invoice', invoice, <TypeIcon key='invoice-icon' />],
     ['Swap ID', swapId, <InfoIcon key='swap-id-icon' />],
     ['Destination', destination, <TypeIcon key='destination-icon' />],
-    ['Transaction ID', txid, <HashIcon key='txid-icon' />, showTxidLink ? txidOnClick : undefined],
+    ['Transaction ID', txid || txidLabel, <HashIcon key='txid-icon' />, showTxidLink ? txidOnClick : undefined],
     ['Asset ID', assetId, <InfoIcon key='asset-id-icon' />, assetIdOnClick],
     ['Direction', direction, <DirectionIcon key='direction-icon' />],
     ['Type', type, <TypeIcon key='type-icon' />],
@@ -119,7 +136,7 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     ['Date', date, <DateIcon key='date-icon' />],
     ['Expiry', expiry, <DateIcon key='expiry-icon' />],
     ['Amount', formatAmount(satoshis), <AmountIcon key='amount-icon' />],
-    ['Network fees', formatAmount(fees), <FeesIcon key='fees-icon' />],
+    ['Network fees', fees === undefined ? feesLabel : formatAmount(fees), <FeesIcon key='fees-icon' />],
     ['Total', formatAmount(total), <TotalIcon key='total-icon' />],
   ]
 

--- a/src/components/SwapRouteIcon.tsx
+++ b/src/components/SwapRouteIcon.tsx
@@ -1,0 +1,39 @@
+import TokenLogo, { accountTickerForAssetTicker, tokenLogoTickerForTicker } from './TokenLogo'
+
+interface SwapRouteAsset {
+  assetId?: string
+  icon?: string
+  ticker?: string
+}
+
+interface SwapRouteIconProps {
+  from: SwapRouteAsset
+  size?: 'compact' | 'hero'
+  to: SwapRouteAsset
+}
+
+export default function SwapRouteIcon({ from, size = 'compact', to }: SwapRouteIconProps) {
+  return (
+    <span className={`swap-route-icon swap-route-icon--${size}`} aria-hidden='true'>
+      <SwapRouteAssetLogo asset={from} />
+      <SwapRouteAssetLogo asset={to} />
+    </span>
+  )
+}
+
+function SwapRouteAssetLogo({ asset }: { asset: SwapRouteAsset }) {
+  const accountTicker = accountTickerForAssetTicker(asset.ticker)
+  const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? asset.ticker)
+
+  return (
+    <span className='swap-route-icon__asset'>
+      {tokenLogoTicker ? (
+        <TokenLogo ticker={tokenLogoTicker} />
+      ) : asset.icon ? (
+        <img alt='' src={asset.icon} />
+      ) : (
+        <span className='swap-route-icon__fallback'>{asset.ticker?.trim().charAt(0).toUpperCase() || 'A'}</span>
+      )}
+    </span>
+  )
+}

--- a/src/components/SwapTransactionSummary.tsx
+++ b/src/components/SwapTransactionSummary.tsx
@@ -1,0 +1,48 @@
+import { useContext } from 'react'
+import { ConfigContext } from '../providers/config'
+import { FiatContext } from '../providers/fiat'
+import { Tx } from '../lib/types'
+import { swapRouteLabel, swapUnitOfAccountAmount } from '../lib/swapDisplay'
+import { PrivacyAmount } from './PrivacyAmount'
+import SwapRouteIcon from './SwapRouteIcon'
+
+interface SwapTransactionSummaryProps {
+  fromIcon?: string
+  toIcon?: string
+  tx: Tx
+}
+
+export default function SwapTransactionSummary({ fromIcon, toIcon, tx }: SwapTransactionSummaryProps) {
+  const { config } = useContext(ConfigContext)
+  const { fromFiatAmount, toFiatAmount } = useContext(FiatContext)
+  const swap = tx.assetSwap
+
+  if (!swap) return null
+
+  const amount = swapUnitOfAccountAmount({
+    bitcoinUnit: config.unit,
+    currency: config.currency,
+    fromFiatAmount,
+    toFiatAmount,
+    tx,
+  })
+
+  return (
+    <section className='swap-transaction-summary' aria-labelledby='swap-transaction-title'>
+      <SwapRouteIcon
+        from={{ assetId: swap.fromAssetId, icon: fromIcon, ticker: swap.fromTicker }}
+        size='hero'
+        to={{ assetId: swap.toAssetId, icon: toIcon, ticker: swap.toTicker }}
+      />
+      <div className='swap-transaction-summary__identity'>
+        <h2 id='swap-transaction-title'>Swap</h2>
+        <p>{swapRouteLabel(tx)}</p>
+      </div>
+      {amount ? (
+        <div className='swap-transaction-summary__amount'>
+          <PrivacyAmount masked={amount.masked}>{amount.value}</PrivacyAmount>
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/components/TokenLogo.tsx
+++ b/src/components/TokenLogo.tsx
@@ -1,3 +1,5 @@
+import { walletAccountTicker, type WalletAccountTicker } from '../lib/accountAssets'
+
 export type TokenLogoTicker = 'BTC' | 'USD' | 'USDT' | 'USDC' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
 
 export function tokenLogoTickerForTicker(ticker: string | undefined): TokenLogoTicker | undefined {
@@ -18,14 +20,8 @@ export function tokenLogoTickerForTicker(ticker: string | undefined): TokenLogoT
   }
 }
 
-export function accountTickerForAssetTicker(ticker: string | undefined): TokenLogoTicker | undefined {
-  const normalized = ticker?.trim().toUpperCase()
-  if (normalized === 'BTC') return 'BTC'
-  if (normalized === 'USD' || normalized === 'AUSD') return 'USD'
-  if (normalized === 'USDT') return 'USDT'
-  if (normalized === 'USDC') return 'USDC'
-  if (normalized === 'CHF') return 'CHF'
-  if (normalized === 'BRL' || normalized === 'DPIX' || normalized === 'DEPIX') return 'BRL'
+export function accountTickerForAssetTicker(ticker: string | undefined): WalletAccountTicker | undefined {
+  return walletAccountTicker(ticker)
 }
 
 export default function TokenLogo({ ticker }: { ticker: TokenLogoTicker }) {

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -1,7 +1,7 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useContext, useRef } from 'react'
 import { WalletContext } from '../providers/wallet'
-import { Currencies, Tx } from '../lib/types'
+import { Currencies, Tx, Unit } from '../lib/types'
 import {
   isBurn,
   isIssuance,
@@ -25,6 +25,12 @@ import Focusable from './Focusable'
 import { hapticSubtle } from '../lib/haptics'
 import TokenLogo, { accountTickerForAssetTicker, tokenLogoTickerForTicker, type TokenLogoTicker } from './TokenLogo'
 import { PrivacyAmount } from './PrivacyAmount'
+import SwapRouteIcon from './SwapRouteIcon'
+import { swapRouteLabel, swapStatusForTx, swapStatusLabel, swapUnitOfAccountAmount } from '../lib/swapDisplay'
+import { designatedAccountCurrency, fiatAccountAssetSatoshis } from '../lib/accountAssets'
+import { fiatDecimalsFor } from '../lib/fiat'
+import { AspContext } from '../providers/asp'
+import { AssetsContext } from '../providers/assets'
 
 const border = '1px solid color-mix(in srgb, var(--fg) 6%, transparent)'
 
@@ -40,19 +46,36 @@ const TransactionLine = ({
   mode: 'virtual' | 'static'
 }) => {
   const { config } = useContext(ConfigContext)
-  const { toFiat } = useContext(FiatContext)
+  const { fromFiatAmount, toFiat, toFiatAmount } = useContext(FiatContext)
   const { assetMetadataCache } = useContext(WalletContext)
+  const { aspInfo } = useContext(AspContext)
+  const { isRegistered } = useContext(AssetsContext)
 
   const prefix = tx.type === 'sent' ? '-' : '+'
   const date = tx.createdAt ? prettyDate(tx.createdAt) : tx.boardingTxid ? 'Unconfirmed' : 'Unknown'
   const asAssets = Boolean(tx.assets?.length)
   const swap = tx.type === 'swap'
+  const swapStatus = swap ? swapStatusForTx(tx) : undefined
   const issuance = isIssuance(tx)
   const burn = isBurn(tx)
+  const accountAssetValues = tx.assets?.map((asset) => {
+    const accountInfo = accountInfoForAssetId(asset.assetId, aspInfo.network, isRegistered)
+    const metadata = assetMetadataCache.get(asset.assetId)?.metadata
+    return fiatAccountAssetSatoshis(
+      BigInt(asset.amount),
+      accountInfo?.decimals ?? metadata?.decimals ?? 8,
+      accountInfo?.ticker ?? metadata?.ticker,
+      fromFiatAmount,
+    )
+  })
+  const accountValueSatoshis =
+    accountAssetValues?.length && accountAssetValues.every((value) => value !== undefined)
+      ? accountAssetValues.reduce((total, value) => total + value, 0)
+      : undefined
 
   const Currency = () => {
     if (issuance || burn || swap) return null
-    const value = toFiat(tx.amount)
+    const value = toFiat(accountValueSatoshis ?? tx.amount)
     const statusClassName = tx.boardingTxid && tx.preconfirmed ? ' activity-row__amount--pending' : ''
     const secondaryClassName = asAssets ? ' activity-row__amount--secondary' : ''
     return (
@@ -64,10 +87,30 @@ const TransactionLine = ({
     )
   }
 
-  const iconTone = tx.preconfirmed && tx.boardingTxid ? 'pending' : burn ? 'burn' : swap ? 'pending' : 'default'
+  const iconTone =
+    tx.preconfirmed && tx.boardingTxid
+      ? 'pending'
+      : burn || swapStatus === 'failed' || swapStatus === 'cancelled'
+        ? 'burn'
+        : swapStatus === 'pending'
+          ? 'pending'
+          : 'default'
   const Icon = () => {
     const icon = swap ? (
-      <SwapRouteIcon fromTicker={tx.prototypeSwap?.fromTicker} toTicker={tx.prototypeSwap?.toTicker} />
+      <SwapRouteIcon
+        from={{
+          assetId: tx.assetSwap?.fromAssetId,
+          icon: tx.assetSwap?.fromAssetId
+            ? assetMetadataCache.get(tx.assetSwap.fromAssetId)?.metadata?.icon
+            : undefined,
+          ticker: tx.assetSwap?.fromTicker,
+        }}
+        to={{
+          assetId: tx.assetSwap?.toAssetId,
+          icon: tx.assetSwap?.toAssetId ? assetMetadataCache.get(tx.assetSwap.toAssetId)?.metadata?.icon : undefined,
+          ticker: tx.assetSwap?.toTicker,
+        }}
+      />
     ) : issuance ? (
       <ReceivedIcon />
     ) : burn ? (
@@ -82,10 +125,27 @@ const TransactionLine = ({
     return <span className={`activity-row__icon activity-row__icon--${iconTone}`}>{icon}</span>
   }
 
-  const kind = swap ? 'Swap' : issuance ? 'Issuance' : burn ? 'Burn' : tx.type === 'sent' ? 'Sent' : 'Received'
+  const kind = swap
+    ? swapStatus === 'pending'
+      ? 'Swap pending'
+      : swapStatus === 'failed'
+        ? 'Swap failed'
+        : swapStatus === 'cancelled'
+          ? 'Swap cancelled'
+          : swapStatus === 'recoverable'
+            ? 'Swap recoverable'
+            : 'Swap'
+    : issuance
+      ? 'Issuance'
+      : burn
+        ? 'Burn'
+        : tx.type === 'sent'
+          ? 'Sent'
+          : 'Received'
   const Kind = () => <span className='activity-row__kind'>{kind}</span>
 
-  const When = () => <span className='activity-row__meta'>{date}</span>
+  const swapRoute = swap ? swapRouteLabel(tx) : ''
+  const When = () => <span className='activity-row__meta'>{swapRoute ? `${swapRoute} · ${date}` : date}</span>
 
   const Bitcoin = () =>
     issuance || burn ? null : (
@@ -105,7 +165,7 @@ const TransactionLine = ({
     return (
       <>
         {tx.assets.map((a) => {
-          const accountInfo = accountInfoForAssetId(a.assetId)
+          const accountInfo = accountInfoForAssetId(a.assetId, aspInfo.network, isRegistered)
           const meta = assetMetadataCache.get(a.assetId)?.metadata
           const ticker = accountInfo?.ticker ?? meta?.ticker
           const icon = meta?.icon
@@ -139,10 +199,18 @@ const TransactionLine = ({
 
   const Right = () => (
     <div className='activity-row__right'>
-      {tx.assets?.length ? (
+      {swap ? (
+        <SwapAmountInfo
+          bitcoinUnit={config.unit}
+          configFiat={config.currency}
+          fromFiatAmount={fromFiatAmount}
+          toFiatAmount={toFiatAmount}
+          tx={tx}
+        />
+      ) : tx.assets?.length ? (
         <>
           <AssetInfo />
-          {config.currency === Currencies.BTC ? <Bitcoin /> : <Currency />}
+          {config.currency === Currencies.BTC && accountValueSatoshis === undefined ? <Bitcoin /> : <Currency />}
         </>
       ) : (
         <>{config.currency === Currencies.BTC ? <Bitcoin /> : <Currency />}</>
@@ -162,6 +230,41 @@ const TransactionLine = ({
   )
 }
 
+function SwapAmountInfo({
+  bitcoinUnit,
+  configFiat,
+  fromFiatAmount,
+  toFiatAmount,
+  tx,
+}: {
+  bitcoinUnit: Unit
+  configFiat: Currencies
+  fromFiatAmount: (amount: number, currency: Currencies) => number
+  toFiatAmount: (satoshis: number, currency: Currencies) => number
+  tx: Tx
+}) {
+  const status = swapStatusForTx(tx)
+  const amount = swapUnitOfAccountAmount({
+    bitcoinUnit,
+    currency: configFiat,
+    fromFiatAmount,
+    toFiatAmount,
+    tx,
+  })
+  const statusClassName =
+    status === 'pending'
+      ? ' activity-row__amount--pending'
+      : status === 'failed' || status === 'cancelled'
+        ? ' activity-row__amount--failed'
+        : ''
+
+  return (
+    <span className={`activity-row__amount${statusClassName}`}>
+      {amount ? <PrivacyAmount masked={amount.masked}>{amount.value}</PrivacyAmount> : swapStatusLabel(tx)}
+    </span>
+  )
+}
+
 interface TransactionsListProps {
   /** Show only transactions for a specific asset. Use 'btc' for bitcoin-only activity. */
   assetIdFilter?: string | string[]
@@ -176,7 +279,7 @@ export default function TransactionsList({ assetIdFilter, mode = 'virtual', limi
   const { navigate } = useContext(NavigationContext)
   const { assetMetadataCache, txs: allTxs } = useContext(WalletContext)
   const visibleTxs = allTxs
-    .filter((tx) => !shouldHideDevPrototypeTx(tx, assetMetadataCache))
+    .filter((tx) => !shouldHideDevAssetTx(tx, assetMetadataCache))
     .filter((tx) => matchesAssetFilter(tx, assetIdFilter))
   const txs = mode === 'static' && limit ? visibleTxs.slice(0, limit) : visibleTxs
 
@@ -319,28 +422,19 @@ export default function TransactionsList({ assetIdFilter, mode = 'virtual', limi
 
 function matchesAssetFilter(tx: Tx, assetIdFilter?: string | string[]): boolean {
   if (!assetIdFilter) return true
+  if (tx.type === 'swap' && tx.assetSwap) {
+    const swapAssetIds = [tx.assetSwap.fromAssetId, tx.assetSwap.toAssetId].filter((assetId): assetId is string =>
+      Boolean(assetId),
+    )
+    if (Array.isArray(assetIdFilter)) return swapAssetIds.some((assetId) => assetIdFilter.includes(assetId))
+    return swapAssetIds.includes(assetIdFilter)
+  }
   if (Array.isArray(assetIdFilter)) {
     if (!assetIdFilter.length) return false
     return tx.assets?.some((asset) => assetIdFilter.includes(asset.assetId)) ?? false
   }
   if (assetIdFilter === 'btc') return !tx.assets?.length && tx.amount !== 0
   return tx.assets?.some((asset) => asset.assetId === assetIdFilter) ?? false
-}
-
-function SwapRouteIcon({ fromTicker, toTicker }: { fromTicker?: string; toTicker?: string }) {
-  const from = accountTickerForAssetTicker(fromTicker) ?? 'BTC'
-  const to = accountTickerForAssetTicker(toTicker) ?? 'USD'
-
-  return (
-    <span className='activity-swap-route-icon' aria-hidden='true'>
-      <span>
-        <TokenLogo ticker={from} />
-      </span>
-      <span>
-        <TokenLogo ticker={to} />
-      </span>
-    </span>
-  )
 }
 
 function TransactionAssetAvatar({ assetId, icon, ticker }: { assetId: string; icon?: string; ticker?: string }) {
@@ -358,13 +452,16 @@ function TransactionAssetAvatar({ assetId, icon, ticker }: { assetId: string; ic
 
 function accountInfoForAssetId(
   assetId: string,
+  network: string | undefined,
+  isRegistered: (assetId: string) => boolean,
 ): { ticker: TokenLogoTicker; label: string; decimals: number } | undefined {
-  if (assetId === 'account:usd') return { ticker: 'USD', label: 'USD', decimals: 2 }
-  if (assetId === 'account:chf') return { ticker: 'CHF', label: 'CHF', decimals: 2 }
-  if (assetId === 'account:brl') return { ticker: 'BRL', label: 'BRL', decimals: 2 }
+  if (!isRegistered(assetId)) return
+  const currency = designatedAccountCurrency(network, assetId)
+  if (!currency || currency === Currencies.BTC) return
+  return { ticker: currency as TokenLogoTicker, label: currency, decimals: fiatDecimalsFor(currency) }
 }
 
-function shouldHideDevPrototypeTx(
+function shouldHideDevAssetTx(
   tx: Tx,
   assetMetadataCache: Map<string, { metadata?: { name?: string; ticker?: string } }>,
 ): boolean {

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -28,7 +28,6 @@ import { PrivacyAmount } from './PrivacyAmount'
 import SwapRouteIcon from './SwapRouteIcon'
 import { swapRouteLabel, swapStatusForTx, swapStatusLabel, swapUnitOfAccountAmount } from '../lib/swapDisplay'
 import { designatedAccountCurrency, fiatAccountAssetSatoshis } from '../lib/accountAssets'
-import { fiatDecimalsFor } from '../lib/fiat'
 import { AspContext } from '../providers/asp'
 import { AssetsContext } from '../providers/assets'
 
@@ -63,7 +62,7 @@ const TransactionLine = ({
     const metadata = assetMetadataCache.get(asset.assetId)?.metadata
     return fiatAccountAssetSatoshis(
       BigInt(asset.amount),
-      accountInfo?.decimals ?? metadata?.decimals ?? 8,
+      metadata?.decimals ?? 8,
       accountInfo?.ticker ?? metadata?.ticker,
       fromFiatAmount,
     )
@@ -169,7 +168,7 @@ const TransactionLine = ({
           const meta = assetMetadataCache.get(a.assetId)?.metadata
           const ticker = accountInfo?.ticker ?? meta?.ticker
           const icon = meta?.icon
-          const decimals = accountInfo?.decimals ?? meta?.decimals ?? 8
+          const decimals = meta?.decimals ?? 8
           const accountTicker = accountTickerForAssetTicker(ticker)
           const label = accountInfo?.label ?? accountTicker ?? ticker ?? meta?.name ?? `${a.assetId.slice(0, 8)}...`
           return (
@@ -454,11 +453,11 @@ function accountInfoForAssetId(
   assetId: string,
   network: string | undefined,
   isRegistered: (assetId: string) => boolean,
-): { ticker: TokenLogoTicker; label: string; decimals: number } | undefined {
+): { ticker: TokenLogoTicker; label: string } | undefined {
   if (!isRegistered(assetId)) return
   const currency = designatedAccountCurrency(network, assetId)
   if (!currency || currency === Currencies.BTC) return
-  return { ticker: currency as TokenLogoTicker, label: currency, decimals: fiatDecimalsFor(currency) }
+  return { ticker: currency as TokenLogoTicker, label: currency }
 }
 
 function shouldHideDevAssetTx(

--- a/src/components/WalletSuccessSplash.tsx
+++ b/src/components/WalletSuccessSplash.tsx
@@ -6,16 +6,21 @@ import { hapticLight } from '../lib/haptics'
 import { useReducedMotion } from '../hooks/useReducedMotion'
 
 interface WalletSuccessSplashProps {
-  show: boolean
+  show?: boolean
   headline: string
   text?: string
   ariaLabel: string
   onDone: () => void
 }
 
-export default function WalletSuccessSplash({ show, headline, text, ariaLabel, onDone }: WalletSuccessSplashProps) {
+export default function WalletSuccessSplash({
+  show = true,
+  headline,
+  text,
+  ariaLabel,
+  onDone,
+}: WalletSuccessSplashProps) {
   const prefersReduced = useReducedMotion()
-
   useEffect(() => {
     if (show) hapticLight()
   }, [show])

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -35,13 +35,17 @@ function DrawerOverlay({ className, ...props }: React.ComponentProps<typeof Draw
 }
 
 function DrawerContent({ className, children, ...props }: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  const isSwapDrawer = typeof className === 'string' && className.includes('swap-drawer-content')
+
   return (
     <DrawerPortal data-slot='drawer-portal'>
       <DrawerOverlay />
       <DrawerPrimitive.Content
         data-slot='drawer-content'
         className={cn(
-          'group/drawer-content fixed z-50 mx-auto flex h-auto flex-col bg-popover text-sm text-popover-foreground data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:w-full data-[vaul-drawer-direction=bottom]:max-w-[640px] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t-0 data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:w-full data-[vaul-drawer-direction=top]:max-w-[640px] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b-0 data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm',
+          'group/drawer-content fixed z-50 mx-auto flex h-auto flex-col border-0 bg-popover text-sm text-popover-foreground data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:w-full data-[vaul-drawer-direction=bottom]:max-w-[640px] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:w-full data-[vaul-drawer-direction=top]:max-w-[640px] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm',
+          isSwapDrawer &&
+            'data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:border-b',
           className,
         )}
         {...props}

--- a/src/hooks/usePortfolioFiat.ts
+++ b/src/hooks/usePortfolioFiat.ts
@@ -1,27 +1,32 @@
-import { useContext } from 'react'
 import Decimal from 'decimal.js'
+import { useContext } from 'react'
+import { fiatDecimalsFor } from '../lib/fiat'
+import { Currencies } from '../lib/types'
+import { AssetsContext } from '../providers/assets'
+import { AspContext } from '../providers/asp'
 import { FiatContext } from '../providers/fiat'
 import { WalletContext } from '../providers/wallet'
-import { truncatedAssetId } from '../lib/assets'
-import { fiatForTicker } from '../lib/format'
+import { designatedAccountCurrency, normalizeAssetMinorUnits, type FiatAccountSourceAsset } from '../lib/accountAssets'
 
 export interface PortfolioRow {
-  /** 'btc' for the native bitcoin row. */
+  /** 'btc' for the native bitcoin row, otherwise the asset's on-chain id. */
   assetId: string
   name: string
   ticker: string
   icon?: string
   decimals: number
-  /** Raw balance in the asset's smallest unit (sats for BTC). */
+  /** Raw balance in the asset's smallest unit (sats for BTC, minor units otherwise). */
   balance: number | bigint
-  /** Fiat value in the user's selected currency. */
+  /** Fiat value in the user's selected currency (0 if no price feed). */
   fiatAmount: number
-  /** Equivalent value in satoshis. */
+  /** Equivalent value in satoshis, computed via the live BTC price feed. */
   satsEquivalent: number
   /** True if this asset has a price feed and fiatAmount is meaningful. */
   hasFiatPrice: boolean
-  /** IDs of the underlying wallet assets when this is a product-level account row. */
-  sourceAssetIds?: string[]
+  /** Fiat currency represented by this product-level account. */
+  fiatCurrency?: Currencies
+  /** Backing wallet asset used internally to fulfill account actions. */
+  sourceAsset?: FiatAccountSourceAsset
 }
 
 export interface PortfolioFiat {
@@ -30,46 +35,83 @@ export interface PortfolioFiat {
   rows: PortfolioRow[]
 }
 
+/**
+ * Aggregates BTC + all asset balances into a single fiat total using the
+ * user's configured currency. Recognized fiat-pegged assets use the same
+ * price feed as the rest of the wallet.
+ */
 export function usePortfolioFiat(): PortfolioFiat {
-  const { assetBalances, assetMetadataCache, balance } = useContext(WalletContext)
+  const { aspInfo } = useContext(AspContext)
+  const { isRegistered } = useContext(AssetsContext)
+  const { balance, assetBalances, assetMetadataCache } = useContext(WalletContext)
   const { fromFiatAmount, toFiat } = useContext(FiatContext)
-  const assetRows = assetBalances.map((asset) => {
-    const meta = assetMetadataCache.get(asset.assetId)?.metadata
-    const decimals = meta?.decimals ?? 8
-    const fiat = fiatForTicker(meta?.ticker)
-    const fiatAmount = fiat ? Decimal.div(asset.amount.toString(), Decimal.pow(10, decimals)).toNumber() : 0
-    const satsEquivalent = fiat ? fromFiatAmount(fiatAmount, fiat) : 0
+  const convertToSelectedFiat = (amount: number, from: Currencies) => toFiat(fromFiatAmount(amount, from))
 
-    return {
-      assetId: asset.assetId,
-      name: meta?.name ?? truncatedAssetId(asset.assetId) ?? 'Asset',
-      ticker: meta?.ticker ?? 'TKN',
-      icon: meta?.icon,
-      decimals,
-      balance: asset.amount,
-      fiatAmount: fiat ? toFiat(satsEquivalent) : 0,
-      satsEquivalent,
-      hasFiatPrice: Boolean(fiat && satsEquivalent),
-    } satisfies PortfolioRow
+  const rows: PortfolioRow[] = []
+  let totalSats = 0
+
+  // bitcoin row first, always present.
+  totalSats += balance
+  rows.push({
+    assetId: 'btc',
+    name: 'Bitcoin',
+    ticker: 'BTC',
+    decimals: 8,
+    balance,
+    fiatAmount: toFiat(balance),
+    satsEquivalent: balance,
+    hasFiatPrice: true,
   })
-  const totalSats = assetRows.reduce((total, row) => total + row.satsEquivalent, balance)
-  const totalFiat = toFiat(totalSats)
+
+  // Non-bitcoin asset rows from real SDK data.
+  for (const ab of assetBalances) {
+    const meta = assetMetadataCache.get(ab.assetId)?.metadata
+    const assetDecimals = meta?.decimals ?? 8
+    const sourceFiat = isRegistered(ab.assetId) ? designatedAccountCurrency(aspInfo.network, ab.assetId) : undefined
+
+    if (sourceFiat) {
+      const accountDecimals = fiatDecimalsFor(sourceFiat)
+      const sourceAsset: FiatAccountSourceAsset = {
+        assetId: ab.assetId,
+        balance: BigInt(ab.amount),
+        decimals: assetDecimals,
+      }
+      const minorUnits = normalizeAssetMinorUnits(sourceAsset.balance, assetDecimals, accountDecimals)
+      const amount = Decimal.div(minorUnits.toString(), Decimal.pow(10, accountDecimals)).toNumber()
+      const fiatAmount = convertToSelectedFiat(amount, sourceFiat)
+      const satsEquivalent = fromFiatAmount(amount, sourceFiat)
+      totalSats += satsEquivalent
+      rows.push({
+        assetId: ab.assetId,
+        name: sourceFiat,
+        ticker: sourceFiat,
+        decimals: accountDecimals,
+        balance: minorUnits,
+        fiatAmount,
+        satsEquivalent,
+        hasFiatPrice: true,
+        fiatCurrency: sourceFiat,
+        sourceAsset,
+      })
+      continue
+    }
+
+    rows.push({
+      assetId: ab.assetId,
+      name: meta?.name ?? `Asset ${ab.assetId.slice(0, 8)}...`,
+      ticker: meta?.ticker?.trim().toUpperCase() ?? 'TKN',
+      icon: meta?.icon,
+      decimals: assetDecimals,
+      balance: ab.amount,
+      fiatAmount: 0,
+      satsEquivalent: 0,
+      hasFiatPrice: false,
+    })
+  }
 
   return {
-    totalFiat,
+    totalFiat: toFiat(totalSats),
     totalSats,
-    rows: [
-      {
-        assetId: 'btc',
-        name: 'Bitcoin',
-        ticker: 'BTC',
-        decimals: 8,
-        balance,
-        fiatAmount: totalFiat,
-        satsEquivalent: balance,
-        hasFiatPrice: true,
-      },
-      ...assetRows,
-    ],
+    rows,
   }
 }

--- a/src/icons/ArrowUpDown.tsx
+++ b/src/icons/ArrowUpDown.tsx
@@ -1,0 +1,20 @@
+export default function ArrowUpDownIcon() {
+  return (
+    <svg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'>
+      <path
+        d='M5 2L2.5 4.5M5 2L7.5 4.5M5 2V12'
+        stroke='currentColor'
+        strokeWidth='1.6'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M11 14L13.5 11.5M11 14L8.5 11.5M11 14V4'
+        stroke='currentColor'
+        strokeWidth='1.6'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -948,34 +948,72 @@ iframe {
   height: 2.5rem;
 }
 
-.activity-swap-route-icon {
+.swap-route-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 999px;
 }
 
-.activity-swap-route-icon span {
+.swap-route-icon--compact {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius-full);
+}
+
+.swap-route-icon__asset {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: var(--radius-full);
+  background: var(--bg);
+}
+
+.swap-route-icon--compact .swap-route-icon__asset {
   width: 1.625rem;
   height: 1.625rem;
-  overflow: hidden;
-  border-radius: 999px;
-  background: var(--bg);
   box-shadow:
     0 0 0 2px var(--bg),
     0 4px 10px -6px color-mix(in srgb, var(--fg) 30%, transparent);
 }
 
-.activity-swap-route-icon span + span {
+.swap-route-icon--compact .swap-route-icon__asset + .swap-route-icon__asset {
   margin-left: -0.5rem;
 }
 
-.activity-swap-route-icon svg {
+.swap-route-icon--hero .swap-route-icon__asset {
+  width: var(--size-touch-lg);
+  height: var(--size-touch-lg);
+  box-shadow:
+    0 0 0 3px var(--bg),
+    0 6px 16px -10px color-mix(in srgb, var(--fg) 28%, transparent);
+}
+
+.swap-route-icon--hero .swap-route-icon__asset + .swap-route-icon__asset {
+  margin-left: -1rem;
+}
+
+.swap-route-icon__asset > svg,
+.swap-route-icon__asset > img,
+.swap-route-icon__fallback {
   width: 100%;
   height: 100%;
+}
+
+.swap-route-icon__asset > img {
+  object-fit: cover;
+}
+
+.swap-route-icon__fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--neutral-200);
+  color: color-mix(in srgb, var(--fg) 72%, transparent);
+  font-family: var(--font-family-sans);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--text-sm-line);
 }
 
 .activity-row__copy {
@@ -1044,6 +1082,10 @@ iframe {
   color: var(--orange-500);
 }
 
+.activity-row__amount--failed {
+  color: color-mix(in srgb, var(--red-700) 76%, var(--fg));
+}
+
 .palette-dark .home-section-action {
   color: color-mix(in srgb, var(--purple-200) 86%, var(--fg));
 }
@@ -1076,6 +1118,10 @@ iframe {
   color: var(--orange-400);
 }
 
+.palette-dark .activity-row__amount--failed {
+  color: color-mix(in srgb, var(--red-400) 78%, var(--fg));
+}
+
 .transaction-asset-logo {
   display: inline-flex;
   width: 1rem;
@@ -1096,6 +1142,54 @@ iframe {
   flex-direction: column;
   gap: 0.625rem;
   margin-bottom: 1rem;
+}
+
+.swap-transaction-summary {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 0 1.5rem;
+  text-align: center;
+}
+
+.swap-transaction-summary__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.swap-transaction-summary__identity h2,
+.swap-transaction-summary__identity p {
+  margin: 0;
+}
+
+.swap-transaction-summary__identity h2 {
+  color: var(--fg);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-md-size);
+  font-weight: 500;
+  letter-spacing: var(--heading-md-tracking);
+  line-height: var(--heading-md-line);
+}
+
+.swap-transaction-summary__identity p {
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-family: var(--font-family-sans);
+  font-size: var(--text-sm);
+  font-weight: 400;
+  line-height: var(--text-sm-line);
+}
+
+.swap-transaction-summary__amount {
+  color: var(--fg);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-xl-size);
+  font-weight: 500;
+  letter-spacing: var(--heading-xl-tracking);
+  line-height: var(--heading-xl-line);
+  font-variant-numeric: tabular-nums;
 }
 
 .transaction-detail-asset {
@@ -1700,6 +1794,1078 @@ html.palette-dark .send-asset-menu {
 @keyframes pulse {
   50% {
     opacity: 0.21;
+  }
+}
+
+/* ================================================
+   Asset swap
+   ================================================ */
+
+.asset-swap-content .content-shell {
+  padding-bottom: 2rem;
+}
+
+.asset-swap-lab {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding-bottom: 1.5rem;
+}
+
+.swap-flip-button,
+.swap-keypad button,
+.swap-token-row,
+.swap-input-card__asset button,
+.swap-amount-display,
+.swap-amount-secondary,
+.swap-receive-card {
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.swap-flow-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.swap-unavailable-state {
+  display: flex;
+  min-height: calc(100dvh - 10rem);
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  text-align: center;
+}
+
+.swap-unavailable-state__icon {
+  display: inline-flex;
+  width: 4rem;
+  height: 4rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--purple-700) 8%, var(--bg));
+  color: var(--purple-700);
+}
+
+.swap-unavailable-state__icon svg {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+.swap-unavailable-state p {
+  margin: 0;
+  color: var(--fg);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-sm-size);
+  font-weight: 500;
+  letter-spacing: var(--heading-sm-tracking);
+  line-height: var(--heading-sm-line);
+}
+
+.swap-unavailable-state span:not(.swap-unavailable-state__icon) {
+  display: block;
+  max-width: 18rem;
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm-line);
+}
+
+.swap-asset-list-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.swap-step-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.25rem 0.25rem 0;
+}
+
+.swap-step-heading p {
+  margin: 0;
+  color: var(--fg);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-sm-size);
+  font-weight: 500;
+  letter-spacing: var(--heading-sm-tracking);
+  line-height: var(--heading-sm-line);
+}
+
+.swap-step-heading span {
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm-line);
+}
+
+.swap-search-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: var(--size-touch-lg);
+  border-radius: var(--radius-xl);
+  background: var(--neutral-50);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 4%, transparent);
+}
+
+.swap-search-field span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.swap-search-field::before {
+  content: '';
+  width: 0.875rem;
+  height: 0.875rem;
+  margin-left: 1rem;
+  border: 1.75px solid color-mix(in srgb, var(--fg) 38%, transparent);
+  border-radius: 999px;
+  box-shadow: 0.375rem 0.375rem 0 -0.25rem color-mix(in srgb, var(--fg) 38%, transparent);
+  transform: translateY(-0.0625rem);
+  pointer-events: none;
+}
+
+.swap-search-field input {
+  min-width: 0;
+  width: 100%;
+  min-height: var(--size-touch-lg);
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  font-family: var(--font-family-sans);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: var(--text-base-line);
+  outline: none;
+  padding: 0 1rem 0 0.75rem;
+}
+
+.swap-search-field input::placeholder {
+  color: color-mix(in srgb, var(--fg) 38%, transparent);
+}
+
+.swap-search-field:focus-within {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--purple-700) 20%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--purple-700) 7%, transparent);
+}
+
+.swap-composer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.swap-input-card,
+.swap-receive-card,
+.swap-detail-card,
+.swap-review-card {
+  border-radius: var(--radius-xl);
+  background: var(--bg);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent),
+    0 1px 2px -1px color-mix(in srgb, var(--fg) 7%, transparent),
+    0 2px 4px 0 color-mix(in srgb, var(--fg) 3%, transparent);
+}
+
+.swap-input-card {
+  display: flex;
+  min-height: 12.75rem;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0.875rem 1rem 1.125rem;
+}
+
+.swap-input-card__asset {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.swap-input-card__asset-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.swap-input-card__asset span,
+.swap-receive-card span {
+  color: var(--fg);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--text-sm-line);
+}
+
+.swap-input-card__asset small,
+.swap-receive-card small {
+  color: color-mix(in srgb, var(--fg) 46%, transparent);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  line-height: var(--text-xs-line);
+}
+
+.swap-input-card__asset button {
+  min-height: 2rem;
+  border-radius: 999px;
+  background: var(--neutral-50);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent);
+  color: color-mix(in srgb, var(--fg) 72%, transparent);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  line-height: 1;
+  padding: 0 0.75rem;
+}
+
+.swap-amount-stack {
+  position: relative;
+  display: flex;
+  min-height: 5.875rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.swap-amount-display {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.375rem;
+  border: 0;
+  background: transparent;
+  text-align: center;
+}
+
+.swap-amount-display > .swap-amount-value {
+  color: var(--fg);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-2xl-size);
+  font-weight: 500;
+  letter-spacing: var(--heading-2xl-tracking);
+  line-height: var(--heading-2xl-line);
+  outline: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.swap-amount-display--invalid > .swap-amount-value {
+  color: color-mix(in srgb, var(--red-700) 84%, var(--fg));
+}
+
+.swap-input-error {
+  position: absolute;
+  bottom: calc(50% + 2.375rem);
+  left: 0;
+  right: 0;
+  width: max-content;
+  max-width: 100%;
+  min-height: var(--text-sm-line);
+  margin: 0 auto;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--red-700) 10%, var(--bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--red-700) 14%, transparent);
+  color: color-mix(in srgb, var(--red-700) 84%, var(--fg));
+  font-size: var(--text-xs);
+  font-weight: 500;
+  line-height: var(--text-xs-line);
+  padding: 0.25rem 0.625rem;
+  text-align: center;
+  transform-origin: center bottom;
+}
+
+.swap-amount-value {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.swap-amount-character-slot {
+  display: inline-grid;
+  place-items: center;
+  min-width: 0.36em;
+}
+
+.swap-amount-character-slot--digit {
+  min-width: 0.58em;
+}
+
+.swap-amount-character-slot--space {
+  min-width: 0.32em;
+}
+
+.swap-amount-character-slot--exiting {
+  pointer-events: none;
+}
+
+.swap-amount-character {
+  grid-area: 1 / 1;
+  display: inline-block;
+  white-space: pre;
+  will-change: transform, opacity;
+}
+
+.swap-amount-character--entering {
+  animation: swap-amount-character-in 280ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+.swap-amount-character--exiting {
+  animation: swap-amount-character-out 170ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+.swap-amount-value--secondary {
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+}
+
+.swap-skeleton-text {
+  position: relative;
+  display: inline-flex;
+  height: 0.875rem;
+  max-width: 100%;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--fg) 7%, transparent);
+  vertical-align: middle;
+}
+
+.swap-skeleton-text::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--bg) 72%, transparent), transparent);
+  transform: translateX(-100%);
+  animation: swap-skeleton-shimmer 1050ms cubic-bezier(0.23, 1, 0.32, 1) infinite;
+}
+
+.swap-amount-secondary {
+  align-self: center;
+  display: inline-flex;
+  min-height: 2rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--fg) 3.5%, var(--bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent);
+  color: color-mix(in srgb, var(--fg) 54%, transparent);
+  padding: 0 0.625rem 0 0.75rem;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--text-sm-line);
+  font-variant-numeric: tabular-nums;
+  touch-action: manipulation;
+  transition:
+    background-color 160ms ease,
+    transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.swap-amount-secondary:active {
+  transform: scale(0.97);
+}
+
+.swap-amount-secondary__icon {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  color: currentcolor;
+  will-change: transform;
+}
+
+.swap-amount-secondary__icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.swap-receive-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 4.25rem;
+  padding: 0.75rem 0.875rem;
+  text-align: left;
+  transition:
+    background-color 160ms ease,
+    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.swap-receive-card > div {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.swap-receive-card strong {
+  color: color-mix(in srgb, var(--fg) 78%, transparent);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--text-sm-line);
+}
+
+.swap-receive-card:active,
+.swap-input-card__asset button:active,
+.swap-amount-display:active {
+  transform: scale(0.97);
+}
+
+.swap-token-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--neutral-50);
+}
+
+.swap-token-avatar svg {
+  width: 100%;
+  height: 100%;
+}
+
+.swap-receive-card__empty {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--neutral-50);
+  color: color-mix(in srgb, var(--fg) 64%, transparent);
+  font-size: var(--text-xl);
+  font-weight: 500;
+  line-height: 1;
+}
+
+.swap-flip-button {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--size-touch-min);
+  height: var(--size-touch-min);
+  margin: -0.5rem 0;
+  border: 0;
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--purple-700);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--fg) 6%, transparent),
+    0 6px 16px -10px color-mix(in srgb, var(--fg) 28%, transparent);
+  z-index: 1;
+}
+
+.swap-flip-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.swap-flip-button:active {
+  transform: scale(0.97);
+}
+
+.swap-flip-button:disabled {
+  opacity: 0.45;
+}
+
+.swap-detail-card,
+.swap-review-card {
+  padding: 1rem;
+}
+
+.swap-detail-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  background: var(--bg);
+}
+
+.swap-metric-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  min-height: 3.125rem;
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: var(--text-sm);
+  font-weight: 400;
+  line-height: 1;
+  border-top: 1px solid color-mix(in srgb, var(--fg) 5%, transparent);
+}
+
+.swap-metric-row:first-child {
+  border-top: 0;
+}
+
+.swap-metric-row span {
+  display: flex;
+  align-items: center;
+  min-height: var(--text-sm-line);
+}
+
+.swap-metric-row span:first-child {
+  min-width: 0;
+}
+
+.swap-rate-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.swap-rate-disclosure {
+  position: relative;
+  display: inline-flex;
+}
+
+.swap-rate-info {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  margin: -0.75rem;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: color-mix(in srgb, var(--fg) 44%, transparent);
+  cursor: pointer;
+  font: inherit;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.swap-rate-info svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.swap-rate-info:focus-visible {
+  outline: 2px solid var(--purple-700);
+  outline-offset: 2px;
+}
+
+.swap-rate-tooltip {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 0.5rem);
+  z-index: 2;
+  max-width: 14rem;
+  width: max-content;
+  padding: 0.5rem 0.625rem;
+  border-radius: var(--radius-md);
+  background: var(--fg);
+  color: var(--bg);
+  box-shadow: var(--shadow-md);
+  font-size: var(--text-xs);
+  white-space: normal;
+  line-height: var(--text-xs-line);
+  text-align: left;
+  pointer-events: none;
+  transform-origin: left bottom;
+}
+
+.swap-metric-row span:last-child {
+  justify-content: flex-end;
+  color: color-mix(in srgb, var(--fg) 82%, transparent);
+  font-weight: 500;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.swap-review-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.125rem;
+}
+
+.swap-review-card h3 {
+  margin: 0;
+}
+
+.swap-review-hero {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+}
+
+.swap-review-hero > div:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.swap-review-hero span {
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  line-height: var(--text-xs-line);
+}
+
+.swap-review-avatars {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.swap-review-avatars > * + * {
+  margin-left: -0.625rem;
+  box-shadow: 0 0 0 3px var(--bg);
+}
+
+.swap-keypad-shell {
+  display: flex;
+  flex-direction: column;
+  padding: 0.375rem 0 0.25rem;
+}
+
+.swap-keypad {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.125rem;
+}
+
+.swap-keypad button {
+  min-height: 3.25rem;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--fg);
+  font-family: var(--font-family-sans);
+  font-size: var(--text-xl);
+  font-weight: 500;
+}
+
+.swap-keypad button:active {
+  transform: scale(0.97);
+  background: var(--neutral-50);
+}
+
+.swap-drawer-content {
+  border-color: var(--neutral-100) !important;
+  background: var(--bg) !important;
+}
+
+.swap-review-drawer-content {
+  max-height: min(92vh, 42rem) !important;
+  overflow: hidden;
+}
+
+.swap-review-header {
+  align-items: flex-start !important;
+  gap: 0.25rem !important;
+  padding: 1.25rem 1rem 0.875rem !important;
+  text-align: left !important;
+}
+
+.swap-picker-header {
+  align-items: flex-start !important;
+  gap: 0.375rem !important;
+  padding: 1.375rem 1rem 1rem !important;
+  text-align: left !important;
+}
+
+.swap-picker-header [data-slot='drawer-title'] {
+  color: var(--fg);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-md-size);
+  font-weight: 500;
+  letter-spacing: var(--heading-md-tracking);
+  line-height: var(--heading-md-line);
+}
+
+.swap-picker-header [data-slot='drawer-description'] {
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm-line);
+}
+
+.swap-review-header [data-slot='drawer-title'] {
+  color: var(--fg);
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-sm-size);
+  font-weight: 500;
+  letter-spacing: var(--heading-sm-tracking);
+  line-height: var(--heading-sm-line);
+}
+
+.swap-review-header [data-slot='drawer-description'] {
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm-line);
+}
+
+.swap-drawer-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 0 1rem 1rem;
+}
+
+.swap-token-list,
+.swap-review-drawer-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.swap-review-drawer-body {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  gap: 0.75rem;
+  padding: 0 1rem 0.75rem;
+}
+
+.swap-review-action {
+  position: sticky;
+  bottom: 0;
+  background: var(--bg);
+  padding: 0.75rem 1rem max(1rem, env(safe-area-inset-bottom));
+  box-shadow: 0 -12px 24px -18px color-mix(in srgb, var(--fg) 22%, transparent);
+}
+
+.swap-confirm-error {
+  margin: 0 0 0.625rem;
+  color: color-mix(in srgb, var(--red-700) 84%, var(--fg));
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--text-sm-line);
+  text-align: center;
+}
+
+.swap-token-list--page {
+  padding-top: 0.125rem;
+}
+
+.swap-token-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  min-height: 4rem;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  padding: 0.5rem;
+  text-align: left;
+  transition:
+    background-color 160ms ease,
+    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.swap-token-row--active,
+.swap-token-row:active {
+  background: var(--neutral-50);
+}
+
+.swap-token-row:active {
+  transform: scale(0.985);
+}
+
+.swap-token-row__copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.swap-token-row__copy > span {
+  font-weight: 500;
+}
+
+.swap-token-row small {
+  color: var(--neutral-500);
+  font-size: var(--text-sm);
+}
+
+.swap-token-row strong {
+  margin-left: auto;
+  color: color-mix(in srgb, var(--fg) 76%, transparent);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--text-sm-line);
+}
+
+.swap-empty-state {
+  min-height: 8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-xl);
+  background: var(--neutral-50);
+  color: color-mix(in srgb, var(--fg) 46%, transparent);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm-line);
+}
+
+@keyframes swap-skeleton-shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes swap-amount-character-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.32em);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes swap-amount-character-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-0.28em);
+  }
+}
+
+.wallet-success-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  border: 0;
+  background:
+    radial-gradient(circle at 50% 34%, color-mix(in srgb, var(--purple-500) 28%, transparent), transparent 32%),
+    linear-gradient(180deg, var(--purple-600), var(--purple-800));
+  color: white;
+  font: inherit;
+  text-align: center;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.wallet-success-splash__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 7.75rem;
+  height: 7.5rem;
+}
+
+.wallet-success-splash__mark svg {
+  width: 7.25rem;
+  height: auto;
+  filter: drop-shadow(0 18px 26px color-mix(in srgb, black 22%, transparent));
+}
+
+.wallet-success-splash__mark svg path {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: swap-success-pixel-in 180ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+.wallet-success-splash__mark svg path:nth-child(1),
+.wallet-success-splash__mark svg path:nth-child(2),
+.wallet-success-splash__mark svg path:nth-child(26),
+.wallet-success-splash__mark svg path:nth-child(27),
+.wallet-success-splash__mark svg path:nth-child(28),
+.wallet-success-splash__mark svg path:nth-child(29),
+.wallet-success-splash__mark svg path:nth-child(30),
+.wallet-success-splash__mark svg path:nth-child(31),
+.wallet-success-splash__mark svg path:nth-child(32),
+.wallet-success-splash__mark svg path:nth-child(33) {
+  animation-delay: 120ms;
+}
+
+.wallet-success-splash__mark svg path:nth-child(n + 3):nth-child(-n + 25) {
+  animation-delay: calc(170ms + (var(--swap-success-pixel-index, 0) * 18ms));
+}
+
+.wallet-success-splash__mark svg path:nth-child(3) {
+  --swap-success-pixel-index: 22;
+}
+
+.wallet-success-splash__mark svg path:nth-child(4) {
+  --swap-success-pixel-index: 21;
+}
+
+.wallet-success-splash__mark svg path:nth-child(5) {
+  --swap-success-pixel-index: 20;
+}
+
+.wallet-success-splash__mark svg path:nth-child(6) {
+  --swap-success-pixel-index: 19;
+}
+
+.wallet-success-splash__mark svg path:nth-child(7) {
+  --swap-success-pixel-index: 18;
+}
+
+.wallet-success-splash__mark svg path:nth-child(8) {
+  --swap-success-pixel-index: 17;
+}
+
+.wallet-success-splash__mark svg path:nth-child(9) {
+  --swap-success-pixel-index: 16;
+}
+
+.wallet-success-splash__mark svg path:nth-child(10) {
+  --swap-success-pixel-index: 15;
+}
+
+.wallet-success-splash__mark svg path:nth-child(11) {
+  --swap-success-pixel-index: 14;
+}
+
+.wallet-success-splash__mark svg path:nth-child(12) {
+  --swap-success-pixel-index: 13;
+}
+
+.wallet-success-splash__mark svg path:nth-child(13) {
+  --swap-success-pixel-index: 12;
+}
+
+.wallet-success-splash__mark svg path:nth-child(14) {
+  --swap-success-pixel-index: 11;
+}
+
+.wallet-success-splash__mark svg path:nth-child(15) {
+  --swap-success-pixel-index: 10;
+}
+
+.wallet-success-splash__mark svg path:nth-child(16) {
+  --swap-success-pixel-index: 9;
+}
+
+.wallet-success-splash__mark svg path:nth-child(17) {
+  --swap-success-pixel-index: 8;
+}
+
+.wallet-success-splash__mark svg path:nth-child(18) {
+  --swap-success-pixel-index: 7;
+}
+
+.wallet-success-splash__mark svg path:nth-child(19) {
+  --swap-success-pixel-index: 6;
+}
+
+.wallet-success-splash__mark svg path:nth-child(20) {
+  --swap-success-pixel-index: 5;
+}
+
+.wallet-success-splash__mark svg path:nth-child(21) {
+  --swap-success-pixel-index: 4;
+}
+
+.wallet-success-splash__mark svg path:nth-child(22) {
+  --swap-success-pixel-index: 3;
+}
+
+.wallet-success-splash__mark svg path:nth-child(23) {
+  --swap-success-pixel-index: 2;
+}
+
+.wallet-success-splash__mark svg path:nth-child(24) {
+  --swap-success-pixel-index: 1;
+}
+
+.wallet-success-splash__mark svg path:nth-child(25) {
+  --swap-success-pixel-index: 0;
+}
+
+@keyframes swap-success-pixel-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 3px, 0) scale(0.86);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+.wallet-success-splash__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0 2rem;
+}
+
+.wallet-success-splash__copy strong {
+  font-family: var(--font-family-heading);
+  font-size: var(--heading-xl-size);
+  font-weight: 500;
+  letter-spacing: var(--heading-xl-tracking);
+  line-height: var(--heading-xl-line);
+}
+
+.wallet-success-splash__copy small {
+  color: color-mix(in srgb, white 72%, transparent);
+  font-size: var(--text-sm);
+  font-weight: 400;
+  line-height: var(--text-sm-line);
+}
+
+@media (min-width: 720px) {
+  .asset-swap-lab {
+    max-width: 44rem;
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: 380px) {
+  .swap-amount-display > .swap-amount-value {
+    font-size: var(--heading-xl-size);
+    line-height: var(--heading-xl-line);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wallet-success-splash__mark svg path {
+    animation: none;
+  }
+
+  .swap-skeleton-text::after {
+    animation: none;
+  }
+
+  .swap-keypad button:active,
+  .swap-token-row:active,
+  .swap-receive-card:active,
+  .swap-input-card__asset button:active,
+  .swap-amount-secondary:active,
+  .swap-amount-display:active {
+    transform: none;
   }
 }
 
@@ -2447,6 +3613,13 @@ html.palette-dark .settings-row--danger .settings-row__chevron {
   font-variant-numeric: tabular-nums;
 }
 
+.asset-detail-price--unavailable {
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-family: inherit;
+  font-size: var(--asset-detail-section-size);
+  line-height: 1;
+}
+
 .asset-detail-delta {
   display: inline-flex;
   min-height: 2rem;
@@ -2561,19 +3734,14 @@ html.palette-dark .settings-row--danger .settings-row__chevron {
 }
 
 .asset-detail-chart-fallback {
+  display: flex;
   width: 100%;
   height: 100%;
-  background:
-    linear-gradient(
-      135deg,
-      transparent 0%,
-      transparent 42%,
-      color-mix(in srgb, var(--purple-700) 24%, transparent) 43%,
-      color-mix(in srgb, var(--purple-700) 24%, transparent) 44%,
-      transparent 45%,
-      transparent 100%
-    ),
-    var(--neutral-50);
+  align-items: center;
+  justify-content: center;
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+  font-size: var(--asset-detail-control-size);
+  font-weight: var(--asset-detail-support-weight);
 }
 
 .asset-detail-range-tabs {
@@ -2748,7 +3916,7 @@ html.palette-dark .settings-row--danger .settings-row__chevron {
 }
 
 /* ================================================
-   Asset Swap Prototype Lab
+   Asset swap
    ================================================ */
 
 .asset-swap-content .content-shell {

--- a/src/lib/accountAssets.ts
+++ b/src/lib/accountAssets.ts
@@ -1,0 +1,114 @@
+import Decimal from 'decimal.js'
+import { Currencies } from './types'
+
+export type WalletAccountTicker = 'BTC' | 'USD' | 'CHF' | 'BRL' | 'CNY' | 'EUR' | 'GBP' | 'JPY'
+
+export const MUTINYNET_DEPIX_ASSET_ID = '47004bf4a5fbdb2221f708030528de68ea28f5980044e546b7bb5a352457d1f30000'
+export const MUTINYNET_USDT_ASSET_ID = 'f121ac9b7656797cc68d1e8fecacfbaa2069ec1461edf0bf2f3c37404cb9791a0000'
+
+const DESIGNATED_ACCOUNT_ASSETS: Record<string, Partial<Record<string, Currencies>>> = {
+  mutinynet: {
+    [MUTINYNET_DEPIX_ASSET_ID]: Currencies.BRL,
+    [MUTINYNET_USDT_ASSET_ID]: Currencies.USD,
+  },
+}
+
+export interface FiatAccountSourceAsset {
+  assetId: string
+  balance: bigint
+  decimals: number
+}
+
+export interface FiatAccountSend {
+  assetId: string
+  ticker: WalletAccountTicker
+  balance: bigint
+  decimals: number
+  amount: bigint
+  source: FiatAccountSourceAsset
+}
+
+const ACCOUNT_CHART_COLOR_TOKENS: Record<WalletAccountTicker, string> = {
+  BTC: '--account-chart-btc',
+  USD: '--account-chart-usd',
+  CHF: '--account-chart-chf',
+  BRL: '--account-chart-brl',
+  CNY: '--account-chart-cny',
+  EUR: '--account-chart-eur',
+  GBP: '--account-chart-gbp',
+  JPY: '--account-chart-jpy',
+}
+
+export function walletAccountTicker(ticker: string | undefined): WalletAccountTicker | undefined {
+  const normalized = ticker?.trim().toUpperCase()
+  if (normalized === 'BTC') return 'BTC'
+  if (normalized === 'USD') return 'USD'
+  if (normalized === 'CHF') return 'CHF'
+  if (normalized === 'BRL') return 'BRL'
+  if (normalized === 'CNY') return 'CNY'
+  if (normalized === 'EUR') return 'EUR'
+  if (normalized === 'GBP') return 'GBP'
+  if (normalized === 'JPY') return 'JPY'
+}
+
+export function designatedAccountCurrency(network: string | undefined, assetId: string): Currencies | undefined {
+  return network ? DESIGNATED_ACCOUNT_ASSETS[network]?.[assetId] : undefined
+}
+
+export function accountChartColorToken(ticker: string | undefined): string {
+  const accountTicker = walletAccountTicker(ticker)
+  return accountTicker ? ACCOUNT_CHART_COLOR_TOKENS[accountTicker] : '--account-chart-default'
+}
+
+export function walletAssetPresentation(
+  metadata: { name?: string; ticker?: string; icon?: string } | undefined,
+  fallbackName = 'Asset',
+): { name: string; ticker: string; icon?: string } {
+  const accountTicker = walletAccountTicker(metadata?.ticker)
+  if (accountTicker) return { name: accountTicker, ticker: accountTicker }
+
+  return {
+    name: metadata?.name ?? fallbackName,
+    ticker: metadata?.ticker?.trim().toUpperCase() ?? '',
+    icon: metadata?.icon,
+  }
+}
+
+export function walletAssetPresentationForId(
+  network: string | undefined,
+  assetId: string | undefined,
+  isRegistered: (assetId: string) => boolean,
+  metadata: { name?: string; ticker?: string; icon?: string } | undefined,
+  fallbackName = 'Asset',
+): { name: string; ticker: string; icon?: string } {
+  const currency = assetId && isRegistered(assetId) ? designatedAccountCurrency(network, assetId) : undefined
+  return currency
+    ? { name: currency, ticker: currency, icon: metadata?.icon }
+    : walletAssetPresentation(metadata, fallbackName)
+}
+
+export function walletAssetLabel(presentation: { name: string; ticker: string }): string {
+  return !presentation.ticker || presentation.name === presentation.ticker
+    ? presentation.name
+    : `${presentation.name} (${presentation.ticker})`
+}
+
+export function fiatAccountAssetSatoshis(
+  amount: bigint,
+  decimals: number,
+  ticker: string | undefined,
+  fromFiatAmount: (amount: number, currency: Currencies) => number,
+): number | undefined {
+  const accountTicker = walletAccountTicker(ticker)
+  if (!accountTicker || accountTicker === 'BTC') return undefined
+
+  const accountAmount = Decimal.div(amount.toString(), Decimal.pow(10, decimals)).toNumber()
+  return fromFiatAmount(accountAmount, accountTicker as Currencies)
+}
+
+export function normalizeAssetMinorUnits(rawAmount: number | bigint, fromDecimals: number, toDecimals: number): bigint {
+  const amount = typeof rawAmount === 'bigint' ? rawAmount : BigInt(rawAmount)
+  if (fromDecimals === toDecimals) return amount
+  if (fromDecimals > toDecimals) return amount / BigInt(10) ** BigInt(fromDecimals - toDecimals)
+  return amount * BigInt(10) ** BigInt(toDecimals - fromDecimals)
+}

--- a/src/lib/fiat.ts
+++ b/src/lib/fiat.ts
@@ -12,14 +12,13 @@ export interface FiatPrices {
 }
 
 // Currencies listed here are prefixed with their symbol when displaying amounts.
-// Those omitted (CHF, CNY) keep the trailing ISO code — CNY skips ¥ to avoid
-// clashing with JPY.
+// Those omitted (BRL, CHF, CNY) keep the trailing ISO code. BRL is explicit by
+// product convention, while CNY skips ¥ to avoid clashing with JPY.
 export const FIAT_SYMBOLS: Partial<Record<Currencies, string>> = {
   [Currencies.USD]: '$',
   [Currencies.EUR]: '€',
   [Currencies.GBP]: '£',
   [Currencies.JPY]: '¥',
-  [Currencies.BRL]: 'R$',
 }
 
 export const fiatDecimalsFor = (currency: Currencies, bitcoinUnit = Unit.BTC): number => {

--- a/src/lib/marketData.ts
+++ b/src/lib/marketData.ts
@@ -3,6 +3,9 @@ import { Currencies } from './types'
 
 const host = 'https://price-chart-proxy.arkade.money'
 
+const DEFAULT_CONSTANT_SERIES_WINDOW_SECS = 86_400
+const CONSTANT_SERIES_INTERVALS = 100
+
 interface HistoricalMarketDataResponse {
   when: number
   from: string
@@ -23,6 +26,21 @@ const secsToPeriod = (secs: number): string => {
   return window ? window.label : 'oneDay'
 }
 
+export const buildConstantMarketSeries = (
+  value: number,
+  windowSecs: number,
+  now = Math.floor(Date.now() / 1000),
+): LivelinePoint[] => {
+  const duration = windowSecs > 0 ? windowSecs : DEFAULT_CONSTANT_SERIES_WINDOW_SECS
+  const intervalCount = Math.max(1, Math.min(CONSTANT_SERIES_INTERVALS, Math.floor(duration)))
+  const start = now - duration
+
+  return Array.from({ length: intervalCount + 1 }, (_, index) => ({
+    time: start + Math.floor((duration * index) / intervalCount),
+    value,
+  }))
+}
+
 export const fetchHistoricalMarketData = async (
   secs: number,
   fiat: Currencies,
@@ -34,6 +52,44 @@ export const fetchHistoricalMarketData = async (
   if (!resp.ok) throw new Error(`Market data fetch failed: ${resp.status}`)
   const data = await resp.json()
   return isValidHistoricalMarketDataResponse(data) ? data.data : []
+}
+
+export const buildCrossRatePoints = (sourcePoints: LivelinePoint[], marketPoints: LivelinePoint[]): LivelinePoint[] => {
+  const source = validMarketPoints(sourcePoints)
+  const market = validMarketPoints(marketPoints)
+  if (source.length < 2 || market.length < 2) return []
+
+  const tolerance = Math.ceil(Math.max(estimatePointInterval(source), estimatePointInterval(market)) * 1.5)
+  let marketIndex = 0
+
+  return source.flatMap((sourcePoint) => {
+    while (
+      marketIndex + 1 < market.length &&
+      Math.abs(market[marketIndex + 1].time - sourcePoint.time) <= Math.abs(market[marketIndex].time - sourcePoint.time)
+    ) {
+      marketIndex += 1
+    }
+
+    const marketPoint = market[marketIndex]
+    if (!marketPoint || Math.abs(marketPoint.time - sourcePoint.time) > tolerance) return []
+    return [{ time: sourcePoint.time, value: marketPoint.value / sourcePoint.value }]
+  })
+}
+
+const validMarketPoints = (points: LivelinePoint[]): LivelinePoint[] => {
+  return points
+    .filter((point) => Number.isFinite(point.time) && Number.isFinite(point.value) && point.time > 0 && point.value > 0)
+    .sort((a, b) => a.time - b.time)
+}
+
+const estimatePointInterval = (points: LivelinePoint[]): number => {
+  const intervals = points
+    .slice(1)
+    .map((point, index) => point.time - points[index].time)
+    .filter((interval) => interval > 0)
+    .sort((a, b) => a - b)
+
+  return intervals[Math.floor(intervals.length / 2)] ?? 3_600
 }
 
 const isValidHistoricalMarketDataResponse = (data: unknown): data is HistoricalMarketDataResponse => {

--- a/src/lib/swap/store.ts
+++ b/src/lib/swap/store.ts
@@ -1,7 +1,24 @@
 import { getStorageItem } from '../storage'
 import { consoleError } from '../logs'
+import type { Tx } from '../types'
+import { designatedAccountCurrency } from '../accountAssets'
 
 export type AssetSwapStatus = 'pending' | 'cancelling' | 'fulfilled' | 'cancelled' | 'recoverable'
+
+export interface AssetSwapQuoteSnapshot {
+  fromName: string
+  fromTicker: string
+  fromDecimals: number
+  toName: string
+  toTicker: string
+  toDecimals: number
+  feeBps: number
+  rate: string
+  fiatCurrency: string
+  fromFiatAmount: number
+  toFiatAmount: number
+  quotedAt: number
+}
 
 export interface AssetSwap {
   /** Funding txid — the swap's identity. */
@@ -22,6 +39,8 @@ export interface AssetSwap {
   spentTxid?: string
   status: AssetSwapStatus
   createdAt: number
+  completedAt?: number
+  quote?: AssetSwapQuoteSnapshot
 }
 
 const KEY = 'assetSwaps'
@@ -56,4 +75,69 @@ export const updateAssetSwap = (id: string, changes: Partial<AssetSwap>): AssetS
   const swaps = getAssetSwaps().map((s) => (s.id === id ? { ...s, ...changes } : s))
   saveAssetSwaps(swaps)
   return swaps
+}
+
+/** Collapse the funding and fill wallet rows into one persisted swap activity. */
+export const mergeAssetSwapActivity = (txs: Tx[], swaps = getAssetSwaps(), network?: string): Tx[] => {
+  const claimed = new Set<Tx>()
+  const activities = swaps.map<Tx>((swap) => {
+    const members = txs.filter((tx) => {
+      const ids = [tx.boardingTxid, tx.redeemTxid, tx.roundTxid]
+      const match = ids.includes(swap.fundingTxid) || Boolean(swap.spentTxid && ids.includes(swap.spentTxid))
+      if (match) claimed.add(tx)
+      return match
+    })
+    const quote = swap.quote
+    const status =
+      swap.status === 'fulfilled'
+        ? 'completed'
+        : swap.status === 'cancelled'
+          ? 'cancelled'
+          : swap.status === 'recoverable'
+            ? 'recoverable'
+            : 'pending'
+    const fill = swap.spentTxid
+      ? members.find((tx) => [tx.boardingTxid, tx.redeemTxid, tx.roundTxid].includes(swap.spentTxid!))
+      : undefined
+    const receivedAsset = fill?.assets?.find((asset) => asset.assetId === swap.toAsset && asset.amount > BigInt(0))
+    const receivedAmount =
+      swap.toAsset === 'btc' && fill?.amount && fill.amount > 0
+        ? BigInt(fill.amount)
+        : (receivedAsset?.amount ?? BigInt(swap.toAmount))
+    const fallbackTicker = (assetId: string) =>
+      assetId === 'btc' ? 'BTC' : (designatedAccountCurrency(network, assetId) ?? assetId.slice(0, 8))
+    return {
+      amount: members[0]?.amount ?? 0,
+      boardingTxid: '',
+      createdAt: Math.floor(swap.createdAt / 1000),
+      explorable: undefined,
+      preconfirmed: status === 'pending',
+      redeemTxid: swap.spentTxid ?? swap.fundingTxid,
+      roundTxid: '',
+      settled: status !== 'pending',
+      type: 'swap',
+      assetSwap: {
+        fromAssetId: swap.fromAsset,
+        fromTicker: quote?.fromTicker ?? fallbackTicker(swap.fromAsset),
+        fromDecimals: quote?.fromDecimals,
+        fromAmount: BigInt(swap.fromAmount),
+        toAssetId: swap.toAsset,
+        toTicker: quote?.toTicker ?? fallbackTicker(swap.toAsset),
+        toDecimals: quote?.toDecimals,
+        toAmount: receivedAmount,
+        fiatAmount: quote?.fromFiatAmount,
+        fiatCurrency: quote?.fiatCurrency,
+        toFiatAmount: quote?.toFiatAmount,
+        feeBps: quote?.feeBps,
+        rate: quote?.rate,
+        quotedAt: quote?.quotedAt,
+        completedAt: swap.completedAt,
+        fundingTxid: swap.fundingTxid,
+        fillTxid: swap.spentTxid,
+        status,
+      },
+    }
+  })
+
+  return [...activities, ...txs.filter((tx) => !claimed.has(tx))].sort((a, b) => b.createdAt - a.createdAt)
 }

--- a/src/lib/swapDisplay.ts
+++ b/src/lib/swapDisplay.ts
@@ -1,0 +1,75 @@
+import { prettyCurrencyAssetAmount, prettyFiatAmount, prettyFiatHide, prettyHide } from './format'
+import { walletAccountTicker } from './accountAssets'
+import { Currencies, Tx, Unit } from './types'
+
+export type SwapStatus = 'pending' | 'failed' | 'completed' | 'cancelled' | 'recoverable'
+
+export interface SwapDisplayAmount {
+  masked: string
+  value: string
+}
+
+interface SwapUnitOfAccountAmountOptions {
+  bitcoinUnit: Unit
+  currency: Currencies
+  fromFiatAmount: (amount: number, currency: Currencies) => number
+  toFiatAmount: (satoshis: number, currency: Currencies) => number
+  tx: Tx
+}
+
+export function swapStatusForTx(tx: Tx): SwapStatus {
+  if (tx.assetSwap?.status) return tx.assetSwap.status
+  return tx.settled ? 'completed' : 'pending'
+}
+
+export function swapStatusLabel(tx: Tx): string {
+  const status = swapStatusForTx(tx)
+  if (status === 'failed') return 'Failed'
+  if (status === 'cancelled') return 'Cancelled'
+  if (status === 'recoverable') return 'Recoverable'
+  if (status === 'pending') return 'Pending'
+  return 'Completed'
+}
+
+export function swapRouteLabel(tx: Tx): string {
+  return [tx.assetSwap?.fromTicker, tx.assetSwap?.toTicker]
+    .map((ticker) => walletAccountTicker(ticker) ?? ticker)
+    .filter(Boolean)
+    .join(' to ')
+}
+
+export function formatSwapAssetAmount(tx: Tx, side: 'from' | 'to'): SwapDisplayAmount | undefined {
+  const swap = tx.assetSwap
+  if (!swap) return undefined
+
+  const amount = side === 'from' ? swap.fromAmount : swap.toAmount
+  const decimals = side === 'from' ? swap.fromDecimals : swap.toDecimals
+  const ticker = side === 'from' ? swap.fromTicker : swap.toTicker
+
+  if (amount === undefined || decimals === undefined || !ticker) return undefined
+  const accountTicker = walletAccountTicker(ticker) ?? ticker
+  return {
+    masked: prettyHide('hidden', accountTicker),
+    value: `${prettyCurrencyAssetAmount(amount, decimals, accountTicker)} ${accountTicker}`,
+  }
+}
+
+export function swapUnitOfAccountAmount({
+  bitcoinUnit,
+  currency,
+  fromFiatAmount,
+  toFiatAmount,
+  tx,
+}: SwapUnitOfAccountAmountOptions): SwapDisplayAmount | undefined {
+  const fiatAmount = tx.assetSwap?.fiatAmount
+  if (fiatAmount === undefined) return undefined
+
+  const sourceCurrency = (tx.assetSwap?.fiatCurrency as Currencies | undefined) ?? Currencies.USD
+  const selectedCurrencyAmount = toFiatAmount(fromFiatAmount(fiatAmount, sourceCurrency), currency)
+  const formatOptions = { bitcoinUnit }
+
+  return {
+    masked: prettyFiatHide(selectedCurrencyAmount, currency, formatOptions),
+    value: prettyFiatAmount(selectedCurrencyAmount, currency, formatOptions),
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,9 +101,25 @@ export type Tx = {
   roundTxid: string
   settled: boolean
   type: string
-  prototypeSwap?: {
+  assetSwap?: {
+    fromAssetId?: string
     fromTicker: string
+    fromDecimals?: number
+    fromAmount?: bigint
+    toAssetId?: string
     toTicker: string
+    toDecimals?: number
+    toAmount?: bigint
+    fiatAmount?: number
+    status?: 'pending' | 'failed' | 'completed' | 'cancelled' | 'recoverable'
+    feeBps?: number
+    rate?: string
+    fiatCurrency?: string
+    toFiatAmount?: number
+    quotedAt?: number
+    completedAt?: number
+    fundingTxid?: string
+    fillTxid?: string
   }
 }
 

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -7,7 +7,7 @@ import { AspContext } from './asp'
 import { WalletContext } from './wallet'
 import { cancelOffer, createOffer, OFFER_PACKET_TYPE } from '../lib/swap/offer'
 import { BTC_ASSET_ID, discoverMarkets } from '../lib/swap/markets'
-import { addAssetSwap, AssetSwap, getAssetSwaps, updateAssetSwap } from '../lib/swap/store'
+import { addAssetSwap, AssetSwap, type AssetSwapQuoteSnapshot, getAssetSwaps, updateAssetSwap } from '../lib/swap/store'
 import { getEmulatorUrlForNetwork } from '../lib/constants'
 import { consoleError } from '../lib/logs'
 import { sleep } from '../lib/sleep'
@@ -22,7 +22,7 @@ interface AssetSwapsContextProps {
   /** True when there are markets and the covenant co-signer is reachable. */
   swapAvailable: boolean
   swaps: AssetSwap[]
-  createSwap: (plan: OfferPlan) => Promise<AssetSwap>
+  createSwap: (plan: OfferPlan, quote?: AssetSwapQuoteSnapshot) => Promise<AssetSwap>
   cancelSwap: (id: string) => Promise<void>
 }
 
@@ -86,7 +86,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
     return assetId.slice(0, 8)
   }
 
-  const createSwap = async (plan: OfferPlan): Promise<AssetSwap> => {
+  const createSwap = async (plan: OfferPlan, quote?: AssetSwapQuoteSnapshot): Promise<AssetSwap> => {
     if (!svcWallet) throw new Error('wallet not available')
     if (!emulatorUrl) throw new Error('swap service unavailable')
     const depositIsBtc = plan.deposit.asset.id === BTC_ASSET_ID
@@ -115,6 +115,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
       fundingTxid: txid,
       status: 'pending',
       createdAt: Date.now(),
+      quote,
     }
     setSwaps(addAssetSwap(swap))
     reloadWallet().catch(consoleError)
@@ -201,7 +202,13 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
           toast.success('Swap cancelled, funds returned')
           reloadWallet().catch(consoleError)
         } else {
-          setSwaps(updateAssetSwap(swap.id, { status: 'fulfilled', spentTxid: vtxo.arkTxId ?? vtxo.spentBy }))
+          setSwaps(
+            updateAssetSwap(swap.id, {
+              status: 'fulfilled',
+              spentTxid: vtxo.arkTxId ?? vtxo.spentBy,
+              completedAt: Date.now(),
+            }),
+          )
           toast.success(`Swap completed, ${tickerFor(swap.toAsset)} received`)
           reloadWallet().catch(consoleError)
         }

--- a/src/providers/assets.tsx
+++ b/src/providers/assets.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext, useEffect, useRef } from 'react'
+import { ReactNode, createContext, useContext, useEffect, useState } from 'react'
 import { consoleError } from '../lib/logs'
 import { AspContext } from './asp'
 
@@ -15,7 +15,7 @@ export const AssetsContext = createContext<AssetsContextProps>({
 export const AssetsProvider = ({ children }: { children: ReactNode }) => {
   const { aspInfo } = useContext(AspContext)
 
-  const assetRegistry = useRef(null as string[] | null)
+  const [assetRegistry, setAssetRegistry] = useState<string[]>()
 
   const getRegistryUrl = (network: string): string => {
     if (!getRegistryFileName(network)) return ''
@@ -30,18 +30,24 @@ export const AssetsProvider = ({ children }: { children: ReactNode }) => {
   }
 
   useEffect(() => {
+    setAssetRegistry(undefined)
     if (!aspInfo.network) return
     const url = getRegistryUrl(aspInfo.network)
     if (!url) return
+    let cancelled = false
     fetch(url)
       .then((response) => response.json())
-      .then((data: string[]) => (assetRegistry.current = data))
+      .then((data: string[]) => {
+        if (!cancelled) setAssetRegistry(data)
+      })
       .catch((error) => consoleError(error, 'Error fetching asset registry data:'))
+    return () => {
+      cancelled = true
+    }
   }, [aspInfo.network])
 
   const isRegistered = (assetId: string): boolean => {
-    if (!assetRegistry.current) return false
-    return assetRegistry.current.includes(assetId)
+    return assetRegistry?.includes(assetId) ?? false
   }
 
   return <AssetsContext.Provider value={{ isRegistered }}>{children}</AssetsContext.Provider>

--- a/src/providers/flow.tsx
+++ b/src/providers/flow.tsx
@@ -2,6 +2,7 @@ import { BoltzSwap } from '@arkade-os/boltz-swap'
 import { ReactNode, createContext, useState } from 'react'
 import type { Asset, AssetDetails, ServiceWorkerWalletMode } from '@arkade-os/sdk'
 import { Tx } from '../lib/types'
+import type { FiatAccountSend } from '../lib/accountAssets'
 
 export interface InitInfo {
   password?: string
@@ -36,6 +37,7 @@ export interface RecvInfo {
 }
 
 export type SendInfo = {
+  account?: FiatAccountSend
   address?: string
   assets?: Asset[]
   arkAddress?: string
@@ -64,6 +66,7 @@ interface FlowContextProps {
   recvInfo: RecvInfo
   sendInfo: SendInfo
   swapInfo: SwapInfo
+  swapFromAssetId: string | undefined
   txInfo: TxInfo
   setInitInfo: (arg0: InitInfo) => void
   setNoteInfo: (arg0: NoteInfo) => void
@@ -71,6 +74,7 @@ interface FlowContextProps {
   setRecvInfo: (arg0: RecvInfo) => void
   setSendInfo: (arg0: SendInfo) => void
   setSwapInfo: (arg0: SwapInfo) => void
+  setSwapFromAssetId: (arg0: string | undefined) => void
   setTxInfo: (arg0: TxInfo) => void
   assetInfo: AssetDetails
   setAssetInfo: (arg0: AssetDetails) => void
@@ -113,6 +117,7 @@ export const FlowContext = createContext<FlowContextProps>({
   recvInfo: emptyRecvInfo,
   sendInfo: emptySendInfo,
   swapInfo: undefined,
+  swapFromAssetId: undefined,
   txInfo: undefined,
   setInitInfo: () => {},
   setNoteInfo: () => {},
@@ -120,6 +125,7 @@ export const FlowContext = createContext<FlowContextProps>({
   setRecvInfo: () => {},
   setSendInfo: () => {},
   setSwapInfo: () => {},
+  setSwapFromAssetId: () => {},
   setTxInfo: () => {},
   assetInfo: emptyAssetInfo,
   setAssetInfo: () => {},
@@ -134,6 +140,7 @@ export const FlowProvider = ({ children }: { children: ReactNode }) => {
   const [recvInfo, setRecvInfo] = useState(emptyRecvInfo)
   const [sendInfo, setSendInfo] = useState(emptySendInfo)
   const [swapInfo, setSwapInfo] = useState<SwapInfo>()
+  const [swapFromAssetId, setSwapFromAssetId] = useState<string | undefined>()
   const [txInfo, setTxInfo] = useState<TxInfo>()
   const [assetInfo, setAssetInfo] = useState<AssetDetails>(emptyAssetInfo)
   const [lnurlInfo, setLnurlInfo] = useState<LnUrlInfo>()
@@ -148,6 +155,7 @@ export const FlowProvider = ({ children }: { children: ReactNode }) => {
         recvInfo,
         sendInfo,
         swapInfo,
+        swapFromAssetId,
         txInfo,
         setInitInfo,
         setNoteInfo,
@@ -155,6 +163,7 @@ export const FlowProvider = ({ children }: { children: ReactNode }) => {
         setRecvInfo,
         setSendInfo,
         setSwapInfo,
+        setSwapFromAssetId,
         setTxInfo,
         assetInfo,
         setAssetInfo,

--- a/src/providers/navigation.tsx
+++ b/src/providers/navigation.tsx
@@ -18,8 +18,9 @@ import Activity from '../screens/Wallet/Activity'
 import Vtxos from '../screens/Settings/Vtxos'
 import Wallet from '../screens/Wallet/Index'
 import BitcoinDetail from '../screens/Wallet/BitcoinDetail'
-import Settings from '../screens/Settings/Index'
+import AccountDetail from '../screens/Wallet/AccountDetail'
 import WalletSwap from '../screens/Wallet/Swap/Index'
+import Settings from '../screens/Settings/Index'
 
 import AppBoltz from '../screens/Apps/Boltz/Index'
 import AppBoltzSettings from '../screens/Apps/Boltz/Settings'
@@ -43,6 +44,7 @@ export type NavigationDirection = 'forward' | 'back' | 'none'
 
 export enum Pages {
   Activity,
+  AccountDetail,
   BitcoinDetail,
   AppBoltz,
   AppBoltzSettings,
@@ -105,6 +107,8 @@ export const pageComponent = (page: Pages): JSX.Element => {
   switch (page) {
     case Pages.Activity:
       return <Activity />
+    case Pages.AccountDetail:
+      return <AccountDetail />
     case Pages.BitcoinDetail:
       return <BitcoinDetail />
     case Pages.AppBoltz:

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -35,6 +35,7 @@ import { arkNoteInUrl } from '../lib/arknote'
 import { deepLinkInUrl } from '../lib/deepLink'
 import { consoleError } from '../lib/logs'
 import { Tx, Vtxo, Wallet } from '../lib/types'
+import { mergeAssetSwapActivity } from '../lib/swap/store'
 import { nsecToPrivateKey, getPrivateKey, noUserDefinedPassword } from '../lib/privateKey'
 import { hasMnemonic, getMnemonic, deriveNostrKeyFromMnemonic } from '../lib/mnemonic'
 import { resolveWalletMode } from '../lib/walletMode'
@@ -440,7 +441,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         updateConfig({ ...config, apps: { ...config.apps, assets: { enabled: true } } })
       }
       setVtxos(vtxos)
-      setTxs(txs)
+      setTxs(mergeAssetSwapActivity(txs, undefined, aspInfo.network))
       if (!hasLoadedOnce.current) {
         hasLoadedOnce.current = true
         setDataReady(true)

--- a/src/screens/Wallet/AccountDetail.tsx
+++ b/src/screens/Wallet/AccountDetail.tsx
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { FlowContext } from '../../providers/flow'
+import BitcoinDetail from './BitcoinDetail'
+
+export default function AccountDetail() {
+  const { assetInfo } = useContext(FlowContext)
+  return <BitcoinDetail assetId={assetInfo.assetId} />
+}

--- a/src/screens/Wallet/AssetsSection.tsx
+++ b/src/screens/Wallet/AssetsSection.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import AssetCard from '../../components/AssetCard'
-import { usePortfolioFiat } from '../../hooks/usePortfolioFiat'
+import { usePortfolioFiat, type PortfolioRow } from '../../hooks/usePortfolioFiat'
 import { ConfigContext } from '../../providers/config'
 import { FiatContext } from '../../providers/fiat'
 import { NavigationContext, Pages } from '../../providers/navigation'
@@ -16,7 +16,7 @@ export default function AssetsSection() {
   const { isRegistered } = useContext(AssetsContext)
 
   const { rows } = usePortfolioFiat()
-  const visibleRows = rows.filter((row) => isRegistered(row.assetId) || row.assetId === 'btc')
+  const visibleRows = rows.filter((row) => isVisibleAssetRow(row, config.importedAssets, isRegistered))
 
   const fiatLabel = (amount: number) => {
     const decimals = fiatDecimals()
@@ -27,11 +27,14 @@ export default function AssetsSection() {
     })
   }
 
-  const handleAssetClick = (assetId: string) => {
-    if (assetId === 'btc') {
+  const handleAssetClick = (row: PortfolioRow) => {
+    if (row.assetId === 'btc') {
       navigate(Pages.BitcoinDetail)
+    } else if (row.fiatCurrency) {
+      setAssetInfo({ assetId: row.assetId, supply: BigInt(0) })
+      navigate(Pages.AccountDetail)
     } else {
-      setAssetInfo({ assetId, supply: BigInt(0) })
+      setAssetInfo({ assetId: row.assetId, supply: BigInt(0) })
       navigate(Pages.AppAssetDetail)
     }
   }
@@ -39,7 +42,7 @@ export default function AssetsSection() {
   return (
     <section className='home-section'>
       <div className='flex w-full items-center justify-between px-1'>
-        <span className='home-section-label'>Assets</span>
+        <span className='home-section-label'>Accounts</span>
       </div>
       <div className='home-section__content'>
         {visibleRows.map((row) => (
@@ -52,10 +55,19 @@ export default function AssetsSection() {
             decimals={row.decimals}
             balance={row.balance}
             fiatText={row.hasFiatPrice ? fiatLabel(row.fiatAmount) : undefined}
-            onClick={() => handleAssetClick(row.assetId)}
+            onClick={() => handleAssetClick(row)}
           />
         ))}
       </div>
     </section>
   )
+}
+
+function isVisibleAssetRow(
+  row: PortfolioRow,
+  importedAssets: string[],
+  isRegistered: (assetId: string) => boolean,
+): boolean {
+  if (row.assetId === 'btc') return true
+  return importedAssets.includes(row.assetId) || isRegistered(row.assetId)
 }

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -1,13 +1,15 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { Liveline, type HoverPoint, type LivelinePoint } from 'liveline'
 import { ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import AssetAvatar from '../../components/AssetAvatar'
 import Content from '../../components/Content'
 import Header from '../../components/Header'
 import Padded from '../../components/Padded'
 import { PrivacyAmount } from '../../components/PrivacyAmount'
 import SwapComingSoonSheet from '../../components/SwapComingSoonSheet'
-import TokenLogo from '../../components/TokenLogo'
+import TokenLogo, { accountTickerForAssetTicker, tokenLogoTickerForTicker } from '../../components/TokenLogo'
 import TransactionsList from '../../components/TransactionsList'
+import { usePortfolioFiat, type PortfolioRow } from '../../hooks/usePortfolioFiat'
 import ReceiveIcon from '../../icons/Receive'
 import ScanIcon from '../../icons/Scan'
 import SendIcon from '../../icons/Send'
@@ -17,6 +19,7 @@ import {
   prettyBitcoinAmount,
   prettyBitcoinHide,
   prettyChartDateTime,
+  prettyCurrencyAssetAmount,
   prettyFiatAmount,
   prettyFiatHide,
   prettyNumber,
@@ -24,15 +27,15 @@ import {
 import { fiatDecimalsFor } from '../../lib/fiat'
 import { hapticLight, hapticSubtle } from '../../lib/haptics'
 import { consoleError } from '../../lib/logs'
-import { Currencies, Themes } from '../../lib/types'
+import { Currencies, Themes, Unit } from '../../lib/types'
 import { useReducedMotion } from '../../hooks/useReducedMotion'
 import { AssetSwapsContext } from '../../providers/assetSwaps'
 import { ConfigContext } from '../../providers/config'
 import { FiatContext } from '../../providers/fiat'
 import { FlowContext, emptyRecvInfo, emptySendInfo } from '../../providers/flow'
 import { NavigationContext, Pages } from '../../providers/navigation'
-import { WalletContext } from '../../providers/wallet'
-import { fetchHistoricalMarketData } from '../../lib/marketData'
+import { buildConstantMarketSeries, buildCrossRatePoints, fetchHistoricalMarketData } from '../../lib/marketData'
+import { accountChartColorToken } from '../../lib/accountAssets'
 
 const CHART_WINDOWS = [
   { label: '1H', secs: 3_600 },
@@ -44,15 +47,28 @@ const CHART_WINDOWS = [
 ]
 
 const MIN_CHART_WINDOW_SECS = 30
-const bitcoinChartCache = new Map<string, LivelinePoint[]>()
+const marketChartCache = new Map<string, LivelinePoint[]>()
 
-export default function BitcoinDetail() {
+type MarketChartStatus = 'loading' | 'ready' | 'unavailable'
+
+const unavailableRow: PortfolioRow = {
+  assetId: '',
+  name: 'Account unavailable',
+  ticker: 'TKN',
+  decimals: 0,
+  balance: BigInt(0),
+  fiatAmount: 0,
+  satsEquivalent: 0,
+  hasFiatPrice: false,
+}
+
+export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string }) {
   const { config } = useContext(ConfigContext)
-  const { toFiatAmount } = useContext(FiatContext)
-  const { setRecvInfo, setSendInfo } = useContext(FlowContext)
+  const { fromFiatAmount, toFiatAmount } = useContext(FiatContext)
+  const { setRecvInfo, setSendInfo, setSwapFromAssetId } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
-  const { balance } = useContext(WalletContext)
   const { swapAvailable, swaps } = useContext(AssetSwapsContext)
+  const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
 
   const [chartWindow, setChartWindow] = useState(CHART_WINDOWS[2].secs)
@@ -60,50 +76,108 @@ export default function BitcoinDetail() {
   const [swapSheetOpen, setSwapSheetOpen] = useState(false)
   const chartHapticState = useRef({ lastPointTime: 0, lastTriggerTime: 0 })
 
-  const marketFiat = config.currency === Currencies.BTC ? Currencies.USD : config.currency
-  const marketDecimals = fiatDecimalsFor(marketFiat)
+  const selectedRow = rows.find((candidate) => candidate.assetId === assetId)
+  const row = selectedRow ?? unavailableRow
+  const isBitcoin = row.assetId === 'btc'
+  const sourceFiat = isBitcoin ? Currencies.BTC : row.fiatCurrency
+  const marketFiat = isBitcoin && config.currency === Currencies.BTC ? Currencies.USD : config.currency
   const bitcoinUnit = config.unit
-  const currentUnitPrice = toFiatAmount(100_000_000, marketFiat)
-  const liveChartData = useBitcoinMarketChartData(marketFiat, chartWindow)
-  const chartUnitPrice = liveChartData.at(-1)?.value ?? currentUnitPrice
-  const fiatValue = (balance / 100_000_000) * currentUnitPrice
-  const formattedFiat = prettyFiatAmount(fiatValue, marketFiat, {
-    maximumFractionDigits: marketDecimals,
-    minimumFractionDigits: marketDecimals,
-  })
-  const chartColor = useTokenColor('--orange-500', config.theme)
+  const marketDecimals = fiatDecimalsFor(marketFiat, bitcoinUnit)
+  const currentUnitPrice = currentPriceForRow(isBitcoin, sourceFiat, marketFiat, fromFiatAmount, toFiatAmount)
+  const marketChart = useAccountMarketChartData(sourceFiat, marketFiat, chartWindow, bitcoinUnit)
+  const chartUnitPrice = marketChart.data.at(-1)?.value ?? currentUnitPrice ?? 0
+  const safeBitcoinBalance =
+    isBitcoin && typeof row.balance === 'number' && Number.isFinite(row.balance)
+      ? Math.max(0, Math.floor(row.balance))
+      : 0
+  const fiatValue = isBitcoin
+    ? currentUnitPrice === undefined
+      ? undefined
+      : (safeBitcoinBalance / 100_000_000) * currentUnitPrice
+    : row.hasFiatPrice
+      ? row.fiatAmount
+      : undefined
+  const formattedFiat =
+    fiatValue === undefined
+      ? undefined
+      : prettyFiatAmount(fiatValue, marketFiat, {
+          bitcoinUnit,
+          maximumFractionDigits: marketDecimals,
+          minimumFractionDigits: marketDecimals,
+        })
+  const rawBalance = typeof row.balance === 'bigint' ? row.balance : BigInt(Math.max(0, Math.floor(row.balance)))
+  const formattedBalance = isBitcoin
+    ? prettyBitcoinAmount(safeBitcoinBalance, bitcoinUnit)
+    : `${prettyCurrencyAssetAmount(rawBalance, row.decimals, row.ticker)} ${row.ticker}`
+  const maskedBalance = isBitcoin ? prettyBitcoinHide(safeBitcoinBalance, bitcoinUnit) : `•••• ${row.ticker}`
+  const chartColor = useTokenColor(accountChartColorToken(row.ticker), config.theme)
   const chartTheme = useResolvedChartTheme(config.theme)
-  const safeBalance = Number.isFinite(balance) ? Math.max(0, Math.floor(balance)) : 0
-  const chartData = useMemo(
-    () => (liveChartData.length ? liveChartData : buildFlatChartData(chartUnitPrice, chartWindow)),
-    [chartWindow, chartUnitPrice, liveChartData],
-  )
   const chartDisplayData = useMemo(
-    () => smoothChartData(chartData, chartWindow, chartInteracting),
-    [chartData, chartInteracting, chartWindow],
+    () => smoothChartData(marketChart.data, chartWindow, chartInteracting),
+    [chartInteracting, chartWindow, marketChart.data],
   )
-  const chartDelta = calculateDelta(chartData)
+  const chartDelta = calculateDelta(marketChart.data)
   const livelineWindow = useMemo(
     () => getLivelineWindowSecs(chartDisplayData, chartWindow),
     [chartDisplayData, chartWindow],
   )
-  const canRenderChart = typeof ResizeObserver !== 'undefined'
+  const canRenderChart =
+    marketChart.status === 'ready' && marketChart.data.length >= 2 && typeof ResizeObserver !== 'undefined'
+  const accountTicker = accountTickerForAssetTicker(row.ticker)
+  const sourceAssetId = row.sourceAsset?.assetId ?? (!isBitcoin ? row.assetId : undefined)
+  const sendAccount =
+    !isBitcoin && accountTicker && accountTicker !== 'BTC' && row.sourceAsset
+      ? {
+          assetId: row.assetId,
+          ticker: accountTicker,
+          balance: rawBalance,
+          decimals: row.decimals,
+          amount: BigInt(0),
+          source: row.sourceAsset,
+        }
+      : undefined
+  const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? row.ticker)
+  const activityAssetFilter = isBitcoin ? 'btc' : row.assetId
+  const priceText =
+    currentUnitPrice === undefined
+      ? 'Price unavailable'
+      : prettyFiatAmount(currentUnitPrice, marketFiat, {
+          bitcoinUnit,
+          maximumFractionDigits: marketDecimals,
+          minimumFractionDigits: marketDecimals,
+        })
 
   const handleSend = () => {
     hapticLight()
-    setSendInfo(emptySendInfo)
+    setSendInfo(
+      sendAccount
+        ? { ...emptySendInfo, account: sendAccount }
+        : isBitcoin || !sourceAssetId
+          ? emptySendInfo
+          : { ...emptySendInfo, assets: [{ assetId: sourceAssetId, amount: BigInt(0) }] },
+    )
     navigate(Pages.SendForm)
   }
 
   const handleReceive = () => {
     hapticLight()
-    setRecvInfo(emptyRecvInfo)
+    setRecvInfo(
+      isBitcoin || !sourceAssetId
+        ? emptyRecvInfo
+        : { ...emptyRecvInfo, assetId: sourceAssetId, assetAmount: BigInt(0) },
+    )
     navigate(Pages.ReceiveQRCode)
   }
 
   const handleScan = () => {
     hapticLight()
-    setSendInfo({ ...emptySendInfo, scan: true })
+    setSendInfo(
+      sendAccount
+        ? { ...emptySendInfo, account: sendAccount, scan: true }
+        : isBitcoin || !sourceAssetId
+          ? { ...emptySendInfo, scan: true }
+          : { ...emptySendInfo, assets: [{ assetId: sourceAssetId, amount: BigInt(0) }], scan: true },
+    )
     navigate(Pages.SendForm)
   }
 
@@ -111,8 +185,12 @@ export default function BitcoinDetail() {
     hapticLight()
     // existing swaps stay reachable during outages so pending funds
     // remain cancellable from the swap screen
-    if (swapAvailable || swaps.length > 0) navigate(Pages.WalletSwap)
-    else setSwapSheetOpen(true)
+    if (swapAvailable || swaps.length > 0) {
+      setSwapFromAssetId(row.assetId)
+      navigate(Pages.WalletSwap)
+    } else {
+      setSwapSheetOpen(true)
+    }
   }
 
   const handleChartPress = useCallback(() => {
@@ -144,6 +222,19 @@ export default function BitcoinDetail() {
     [prefersReduced],
   )
 
+  if (!selectedRow) {
+    return (
+      <>
+        <Header text='' back />
+        <Content>
+          <Padded>
+            <div className='asset-detail-page'>Account unavailable</div>
+          </Padded>
+        </Content>
+      </>
+    )
+  }
+
   return (
     <>
       <Header text='' back />
@@ -158,10 +249,14 @@ export default function BitcoinDetail() {
             <motion.section className='asset-detail-hero' variants={prefersReduced ? undefined : walletLoadInChild}>
               <motion.div className='asset-detail-identity' variants={prefersReduced ? undefined : walletLoadInChild}>
                 <span className='asset-detail-logo' aria-hidden='true'>
-                  <TokenLogo ticker='BTC' />
+                  {tokenLogoTicker ? (
+                    <TokenLogo ticker={tokenLogoTicker} />
+                  ) : (
+                    <AssetAvatar icon={row.icon} name={row.name} ticker={row.ticker} size={60} />
+                  )}
                 </span>
                 <div>
-                  <h1 className='asset-detail-name'>Bitcoin</h1>
+                  <h1 className='asset-detail-name'>{row.name}</h1>
                 </div>
               </motion.div>
 
@@ -172,25 +267,42 @@ export default function BitcoinDetail() {
               >
                 <AnimatePresence mode='popLayout' initial={false}>
                   <motion.div
-                    key={`${currentUnitPrice}-${marketFiat}`}
-                    className='asset-detail-price'
+                    key={`${priceText}-${marketFiat}`}
+                    className={`asset-detail-price${currentUnitPrice === undefined ? ' asset-detail-price--unavailable' : ''}`}
                     initial={prefersReduced ? false : { opacity: 0, y: 8, filter: 'blur(2px)' }}
                     animate={prefersReduced ? undefined : { opacity: 1, y: 0, filter: 'blur(0px)' }}
                     exit={prefersReduced ? undefined : { opacity: 0, y: -8, filter: 'blur(2px)' }}
                     transition={{ duration: 0.22, ease: [0.23, 1, 0.32, 1] }}
                   >
-                    {prettyFiatAmount(currentUnitPrice, marketFiat)}
+                    {priceText}
                   </motion.div>
                 </AnimatePresence>
-                <DeltaBadge value={chartDelta} />
+                {marketChart.status === 'ready' && marketChart.data.length >= 2 ? (
+                  <DeltaBadge value={chartDelta} />
+                ) : null}
               </motion.div>
             </motion.section>
 
             <motion.div className='asset-detail-actions' variants={prefersReduced ? undefined : walletLoadInChild}>
-              <AssetAction icon={<ReceiveIcon />} label='Receive' onClick={handleReceive} />
-              <AssetAction icon={<SendIcon />} label='Send' onClick={handleSend} disabled={balance === 0} />
+              <AssetAction
+                icon={<ReceiveIcon />}
+                label='Receive'
+                onClick={handleReceive}
+                disabled={!isBitcoin && !sourceAssetId}
+              />
+              <AssetAction
+                icon={<SendIcon />}
+                label='Send'
+                onClick={handleSend}
+                disabled={rawBalance === BigInt(0) || (!isBitcoin && !sendAccount && !sourceAssetId)}
+              />
               <AssetAction icon={<SwapIcon />} label='Swap' onClick={handleSwap} />
-              <AssetAction icon={<ScanIcon />} label='Scan' onClick={handleScan} />
+              <AssetAction
+                icon={<ScanIcon />}
+                label='Scan'
+                onClick={handleScan}
+                disabled={!isBitcoin && !sourceAssetId}
+              />
             </motion.div>
 
             <motion.section
@@ -200,10 +312,13 @@ export default function BitcoinDetail() {
               <div
                 className='asset-detail-chart'
                 onPointerDown={() => {
+                  if (!canRenderChart) return
                   setChartScrubbing(true)
                   handleChartPress()
                 }}
-                onPointerEnter={() => setChartScrubbing(true)}
+                onPointerEnter={() => {
+                  if (canRenderChart) setChartScrubbing(true)
+                }}
                 onPointerLeave={() => setChartScrubbing(false)}
                 onPointerUp={() => setChartScrubbing(false)}
                 onPointerCancel={() => setChartScrubbing(false)}
@@ -218,7 +333,7 @@ export default function BitcoinDetail() {
                     badge={false}
                     badgeTail
                     badgeVariant='minimal'
-                    formatValue={(value) => prettyFiatAmount(value, marketFiat)}
+                    formatValue={(value) => prettyFiatAmount(value, marketFiat, { bitcoinUnit })}
                     formatTime={prettyChartDateTime}
                     grid={false}
                     paused={chartInteracting}
@@ -241,7 +356,9 @@ export default function BitcoinDetail() {
                     cursor='default'
                   />
                 ) : (
-                  <div className='asset-detail-chart-fallback' aria-hidden='true' />
+                  <div className='asset-detail-chart-fallback' role='status'>
+                    {marketChart.status === 'loading' ? 'Loading price history…' : 'Price history unavailable'}
+                  </div>
                 )}
               </div>
               <div className='asset-detail-range-tabs' role='tablist' aria-label='Price chart range'>
@@ -269,15 +386,21 @@ export default function BitcoinDetail() {
               <div className='asset-detail-holding'>
                 <span>Balance</span>
                 <strong>
-                  <PrivacyAmount masked={prettyBitcoinHide(safeBalance, bitcoinUnit)}>
-                    <span className='asset-detail-holding-amount'>{prettyBitcoinAmount(safeBalance, bitcoinUnit)}</span>
+                  <PrivacyAmount masked={maskedBalance}>
+                    <span className='asset-detail-holding-amount'>{formattedBalance}</span>
                   </PrivacyAmount>
                 </strong>
               </div>
               <div className='asset-detail-holding'>
                 <span>Value</span>
                 <strong>
-                  <PrivacyAmount masked={prettyFiatHide(fiatValue, marketFiat)}>{formattedFiat}</PrivacyAmount>
+                  {formattedFiat === undefined || fiatValue === undefined ? (
+                    'Unavailable'
+                  ) : (
+                    <PrivacyAmount masked={prettyFiatHide(fiatValue, marketFiat, { bitcoinUnit })}>
+                      {formattedFiat}
+                    </PrivacyAmount>
+                  )}
                 </strong>
               </div>
             </motion.section>
@@ -286,7 +409,7 @@ export default function BitcoinDetail() {
               <div className='asset-detail-section-header'>
                 <strong>Recent activity</strong>
               </div>
-              <TransactionsList mode='static' assetIdFilter='btc' limit={5} />
+              <TransactionsList mode='static' assetIdFilter={activityAssetFilter} limit={5} />
             </motion.section>
           </motion.div>
         </Padded>
@@ -391,49 +514,99 @@ function useResolvedChartTheme(theme: Themes): 'light' | 'dark' {
   return resolved
 }
 
-function useBitcoinMarketChartData(currency: Currencies, windowSecs: number): LivelinePoint[] {
-  const [data, setData] = useState<LivelinePoint[]>([])
+function currentPriceForRow(
+  isBitcoin: boolean,
+  sourceFiat: Currencies | undefined,
+  marketFiat: Currencies,
+  fromFiatAmount: (amount: number, currency: Currencies) => number,
+  toFiatAmount: (satoshis: number, currency: Currencies) => number,
+): number | undefined {
+  if (isBitcoin) return toFiatAmount(100_000_000, marketFiat)
+  if (!sourceFiat) return undefined
+  if (sourceFiat === marketFiat) return 1
+
+  const converted = toFiatAmount(fromFiatAmount(1, sourceFiat), marketFiat)
+  return Number.isFinite(converted) && converted > 0 ? converted : undefined
+}
+
+function useAccountMarketChartData(
+  sourceFiat: Currencies | undefined,
+  marketFiat: Currencies,
+  windowSecs: number,
+  bitcoinUnit: Unit,
+): { data: LivelinePoint[]; status: MarketChartStatus } {
+  const [chart, setChart] = useState<{ data: LivelinePoint[]; status: MarketChartStatus }>({
+    data: [],
+    status: sourceFiat ? 'loading' : 'unavailable',
+  })
 
   useEffect(() => {
     const controller = new AbortController()
-    const cacheKey = bitcoinChartCacheKey(currency, windowSecs)
-    const cached = bitcoinChartCache.get(cacheKey)
+    const cacheKey = marketChartCacheKey(sourceFiat, marketFiat, windowSecs, bitcoinUnit)
+    const cached = marketChartCache.get(cacheKey)
 
-    if (currency === Currencies.BTC) {
-      setData([])
+    if (!sourceFiat) {
+      setChart({ data: [], status: 'unavailable' })
       return () => controller.abort()
     }
 
     if (cached) {
-      setData(cached)
+      setChart({ data: cached, status: 'ready' })
       return () => controller.abort()
     }
 
-    fetchHistoricalMarketData(windowSecs, currency, controller.signal)
+    if (sourceFiat === marketFiat) {
+      const points = buildConstantMarketSeries(1, windowSecs)
+      marketChartCache.set(cacheKey, points)
+      setChart({ data: points, status: 'ready' })
+      return () => controller.abort()
+    }
+
+    setChart({ data: [], status: 'loading' })
+    fetchAccountMarketData(sourceFiat, marketFiat, windowSecs, bitcoinUnit, controller.signal)
       .then((points) => {
         if (controller.signal.aborted) return
-        bitcoinChartCache.set(cacheKey, points)
-        setData(points)
+        if (points.length < 2) {
+          setChart({ data: [], status: 'unavailable' })
+          return
+        }
+        marketChartCache.set(cacheKey, points)
+        setChart({ data: points, status: 'ready' })
       })
       .catch((err) => {
         if (controller.signal.aborted) return
-        consoleError(err, 'error fetching bitcoin market chart')
-        setData([])
+        consoleError(err, 'error fetching account market chart')
+        setChart({ data: [], status: 'unavailable' })
       })
 
     return () => controller.abort()
-  }, [currency, windowSecs])
+  }, [bitcoinUnit, marketFiat, sourceFiat, windowSecs])
 
-  return data
+  return chart
 }
 
-function buildFlatChartData(latestValue: number, windowSecs: number): LivelinePoint[] {
-  const now = Math.floor(Date.now() / 1000)
-  const fallbackWindowSecs = isAllChartWindow(windowSecs) ? 86_400 : windowSecs
-  return [
-    { time: now - fallbackWindowSecs, value: latestValue },
-    { time: now, value: latestValue },
-  ]
+async function fetchAccountMarketData(
+  sourceFiat: Currencies,
+  marketFiat: Currencies,
+  windowSecs: number,
+  bitcoinUnit: Unit,
+  signal: AbortSignal,
+): Promise<LivelinePoint[]> {
+  if (sourceFiat === Currencies.BTC) return fetchHistoricalMarketData(windowSecs, marketFiat, signal)
+
+  if (marketFiat === Currencies.BTC) {
+    const sourcePoints = await fetchHistoricalMarketData(windowSecs, sourceFiat, signal)
+    const bitcoinUnitScale = bitcoinUnit === Unit.BTC ? 1 : 100_000_000
+    return sourcePoints
+      .filter((point) => Number.isFinite(point.value) && point.value > 0)
+      .map((point) => ({ time: point.time, value: bitcoinUnitScale / point.value }))
+  }
+
+  const [sourcePoints, marketPoints] = await Promise.all([
+    fetchHistoricalMarketData(windowSecs, sourceFiat, signal),
+    fetchHistoricalMarketData(windowSecs, marketFiat, signal),
+  ])
+  return buildCrossRatePoints(sourcePoints, marketPoints)
 }
 
 function smoothChartData(data: LivelinePoint[], windowSecs: number, isInteracting: boolean): LivelinePoint[] {
@@ -522,8 +695,13 @@ function calculateDelta(data: LivelinePoint[]): number {
   return ((last - first) / first) * 100
 }
 
-function bitcoinChartCacheKey(currency: Currencies, windowSecs: number): string {
-  return `${currency}:${windowSecs}`
+function marketChartCacheKey(
+  sourceFiat: Currencies | undefined,
+  marketFiat: Currencies,
+  windowSecs: number,
+  bitcoinUnit: Unit,
+): string {
+  return `${sourceFiat ?? 'unpriced'}:${marketFiat}:${windowSecs}:${bitcoinUnit}`
 }
 
 function isAllChartWindow(windowSecs: number): boolean {

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -84,7 +84,13 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
   const bitcoinUnit = config.unit
   const marketDecimals = fiatDecimalsFor(marketFiat, bitcoinUnit)
   const currentUnitPrice = currentPriceForRow(isBitcoin, sourceFiat, marketFiat, fromFiatAmount, toFiatAmount)
-  const marketChart = useAccountMarketChartData(sourceFiat, marketFiat, chartWindow, bitcoinUnit)
+  const marketChart = useAccountMarketChartData(
+    sourceFiat,
+    marketFiat,
+    chartWindow,
+    bitcoinUnit,
+    sourceFiat === Currencies.BTC ? undefined : currentUnitPrice,
+  )
   const chartUnitPrice = marketChart.data.at(-1)?.value ?? currentUnitPrice ?? 0
   const safeBitcoinBalance =
     isBitcoin && typeof row.balance === 'number' && Number.isFinite(row.balance)
@@ -534,6 +540,7 @@ function useAccountMarketChartData(
   marketFiat: Currencies,
   windowSecs: number,
   bitcoinUnit: Unit,
+  fallbackUnitPrice?: number,
 ): { data: LivelinePoint[]; status: MarketChartStatus } {
   const [chart, setChart] = useState<{ data: LivelinePoint[]; status: MarketChartStatus }>({
     data: [],
@@ -544,6 +551,10 @@ function useAccountMarketChartData(
     const controller = new AbortController()
     const cacheKey = marketChartCacheKey(sourceFiat, marketFiat, windowSecs, bitcoinUnit)
     const cached = marketChartCache.get(cacheKey)
+    const fallback =
+      fallbackUnitPrice && Number.isFinite(fallbackUnitPrice) && fallbackUnitPrice > 0
+        ? buildConstantMarketSeries(fallbackUnitPrice, windowSecs)
+        : []
 
     if (!sourceFiat) {
       setChart({ data: [], status: 'unavailable' })
@@ -567,7 +578,7 @@ function useAccountMarketChartData(
       .then((points) => {
         if (controller.signal.aborted) return
         if (points.length < 2) {
-          setChart({ data: [], status: 'unavailable' })
+          setChart({ data: fallback, status: fallback.length ? 'ready' : 'unavailable' })
           return
         }
         marketChartCache.set(cacheKey, points)
@@ -576,11 +587,11 @@ function useAccountMarketChartData(
       .catch((err) => {
         if (controller.signal.aborted) return
         consoleError(err, 'error fetching account market chart')
-        setChart({ data: [], status: 'unavailable' })
+        setChart({ data: fallback, status: fallback.length ? 'ready' : 'unavailable' })
       })
 
     return () => controller.abort()
-  }, [bitcoinUnit, marketFiat, sourceFiat, windowSecs])
+  }, [bitcoinUnit, fallbackUnitPrice, marketFiat, sourceFiat, windowSecs])
 
   return chart
 }

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -41,8 +41,11 @@ import { useReducedMotion } from '../../../hooks/useReducedMotion'
 import ButtonsOnBottom from '../../../components/ButtonsOnBottom'
 import { AssetOption, Unit } from '../../../lib/types'
 import { EASE_OUT_QUINT } from '../../../lib/animations'
+import { walletAssetPresentationForId } from '../../../lib/accountAssets'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
+import { AspContext } from '../../../providers/asp'
+import { AssetsContext } from '../../../providers/assets'
 
 /**
  * Decide which value the QR should encode. Honours an explicit copy-sheet
@@ -60,6 +63,8 @@ export const resolveQrValue = (
 }
 
 export default function ReceiveQRCode() {
+  const { aspInfo } = useContext(AspContext)
+  const { isRegistered } = useContext(AssetsContext)
   const { config, useFiat } = useContext(ConfigContext)
   const { fromFiat } = useContext(FiatContext)
   const { navigate } = useContext(NavigationContext)
@@ -375,13 +380,20 @@ export default function ReceiveQRCode() {
     setAmountTextValue('')
   }
 
+  const assetPresentation = walletAssetPresentationForId(
+    aspInfo.network,
+    assetId,
+    isRegistered,
+    assetMeta?.metadata,
+    '',
+  )
   const assetOption: AssetOption = {
     assetId: assetId ?? '',
-    name: assetMeta?.metadata?.name ?? '',
-    ticker: assetMeta?.metadata?.ticker ?? '',
+    name: assetPresentation.name,
+    ticker: assetPresentation.ticker,
     balance: BigInt(0),
     decimals: assetMeta?.metadata?.decimals ?? 0,
-    icon: assetMeta?.metadata?.icon,
+    icon: assetPresentation.icon,
   }
 
   const data = { title: 'Receive', text: qrCodeValue }
@@ -413,7 +425,7 @@ export default function ReceiveQRCode() {
   }
 
   const amountLabel = hasAmount ? 'Edit amount' : 'Add amount'
-  const unitLabel = assetMeta?.metadata?.ticker ?? 'sats'
+  const unitLabel = assetMeta ? assetPresentation.ticker : 'sats'
 
   return (
     <>

--- a/src/screens/Wallet/Receive/Success.tsx
+++ b/src/screens/Wallet/Receive/Success.tsx
@@ -1,26 +1,34 @@
 import { useContext, useEffect, useState } from 'react'
-import Button from '../../../components/Button'
-import ButtonsOnBottom from '../../../components/ButtonsOnBottom'
-import Content from '../../../components/Content'
-import FlexCol from '../../../components/FlexCol'
-import Padded from '../../../components/Padded'
-import Text from '../../../components/Text'
-import SuccessIcon from '../../../icons/Success'
-import Success from '../../../components/Success'
+import WalletSuccessSplash from '../../../components/WalletSuccessSplash'
 import { NotificationsContext } from '../../../providers/notifications'
 import { FlowContext } from '../../../providers/flow'
-import Header from '../../../components/Header'
 import { NavigationContext, Pages } from '../../../providers/navigation'
-import { prettyAmount, prettyFiatAmount } from '../../../lib/format'
+import { prettyAmount, prettyCurrencyAssetAmount, prettyFiatAmount } from '../../../lib/format'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 import { WalletContext } from '../../../providers/wallet'
 import { consoleError } from '../../../lib/logs'
 import type { AssetDetails } from '@arkade-os/sdk'
-import AssetCard from '../../../components/AssetCard'
-import { prettyAssetAmount } from '../../../lib/assets'
+import { walletAssetPresentationForId } from '../../../lib/accountAssets'
+import { AspContext } from '../../../providers/asp'
+import { AssetsContext } from '../../../providers/assets'
+
+function formatAssetLabel(
+  a: { assetId: string; amount: bigint },
+  details: AssetDetails | undefined,
+  network: string | undefined,
+  isRegistered: (assetId: string) => boolean,
+) {
+  const meta = details?.metadata
+  const presentation = walletAssetPresentationForId(network, a.assetId, isRegistered, meta, 'assets')
+  const ticker = presentation.ticker || presentation.name
+  const amount = prettyCurrencyAssetAmount(a.amount, meta?.decimals ?? 0, ticker)
+  return `${amount} ${ticker}`
+}
 
 export default function ReceiveSuccess() {
+  const { aspInfo } = useContext(AspContext)
+  const { isRegistered } = useContext(AssetsContext)
   const { config, useFiat } = useContext(ConfigContext)
   const { toFiat } = useContext(FiatContext)
   const { recvInfo } = useContext(FlowContext)
@@ -62,12 +70,9 @@ export default function ReceiveSuccess() {
   useEffect(() => {
     if (isAssetReceive) {
       if (assetDetails.size < receivedAssets.length) return
-      const labels = receivedAssets.map((a) => {
-        const meta = assetDetails.get(a.assetId)?.metadata
-        const amount = prettyAssetAmount(a.amount, meta?.decimals ?? 0)
-        const ticker = meta?.ticker ?? meta?.name ?? 'assets'
-        return `${amount} ${ticker}`
-      })
+      const labels = receivedAssets.map((a) =>
+        formatAssetLabel(a, assetDetails.get(a.assetId), aspInfo.network, isRegistered),
+      )
       notifyPaymentReceived(recvInfo.satoshis, labels.join(', '))
     } else {
       notifyPaymentReceived(recvInfo.satoshis)
@@ -78,59 +83,18 @@ export default function ReceiveSuccess() {
     ? prettyFiatAmount(toFiat(recvInfo.satoshis), config.currency, { bitcoinUnit: config.unit })
     : prettyAmount(recvInfo.satoshis)
 
-  if (isAssetReceive) {
-    return (
-      <>
-        <Header text='Success' />
-        <Content>
-          <Padded>
-            <FlexCol gap='1.5rem' centered padding='1rem 0 0 0'>
-              <SuccessIcon small />
-              <Text centered big bold>
-                Payment received!
-              </Text>
-
-              {receivedAssets.map((a) => {
-                const meta = assetDetails.get(a.assetId)?.metadata
-                const name = meta?.name ?? 'Unknown Asset'
-                const ticker = meta?.ticker ?? ''
-                const icon = meta?.icon
-
-                return (
-                  <AssetCard
-                    icon={icon}
-                    name={name}
-                    ticker={ticker}
-                    key={a.assetId}
-                    assetId={a.assetId}
-                    balance={a.amount}
-                    decimals={meta?.decimals ?? 0}
-                  />
-                )
-              })}
-
-              <Text centered color='neutral-700' thin small wrap>
-                {displayAmount}
-              </Text>
-            </FlexCol>
-          </Padded>
-        </Content>
-        <ButtonsOnBottom>
-          <Button label='Sounds good' onClick={() => navigate(Pages.Wallet)} />
-        </ButtonsOnBottom>
-      </>
-    )
-  }
+  const displayText = isAssetReceive
+    ? receivedAssets
+        .map((a) => formatAssetLabel(a, assetDetails.get(a.assetId), aspInfo.network, isRegistered))
+        .join(', ')
+    : `${displayAmount} received successfully`
 
   return (
-    <>
-      <Header text='Success' />
-      <Content>
-        <Success headline='Payment received!' text={`${displayAmount} received successfully`} />
-      </Content>
-      <ButtonsOnBottom>
-        <Button label='Sounds good' onClick={() => navigate(Pages.Wallet)} />
-      </ButtonsOnBottom>
-    </>
+    <WalletSuccessSplash
+      headline='Payment received'
+      text={displayText}
+      ariaLabel='Payment received successfully. Tap to go home.'
+      onDone={() => navigate(Pages.Wallet)}
+    />
   )
 }

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -9,7 +9,7 @@ import ErrorMessage from '../../../components/Error'
 import { WalletContext } from '../../../providers/wallet'
 import Header from '../../../components/Header'
 import { defaultFee } from '../../../lib/constants'
-import { prettyNumber } from '../../../lib/format'
+import { prettyCurrencyAssetAmount, prettyNumber } from '../../../lib/format'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import { collaborativeExitWithFees, sendAssets, sendOffChain } from '../../../lib/asp'
@@ -21,22 +21,32 @@ import { SwapsContext } from '../../../providers/swaps'
 import Text from '../../../components/Text'
 import { isPendingChainSwap, isPendingSubmarineSwap } from '@arkade-os/boltz-swap'
 import { FeesContext } from '../../../providers/fees'
-import { prettyAssetAmount } from '../../../lib/assets'
+import { walletAssetLabel, walletAssetPresentationForId } from '../../../lib/accountAssets'
+import { AspContext } from '../../../providers/asp'
+import { AssetsContext } from '../../../providers/assets'
 
 export default function SendDetails() {
+  const { aspInfo } = useContext(AspContext)
+  const { isRegistered } = useContext(AssetsContext)
   const { navigate } = useContext(NavigationContext)
   const { sendInfo, setSendInfo } = useContext(FlowContext)
   const { calcOnchainOutputFee } = useContext(FeesContext)
-  const isAssetSend = Boolean(sendInfo.assets?.length)
+  const isAssetSend = Boolean(sendInfo.account || sendInfo.assets?.length)
   const { lnSwapsAllowed, utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { payInvoice, payBtc } = useContext(SwapsContext)
   const { assetMetadataCache, balance, svcWallet } = useContext(WalletContext)
 
-  const assetId = sendInfo.assets?.[0]?.assetId
+  const assetId = sendInfo.account?.assetId ?? sendInfo.assets?.[0]?.assetId
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
-  const assetTicker = assetMeta?.metadata?.ticker ?? ''
-  const assetName = assetMeta?.metadata?.name ?? 'Asset'
-  const assetAmountValue = sendInfo.assets?.[0]?.amount ?? BigInt(0)
+  const assetPresentation = sendInfo.account
+    ? { name: sendInfo.account.ticker, ticker: sendInfo.account.ticker }
+    : walletAssetPresentationForId(aspInfo.network, assetId, isRegistered, assetMeta?.metadata, assetId ?? 'Asset')
+  const assetTicker = assetPresentation.ticker
+  const assetName = assetPresentation.name
+  const assetDecimals = sendInfo.account?.decimals ?? assetMeta?.metadata?.decimals ?? 8
+  const assetLabel = walletAssetLabel(assetPresentation)
+  const assetAmountUnit = assetTicker || assetName
+  const assetAmountValue = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
   const [buttonLabel, setButtonLabel] = useState('')
   const [details, setDetails] = useState<DetailsProps>()
@@ -202,10 +212,10 @@ export default function SendDetails() {
               {isAssetSend ? (
                 <FlexCol gap='0.5rem'>
                   <Text color='neutral-500' smaller testId='send-details-asset-name'>
-                    {assetName} ({assetTicker})
+                    {assetLabel}
                   </Text>
                   <Text bold testId='send-details-asset-amount'>
-                    {prettyAssetAmount(assetAmountValue, assetMeta?.metadata?.decimals ?? 8)} {assetTicker}
+                    {prettyCurrencyAssetAmount(assetAmountValue, assetDecimals, assetAmountUnit)} {assetAmountUnit}
                   </Text>
                 </FlexCol>
               ) : null}

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { BrantaService, type Payment } from '@branta-ops/branta/v2'
 import Button from '../../../components/Button'
 import ErrorMessage from '../../../components/Error'
@@ -49,7 +49,8 @@ import SheetModal from '../../../components/SheetModal'
 import { AnimatePresence, motion } from 'framer-motion'
 import { overlaySlideUp, overlayStyle } from '../../../lib/animations'
 import { useReducedMotion } from '../../../hooks/useReducedMotion'
-import TokenLogo, { TokenLogoTicker } from '../../../components/TokenLogo'
+import TokenLogo, { tokenLogoTickerForTicker } from '../../../components/TokenLogo'
+import { normalizeAssetMinorUnits, walletAssetPresentationForId } from '../../../lib/accountAssets'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -58,6 +59,7 @@ import {
 } from '../../../components/ui/dropdown-menu'
 import { hapticLight } from '../../../lib/haptics'
 import { testDomains } from '../../../lib/constants'
+import { AssetsContext } from '../../../providers/assets'
 
 const isProductionEnv = !testDomains.some((d) => window.location.hostname.includes(d))
 
@@ -67,13 +69,7 @@ const brantaClient = new BrantaService({
 })
 
 function AssetIcon({ asset }: { asset: AssetOption | null }) {
-  const ticker = asset?.ticker?.toUpperCase()
-  const tokenTicker =
-    ticker === 'USD' || ticker === 'USDT' || ticker === 'USDC' || ticker === 'CHF' || ticker === 'BRL'
-      ? (ticker as TokenLogoTicker)
-      : asset
-        ? null
-        : 'BTC'
+  const tokenTicker = asset ? tokenLogoTickerForTicker(asset.ticker) : 'BTC'
 
   if (tokenTicker) {
     return (
@@ -96,6 +92,7 @@ function AssetIcon({ asset }: { asset: AssetOption | null }) {
 
 export default function SendForm() {
   const { aspInfo } = useContext(AspContext)
+  const { isRegistered } = useContext(AssetsContext)
   const { config, effectiveTheme, useFiat } = useContext(ConfigContext)
   const { calcOnchainOutputFee } = useContext(FeesContext)
   const { toFiat, fromFiat, fiatDecimals } = useContext(FiatContext)
@@ -147,7 +144,21 @@ export default function SendForm() {
   const timeoutRef = useRef<NodeJS.Timeout>()
 
   const prefersReducedMotion = useReducedMotion()
-  const isAssetSend = selectedAsset !== null
+  const accountAsset = useMemo<AssetOption | null>(
+    () =>
+      sendInfo.account
+        ? {
+            assetId: sendInfo.account.assetId,
+            balance: sendInfo.account.balance,
+            decimals: sendInfo.account.decimals,
+            name: sendInfo.account.ticker,
+            ticker: sendInfo.account.ticker,
+          }
+        : null,
+    [sendInfo.account],
+  )
+  const activeAsset = accountAsset ?? selectedAsset
+  const isAssetSend = activeAsset !== null
 
   const DUST_AMOUNT = 330
   const RECIPIENT_DEBOUNCE_MS = 800
@@ -211,12 +222,19 @@ export default function SendForm() {
             consoleError(err, `error fetching metadata for ${ab.assetId}`)
           }
         }
+        const presentation = walletAssetPresentationForId(
+          aspInfo.network,
+          ab.assetId,
+          isRegistered,
+          meta?.metadata,
+          `${ab.assetId.slice(0, 8)}...`,
+        )
         options.push({
           assetId: ab.assetId,
           balance: ab.amount,
-          name: meta?.metadata?.name ?? `${ab.assetId.slice(0, 8)}...`,
-          ticker: meta?.metadata?.ticker ?? '',
-          icon: meta?.metadata?.icon,
+          name: presentation.name,
+          ticker: presentation.ticker,
+          icon: presentation.icon,
           decimals: meta?.metadata?.decimals ?? 8,
         })
       }
@@ -227,11 +245,15 @@ export default function SendForm() {
 
   // initialize selected asset from pre-set sendInfo.assets (e.g. from Asset Detail page)
   useEffect(() => {
+    if (sendInfo.account) {
+      setSelectedAsset(null)
+      return
+    }
     if (!sendInfo.assets?.length || assetOptions.length === 0) return
     const presetAssetId = sendInfo.assets[0].assetId
     const found = assetOptions.find((a) => a.assetId === presetAssetId)
     if (found && !selectedAsset) setSelectedAsset(found)
-  }, [assetOptions, sendInfo.assets])
+  }, [assetOptions, sendInfo.account, sendInfo.assets])
 
   // update available balance
   useEffect(() => {
@@ -271,12 +293,19 @@ export default function SendForm() {
                 consoleError(err, `error fetching metadata for ${assetId}`)
               }
             }
+            const presentation = walletAssetPresentationForId(
+              aspInfo.network,
+              assetId,
+              isRegistered,
+              meta?.metadata,
+              `${assetId.slice(0, 8)}...`,
+            )
             found = {
               assetId,
               balance: BigInt(0),
-              name: meta?.metadata?.name ?? `${assetId.slice(0, 8)}...`,
-              ticker: meta?.metadata?.ticker ?? '',
-              icon: meta?.metadata?.icon,
+              name: presentation.name,
+              ticker: presentation.ticker,
+              icon: presentation.icon,
               decimals: meta?.metadata?.decimals ?? 8,
             }
           }
@@ -292,6 +321,7 @@ export default function SendForm() {
           })
         }
         setSendInfo({
+          account: sendInfo.account,
           address,
           arkAddress,
           assets: sendInfo.assets,
@@ -500,9 +530,9 @@ export default function SendForm() {
 
   // manage button label and errors
   useEffect(() => {
-    if (isAssetSend && selectedAsset) {
-      const assetAmt = sendInfo.assets?.[0]?.amount ?? 0
-      setLabel(assetAmt > selectedAsset.balance ? 'Insufficient asset balance' : 'Continue')
+    if (isAssetSend && activeAsset) {
+      const assetAmount = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
+      setLabel(assetAmount > activeAsset.balance ? 'Insufficient asset balance' : 'Continue')
       return
     }
     const satoshis = sendInfo.satoshis ?? 0
@@ -521,7 +551,7 @@ export default function SendForm() {
                   ? 'Amount below min limit'
                   : 'Continue',
     )
-  }, [sendInfo.satoshis, sendInfo.assets, liquidBalance, selectedAsset])
+  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.account, liquidBalance, activeAsset])
 
   // manage server unreachable error
   useEffect(() => {
@@ -601,7 +631,24 @@ export default function SendForm() {
     setValueSats(undefined)
     setAmountTextValue(value)
     if (isAssetSend) {
-      if (selectedAsset) {
+      if (sendInfo.account) {
+        const accountAmount = unitsToCents(value, sendInfo.account.decimals)
+        setSendInfo({
+          ...sendInfo,
+          account: { ...sendInfo.account, amount: accountAmount },
+          assets: [
+            {
+              assetId: sendInfo.account.source.assetId,
+              amount: normalizeAssetMinorUnits(
+                accountAmount,
+                sendInfo.account.decimals,
+                sendInfo.account.source.decimals,
+              ),
+            },
+          ],
+          satoshis: 0,
+        })
+      } else if (selectedAsset) {
         const decimals = selectedAsset?.decimals
         const cents = unitsToCents(value, decimals)
         setSendInfo({
@@ -638,12 +685,13 @@ export default function SendForm() {
       }
       setSendInfo({
         ...sendInfo,
+        account: undefined,
         address: '',
         assets: [{ assetId: asset.assetId, amount: BigInt(0) }],
         satoshis: 0,
       })
     } else {
-      setSendInfo({ ...sendInfo, assets: undefined, satoshis: 0 })
+      setSendInfo({ ...sendInfo, account: undefined, assets: undefined, satoshis: 0 })
     }
     setAmountTextValue('')
   }
@@ -700,7 +748,15 @@ export default function SendForm() {
   }
 
   const applySendAll = () => {
-    if (isAssetSend && selectedAsset) {
+    if (sendInfo.account) {
+      setSendInfo({
+        ...sendInfo,
+        account: { ...sendInfo.account, amount: sendInfo.account.balance },
+        assets: [{ assetId: sendInfo.account.source.assetId, amount: sendInfo.account.source.balance }],
+        satoshis: 0,
+      })
+      setAmountTextValue(centsToUnits(sendInfo.account.balance, sendInfo.account.decimals))
+    } else if (isAssetSend && selectedAsset) {
       const { assetId, balance, decimals } = selectedAsset
       const assets = [{ assetId, amount: balance }]
       setSendInfo({ ...sendInfo, assets, satoshis: 0 })
@@ -724,11 +780,11 @@ export default function SendForm() {
   }
 
   const Available = () => {
-    if (isAssetSend && selectedAsset) {
+    if (isAssetSend && activeAsset) {
       return (
         <div onClick={handleSendAll} style={{ cursor: 'pointer' }}>
           <Text color='neutral-500' smaller>
-            {`${prettyAssetAmount(selectedAsset.balance, selectedAsset.decimals)} ${selectedAsset.ticker} available`}
+            {`${prettyAssetAmount(activeAsset.balance, activeAsset.decimals)} ${activeAsset.ticker} available`}
           </Text>
         </div>
       )
@@ -751,11 +807,11 @@ export default function SendForm() {
 
   const { address, arkAddress, lnUrl, invoice, satoshis } = sendInfo
 
-  const assetAmt = sendInfo.assets?.[0]?.amount ?? BigInt(0)
+  const assetAmt = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
   const buttonDisabled = isAssetSend
     ? !(arkAddress && assetAmt > 0) ||
-      (selectedAsset ? assetAmt > selectedAsset.balance : true) ||
+      (activeAsset ? assetAmt > activeAsset.balance : true) ||
       Boolean(recipientError) ||
       aspInfo.unreachable ||
       tryingToSelfSend ||
@@ -773,9 +829,9 @@ export default function SendForm() {
       satoshis < 1 ||
       processing
 
-  const selectedAssetLabel = selectedAsset ? `${selectedAsset.name} (${selectedAsset.ticker})` : 'Bitcoin'
-  const selectedAssetBalance = selectedAsset
-    ? `${prettyAssetAmount(selectedAsset.balance, selectedAsset.decimals)} ${selectedAsset.ticker} available`
+  const selectedAssetLabel = activeAsset ? `${activeAsset.name} (${activeAsset.ticker})` : 'Bitcoin'
+  const selectedAssetBalance = activeAsset
+    ? `${prettyAssetAmount(activeAsset.balance, activeAsset.decimals)} ${activeAsset.ticker} available`
     : `${
         useFiat
           ? prettyFiatAmount(toFiat(liquidBalance), config.currency, { bitcoinUnit: config.unit })
@@ -786,7 +842,7 @@ export default function SendForm() {
   const sendOverlayStyle = { ...overlayStyle, position: 'fixed' as const, zIndex: 20 }
 
   const Keys = () => (
-    <Keyboard asset={selectedAsset ?? undefined} back={() => setKeys(false)} onSave={handleKeyboardAmountSave} />
+    <Keyboard asset={activeAsset ?? undefined} back={() => setKeys(false)} onSave={handleKeyboardAmountSave} />
   )
 
   if (keys && !amountIsReadOnly) {
@@ -938,7 +994,7 @@ export default function SendForm() {
                       data-testid='asset-selector'
                     >
                       <span className='send-asset-trigger__main'>
-                        <AssetIcon asset={selectedAsset} />
+                        <AssetIcon asset={activeAsset} />
                         <span className='send-asset-trigger__copy'>
                           <span className='send-asset-trigger__name'>{selectedAssetLabel}</span>
                           <span className='send-asset-trigger__balance'>{selectedAssetBalance}</span>
@@ -950,7 +1006,7 @@ export default function SendForm() {
                     </DropdownMenuTrigger>
                     <DropdownMenuContent className='send-asset-menu' align='start' side='bottom' sideOffset={8}>
                       <FlexCol gap='0.25rem'>
-                        {selectedAsset ? (
+                        {activeAsset ? (
                           <DropdownMenuItem className='send-asset-option' onClick={() => handleSelectAsset(null)}>
                             <span className='send-asset-option__main'>
                               <AssetIcon asset={null} />
@@ -969,7 +1025,11 @@ export default function SendForm() {
                           </DropdownMenuItem>
                         ) : null}
                         {assetOptions
-                          .filter((asset) => asset.assetId !== selectedAsset?.assetId)
+                          .filter(
+                            (asset) =>
+                              asset.assetId !== activeAsset?.assetId &&
+                              asset.assetId !== sendInfo.account?.source.assetId,
+                          )
                           .map((asset) => (
                             <DropdownMenuItem
                               key={asset.assetId}
@@ -1010,7 +1070,7 @@ export default function SendForm() {
                   onChange={handleAmountChange}
                   min={lnUrlResponse?.minSendable}
                   max={lnUrlResponse?.maxSendable}
-                  asset={selectedAsset ?? undefined}
+                  asset={activeAsset ?? undefined}
                   focus={focus === 'amount' && !isMobileBrowser}
                 />
               </FlexCol>

--- a/src/screens/Wallet/Send/Success.tsx
+++ b/src/screens/Wallet/Send/Success.tsx
@@ -6,22 +6,24 @@ import Header from '../../../components/Header'
 import Content from '../../../components/Content'
 import Button from '../../../components/Button'
 import ButtonsOnBottom from '../../../components/ButtonsOnBottom'
-import Success from '../../../components/Success'
 import CenterScreen from '../../../components/CenterScreen'
 import FlexCol from '../../../components/FlexCol'
 import Padded from '../../../components/Padded'
 import Text from '../../../components/Text'
+import WalletSuccessSplash from '../../../components/WalletSuccessSplash'
 import SuccessIcon from '../../../icons/Success'
 import SpinnerIcon from '../../../icons/Spinner'
-import { prettyAmount, prettyFiatAmount } from '../../../lib/format'
+import { prettyAmount, prettyCurrencyAssetAmount, prettyFiatAmount } from '../../../lib/format'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
 import { WalletContext } from '../../../providers/wallet'
 import { SwapsContext } from '../../../providers/swaps'
 import AssetCard from '../../../components/AssetCard'
-import { prettyAssetAmount } from '../../../lib/assets'
+import { walletAssetPresentationForId } from '../../../lib/accountAssets'
 import { consoleError } from '../../../lib/logs'
 import { BoltzSwap, BoltzSwapStatus, hasSubmarineStatusReached, isSubmarineFailedStatus } from '@arkade-os/boltz-swap'
+import { AspContext } from '../../../providers/asp'
+import { AssetsContext } from '../../../providers/assets'
 
 type LnSendStatus = 'processing' | 'completed' | 'failed' | 'refunded'
 
@@ -45,6 +47,8 @@ const lnStatusUI: Record<LnSendStatus, { color: string; label: string }> = {
 }
 
 export default function SendSuccess() {
+  const { aspInfo } = useContext(AspContext)
+  const { isRegistered } = useContext(AssetsContext)
   const { config, useFiat } = useContext(ConfigContext)
   const { toFiat } = useContext(FiatContext)
   const { sendInfo } = useContext(FlowContext)
@@ -53,14 +57,17 @@ export default function SendSuccess() {
   const { navigate } = useContext(NavigationContext)
   const { getSwapHistory, swapManager } = useContext(SwapsContext)
 
-  const isAssetSend = Boolean(sendInfo.assets?.length)
-  const assetId = sendInfo.assets?.[0]?.assetId
+  const isAssetSend = Boolean(sendInfo.account || sendInfo.assets?.length)
+  const assetId = sendInfo.account?.assetId ?? sendInfo.assets?.[0]?.assetId
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
-  const assetName = assetMeta?.metadata?.name ?? 'Unknown Asset'
-  const assetTicker = assetMeta?.metadata?.ticker ?? ''
-  const assetIcon = assetMeta?.metadata?.icon
-  const assetAmountValue = sendInfo.assets?.[0]?.amount ?? BigInt(0)
-  const assetDecimals = assetMeta?.metadata?.decimals ?? 8
+  const assetPresentation = sendInfo.account
+    ? { name: sendInfo.account.ticker, ticker: sendInfo.account.ticker }
+    : walletAssetPresentationForId(aspInfo.network, assetId, isRegistered, assetMeta?.metadata, 'Unknown asset')
+  const assetName = assetPresentation.name
+  const assetTicker = assetPresentation.ticker
+  const assetIcon = assetPresentation.icon
+  const assetAmountValue = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
+  const assetDecimals = sendInfo.account?.decimals ?? assetMeta?.metadata?.decimals ?? 8
 
   // Lightning sends resolve optimistically once the swap is funded; track the
   // settlement happening in the background and reflect it live on screen.
@@ -121,7 +128,7 @@ export default function SendSuccess() {
 
   const totalSats = sendInfo.total ?? 0
   const displayAmount = isAssetSend
-    ? `${prettyAssetAmount(assetAmountValue, assetDecimals)} ${assetTicker}`
+    ? `${prettyCurrencyAssetAmount(assetAmountValue, assetDecimals, assetTicker)} ${assetTicker}`
     : useFiat
       ? prettyFiatAmount(toFiat(totalSats), config.currency, { bitcoinUnit: config.unit })
       : prettyAmount(totalSats)
@@ -196,14 +203,11 @@ export default function SendSuccess() {
   }
 
   return (
-    <>
-      <Header text='Success' />
-      <Content>
-        <Success headline='Payment sent!' text={`${displayAmount} sent successfully`} />
-      </Content>
-      <ButtonsOnBottom>
-        <Button label='Sounds good' onClick={() => navigate(Pages.Wallet)} />
-      </ButtonsOnBottom>
-    </>
+    <WalletSuccessSplash
+      headline='Payment sent'
+      text={`${displayAmount} sent successfully`}
+      ariaLabel='Payment sent successfully. Tap to go home.'
+      onDone={() => navigate(Pages.Wallet)}
+    />
   )
 }

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -1,33 +1,81 @@
 import { AnimatePresence, motion } from 'framer-motion'
-import { useContext, useEffect, useMemo, useState } from 'react'
-import { fromAtomic, toAtomic, type OfferAmount } from '@arkade-os/solver-discovery'
+import { fromAtomic, type OfferPlan } from '@arkade-os/solver-discovery'
 import { useOfferQuote } from '@arkade-os/solver-discovery/react'
+import { type ReactNode, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from 'react'
+import AssetAvatar from '../../../components/AssetAvatar'
 import Button from '../../../components/Button'
 import Content from '../../../components/Content'
 import Header from '../../../components/Header'
 import Padded from '../../../components/Padded'
+import TokenLogo, { tokenLogoTickerForTicker } from '../../../components/TokenLogo'
 import WalletSuccessSplash from '../../../components/WalletSuccessSplash'
-import { EASE_IN_OUT_QUINT_TUPLE } from '../../../lib/animations'
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '../../../components/ui/drawer'
+import ArrowUpDownIcon from '../../../icons/ArrowUpDown'
+import ChevronDownIcon from '../../../icons/ChevronDown'
+import InfoIcon from '../../../icons/Info'
+import SwapIcon from '../../../icons/Swap'
+import { EASE_IN_OUT_QUINT_TUPLE, EASE_OUT_QUINT_TUPLE } from '../../../lib/animations'
 import { extractError } from '../../../lib/error'
-import { normalizeBitcoinUnit, prettyBitcoinAmount, prettyCurrencyAssetAmount, prettyNumber } from '../../../lib/format'
-import { hapticLight, hapticSubtle } from '../../../lib/haptics'
+import {
+  formatFiatAmountParts,
+  normalizeBitcoinUnit,
+  prettyCurrencyAssetAmount,
+  prettyFiatAmount,
+  prettyNumber,
+} from '../../../lib/format'
+import { hapticLight, hapticSubtle, hapticTap } from '../../../lib/haptics'
 import { BTC_ASSET_ID, findMarket, QUOTE_OPTIONS, validatePlan } from '../../../lib/swap/markets'
-import { AssetSwap, AssetSwapStatus } from '../../../lib/swap/store'
-import { Unit } from '../../../lib/types'
+import { type AssetSwap, type AssetSwapQuoteSnapshot, type AssetSwapStatus } from '../../../lib/swap/store'
+import { Currencies, Unit } from '../../../lib/types'
 import { AspContext } from '../../../providers/asp'
 import { AssetSwapsContext } from '../../../providers/assetSwaps'
 import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import { FlowContext } from '../../../providers/flow'
 import { NavigationContext, Pages } from '../../../providers/navigation'
 import { WalletContext } from '../../../providers/wallet'
+import { usePortfolioFiat, type PortfolioRow } from '../../../hooks/usePortfolioFiat'
 import { useReducedMotion } from '../../../hooks/useReducedMotion'
-import { AssetPickerDrawer, ReviewDrawer, SwapAsset, SwapAssetList, SwapUnavailableState } from './Components'
-import ButtonsOnBottom from '@/components/ButtonsOnBottom'
-import SwapForm from './Form'
-import Keyboard from '@/components/Keyboard'
 
-type SwapStep = 'select-from' | 'compose'
+type AssetTarget = 'from' | 'to'
 type DrawerState = 'to' | 'review' | null
+type SwapStep = 'select-from' | 'compose'
+type AmountMode = 'asset' | 'fiat'
+type SwapValidationState = 'idle' | 'insufficient-balance' | 'quote-unavailable'
 
+interface SwapAsset {
+  assetId: string
+  name: string
+  ticker: string
+  decimals: number
+  balance: number | bigint
+  fiatText?: string
+  icon?: string
+  usdPrice?: number
+}
+
+interface SwapQuote {
+  fromAsset: SwapAsset
+  toAsset?: SwapAsset
+  fromAmount: string
+  fromFiat: string
+  toAmount: string
+  toFiat: string
+  feeFiat: string
+  rateLabel: string
+  fromFiatValue: number
+  toFiatValue: number
+}
+
+interface ExitingAmountCharacter {
+  character: string
+  id: number
+  slotClassName: string
+}
+
+const keypadKeys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '0', 'Back']
+const rateNote = 'Rates are dynamic and may update before you confirm.'
+const rateNoteAutoDismissMs = 2400
 const statusLabels: Record<AssetSwapStatus, string> = {
   pending: 'Pending',
   cancelling: 'Cancelling',
@@ -35,185 +83,210 @@ const statusLabels: Record<AssetSwapStatus, string> = {
   cancelled: 'Cancelled',
   recoverable: 'Recoverable',
 }
+const emptySwapAsset: SwapAsset = {
+  assetId: 'swap-empty',
+  name: 'Asset',
+  ticker: 'ASSET',
+  decimals: 0,
+  balance: BigInt(0),
+  usdPrice: 0,
+}
 
 export default function WalletSwap() {
   const { aspInfo } = useContext(AspContext)
   const { cancelSwap, createSwap, markets, swapAvailable, swaps } = useContext(AssetSwapsContext)
   const { config } = useContext(ConfigContext)
+  const { fiatDecimals, fromFiatAmount, toFiat, toFiatAmount } = useContext(FiatContext)
+  const { swapFromAssetId, setSwapFromAssetId } = useContext(FlowContext)
   const { goBack, navigate } = useContext(NavigationContext)
   const { assetBalances, assetMetadataCache, balance, svcWallet } = useContext(WalletContext)
+  const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
 
   const [availableSats, setAvailableSats] = useState(0)
-  const [step, setStep] = useState<SwapStep>('select-from')
-  const [amount, setAmount] = useState('')
-  const [fromAssetId, setFromAssetId] = useState(BTC_ASSET_ID)
-  const [toAssetId, setToAssetId] = useState<string>()
-  const [drawer, setDrawer] = useState<DrawerState>(null)
-  const [confirming, setConfirming] = useState(false)
-  const [confirmError, setConfirmError] = useState('')
-  const [successText, setSuccessText] = useState('')
   const [cancelling, setCancelling] = useState('')
-  const [showKeypad, setShowKeypad] = useState(false)
 
-  // spendable offchain balance, refreshed like the send form does
   useEffect(() => {
     if (!svcWallet) return
     svcWallet
       .getBalance()
-      .then((bal) => setAvailableSats(bal.available))
+      .then((walletBalance) => setAvailableSats(walletBalance.available))
       .catch(() => {})
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [balance, svcWallet])
 
-  // the wallet-wide bitcoin unit governs how the btc side is typed and shown
   const btcUnit = normalizeBitcoinUnit(config.unit)
-  const btcEntryPrecision = btcUnit === Unit.BTC ? 8 : 0 // sats and ₿ are typed as whole sats
-
-  // btc + every asset quoted by a discovered market, with wallet balances
+  const btcEntryPrecision = btcUnit === Unit.BTC ? 8 : 0
   const swapAssets = useMemo<SwapAsset[]>(() => {
-    const assets: SwapAsset[] = [
-      {
-        assetId: BTC_ASSET_ID,
-        name: 'Bitcoin',
-        ticker: btcUnit === Unit.BTC ? 'BTC' : btcUnit,
-        decimals: btcEntryPrecision,
-        balance: BigInt(availableSats),
-      },
-    ]
-    for (const market of markets) {
-      const { id, name, ticker, decimals } = market.quote_asset
-      if (assets.some((asset) => asset.assetId === id)) continue
-      const owned = assetBalances?.find((ab) => ab.assetId === id)
-      assets.push({
-        assetId: id,
-        name,
-        ticker,
-        decimals,
-        balance: owned ? BigInt(owned.amount) : BigInt(0),
-        icon: assetMetadataCache.get(id)?.metadata?.icon,
-      })
-    }
-    return assets
-  }, [markets, availableSats, assetBalances, assetMetadataCache, btcUnit, btcEntryPrecision])
+    const marketAssets = markets.flatMap((market) => [market.base_asset, market.quote_asset])
+    const uniqueAssets = new Map(marketAssets.map((asset) => [asset.id, asset]))
+    uniqueAssets.set(BTC_ASSET_ID, {
+      id: BTC_ASSET_ID,
+      name: 'Bitcoin',
+      ticker: 'BTC',
+      decimals: 8,
+    })
 
-  const assetById = (assetId: string) => swapAssets.find((asset) => asset.assetId === assetId)
-  const fromAsset = assetById(fromAssetId) ?? swapAssets[0]
-  const toAsset = toAssetId ? assetById(toAssetId) : undefined
+    return [...uniqueAssets.values()].map((asset) => {
+      if (asset.id === BTC_ASSET_ID) {
+        const bitcoinRow = rows.find((row) => row.assetId === 'btc')
+        return {
+          assetId: BTC_ASSET_ID,
+          name: 'Bitcoin',
+          ticker: btcUnit === Unit.BTC ? 'BTC' : btcUnit,
+          decimals: btcEntryPrecision,
+          balance: BigInt(availableSats),
+          fiatText: bitcoinRow?.hasFiatPrice
+            ? prettyFiatAmount(bitcoinRow.fiatAmount, config.currency, { bitcoinUnit: config.unit })
+            : undefined,
+          usdPrice: bitcoinRow
+            ? estimateRowUsdPrice(bitcoinRow, config.currency, fromFiatAmount, toFiat, toFiatAmount)
+            : 0,
+        }
+      }
 
+      const row = rows.find((candidate) => candidate.assetId === asset.id)
+      const owned = assetBalances.find((balance) => balance.assetId === asset.id)
+      return {
+        assetId: asset.id,
+        name: row?.name ?? asset.name,
+        ticker: row?.ticker ?? asset.ticker,
+        decimals: asset.decimals,
+        balance: BigInt(owned?.amount ?? 0),
+        fiatText: row?.hasFiatPrice
+          ? prettyFiatAmount(row.fiatAmount, config.currency, { bitcoinUnit: config.unit })
+          : undefined,
+        icon: assetMetadataCache.get(asset.id)?.metadata?.icon,
+        usdPrice: row ? estimateRowUsdPrice(row, config.currency, fromFiatAmount, toFiat, toFiatAmount) : 0,
+      }
+    })
+  }, [
+    assetBalances,
+    assetMetadataCache,
+    availableSats,
+    btcEntryPrecision,
+    btcUnit,
+    config.currency,
+    config.unit,
+    fromFiatAmount,
+    markets,
+    rows,
+    toFiat,
+    toFiatAmount,
+  ])
+  const initialFromAssetId = resolveInitialFromAssetId(swapAssets, swapFromAssetId)
+  const openedWithPreselectedAsset = useRef(Boolean(swapFromAssetId))
+  const [step, setStep] = useState<SwapStep>(swapFromAssetId && initialFromAssetId ? 'compose' : 'select-from')
+  const [search, setSearch] = useState('')
+  const [amount, setAmount] = useState('0')
+  const [amountMode, setAmountMode] = useState<AmountMode>('fiat')
+  const [fromAssetId, setFromAssetId] = useState(initialFromAssetId ?? swapAssets[0]?.assetId ?? 'btc')
+  const [toAssetId, setToAssetId] = useState<string | undefined>()
+  const [drawer, setDrawer] = useState<DrawerState>(null)
+  const [swapTurn, setSwapTurn] = useState(0)
+  const [invalidPulse, setInvalidPulse] = useState(0)
+  const [confirming, setConfirming] = useState(false)
+  const [confirmError, setConfirmError] = useState('')
+  const [successQuote, setSuccessQuote] = useState<SwapQuote>()
+
+  const fromAsset =
+    swapAssets.find((asset) => asset.assetId === fromAssetId) ??
+    firstPositiveBalanceAsset(swapAssets) ??
+    swapAssets[0] ??
+    emptySwapAsset
+  const toAsset = toAssetId
+    ? swapAssets.find((asset) => asset.assetId === toAssetId && asset.assetId !== fromAsset.assetId)
+    : undefined
+  const unitOfAccountUsd = toFiatAmount(fromFiatAmount(1, config.currency), Currencies.USD)
   const pair = toAsset ? findMarket(markets, fromAsset.assetId, toAsset.assetId) : undefined
   const { plan, setGiveAmount, solvable, status } = useOfferQuote(pair?.market ?? null, {
     give: pair?.give,
     ...QUOTE_OPTIONS,
   })
+  const assetAmount = amountInAssetUnits(amount, amountMode, fromAsset, unitOfAccountUsd)
+  const [quotedAmount, setQuotedAmount] = useState('')
 
-  /** Amounts of the btc side render in the configured unit; assets in their own. */
-  const fmtAmount = (offerAmount: OfferAmount): string =>
-    offerAmount.asset.id === BTC_ASSET_ID
-      ? prettyBitcoinAmount(Number(offerAmount.atomic), btcUnit)
-      : `${offerAmount.display} ${offerAmount.asset.ticker}`
-
-  // typed sats are converted to the btc display string the quote lib expects;
-  // the fraction is dropped, never concatenated (the input already blocks it)
-  const amountForQuote = (value: string): string =>
-    fromAsset.assetId === BTC_ASSET_ID && btcEntryPrecision === 0
-      ? fromAtomic(BigInt(value.split('.')[0].replace(/\D/g, '') || '0'), 8)
-      : value
-
-  // the keypad renders instantly; the quote (a price feed fetch) is debounced.
-  // quotedAmount tracks which input produced the current plan so a stale plan
-  // can never be confirmed during the debounce window
-  const [quotedAmount, setQuotedAmount] = useState('0')
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      setGiveAmount(Number(amount) > 0 ? amountForQuote(amount) : '')
+      setGiveAmount(Number(assetAmount) > 0 ? amountForQuote(assetAmount, fromAsset, btcEntryPrecision) : '')
       setQuotedAmount(amount)
     }, 600)
     return () => window.clearTimeout(timer)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [amount, fromAsset.assetId, setGiveAmount])
+  }, [amount, assetAmount, btcEntryPrecision, fromAsset, setGiveAmount])
+
   const quoteStale = quotedAmount !== amount
-
-  // trim the buffer when the send asset allows fewer decimals
-  useEffect(() => {
-    setAmount((current) => {
-      const dot = current.indexOf('.')
-      if (dot < 0) return current
-      if (fromAsset.decimals === 0) return current.slice(0, dot) || '0'
-      return current.slice(0, dot + 1 + fromAsset.decimals)
-    })
-  }, [fromAsset.assetId, fromAsset.decimals])
-
-  const planError = plan ? validatePlan(plan, fromAsset.balance, aspInfo.dust) : undefined
-  const validationMessage = ((): string => {
-    if (!toAsset || !amount) return ''
-    if (!pair?.market || solvable === false) return 'Swap unavailable for this pair'
-    if (status === 'error') return 'Quote unavailable'
-    switch (planError) {
-      case 'insufficient-balance':
-        return 'Insufficient balance'
-      case 'side-disabled':
-        return 'Swap unavailable for this pair'
-      case 'below-min':
-        return `Minimum ${fmtAmount(plan!.limits.min!)}`
-      case 'above-max':
-        return `Maximum ${fmtAmount(plan!.limits.max!)}`
-      case 'below-dust':
-        return 'Amount too small'
-      default:
-        return ''
-    }
-  })()
-
-  const quoteLoading = status === 'loading' || (quoteStale && Number(amount) > 0)
+  const planError = plan
+    ? validatePlan(
+        plan,
+        typeof fromAsset.balance === 'bigint' ? fromAsset.balance : BigInt(fromAsset.balance),
+        aspInfo.dust,
+      )
+    : undefined
+  const validationMessage = swapValidationMessage({
+    amount,
+    fromAsset,
+    pairAvailable: Boolean(pair?.market),
+    plan,
+    planError,
+    solvable: solvable ?? undefined,
+    status,
+  })
+  const quote = useMemo(
+    () =>
+      buildQuoteFromPlan(plan, amount, amountMode, fromAsset, toAsset, unitOfAccountUsd, config.currency, config.unit),
+    [amount, amountMode, config.currency, config.unit, fromAsset, plan, toAsset, unitOfAccountUsd],
+  )
+  const hasPositiveAmount = Number(amount) > 0
+  const validationState: SwapValidationState =
+    validationMessage && validationMessage !== 'Insufficient balance'
+      ? 'quote-unavailable'
+      : validationMessage === 'Insufficient balance'
+        ? 'insufficient-balance'
+        : 'idle'
+  const quoteLoading = status === 'loading' || (quoteStale && hasPositiveAmount)
   const canContinue = Boolean(toAsset && plan && status === 'success' && !planError && !quoteStale)
 
+  const stageTransition = prefersReduced ? { duration: 0 } : { duration: 0.28, ease: EASE_IN_OUT_QUINT_TUPLE }
+
+  const filteredAssets = useMemo(() => filterAssets(swapAssets, search), [search, swapAssets])
+
   useEffect(() => {
-    if (!validationMessage) return
+    if (swapAssets.length === 0) return
+    const currentAssetStillAvailable = swapAssets.some((asset) => asset.assetId === fromAssetId)
+    if (currentAssetStillAvailable) return
+    setFromAssetId(resolveInitialFromAssetId(swapAssets, swapFromAssetId) ?? swapAssets[0]?.assetId ?? 'btc')
+  }, [fromAssetId, swapAssets, swapFromAssetId])
+
+  const focusFromAsset = useCallback(
+    (assetId: string) => {
+      setFromAssetId(assetId)
+      setToAssetId((current) =>
+        current && current !== assetId && findMarket(markets, assetId, current)?.market ? current : undefined,
+      )
+      setSearch('')
+      setStep('compose')
+    },
+    [markets],
+  )
+
+  useEffect(() => {
+    if (!swapFromAssetId || swapAssets.length === 0) return
+    if (!swapAvailable) {
+      setSwapFromAssetId(undefined)
+      setStep('select-from')
+      return
+    }
+
+    const nextFromAssetId = resolveInitialFromAssetId(swapAssets, swapFromAssetId) ?? swapAssets[0]?.assetId ?? 'btc'
+
+    focusFromAsset(nextFromAssetId)
+    setSwapFromAssetId(undefined)
+  }, [focusFromAsset, setSwapFromAssetId, swapAssets, swapAvailable, swapFromAssetId])
+
+  useEffect(() => {
+    if (validationState === 'idle') return
     hapticSubtle()
-  }, [validationMessage])
-
-  const receiveLabel = plan ? `≥ ${fmtAmount(plan.receive)}` : undefined
-  const review =
-    plan && toAsset
-      ? {
-          fromAsset,
-          toAsset,
-          swapAmount: fmtAmount(plan.deposit),
-          receiveAmount: receiveLabel!,
-          feeLabel: `${prettyNumber(plan.market.fee_bps / 100, 2)}%`,
-          rateLabel: `1 ${plan.market.base_asset.ticker} = ${prettyNumber(Number(plan.priceDisplay), 2)} ${plan.market.quote_asset.ticker}`,
-        }
-      : undefined
-
-  const selectFromAsset = (asset: SwapAsset) => {
-    hapticLight()
-    setFromAssetId(asset.assetId)
-    // keep the receive asset only if a market quotes the new pair
-    setToAssetId((current) =>
-      current && current !== asset.assetId && findMarket(markets, asset.assetId, current)?.market ? current : undefined,
-    )
-    setStep('compose')
-  }
-
-  const selectToAsset = (asset: SwapAsset) => {
-    hapticLight()
-    setConfirmError('')
-    setToAssetId(asset.assetId)
-    setDrawer(null)
-  }
-
-  const swapSides = () => {
-    if (!toAsset) return
-    hapticLight()
-    setAmount('')
-    // clear the hook synchronously too — the flipped `give` would otherwise
-    // re-quote the old amount in the new deposit asset's units until the
-    // debounce fires
-    setGiveAmount('')
-    setFromAssetId(toAsset.assetId)
-    setToAssetId(fromAsset.assetId)
-  }
+    setInvalidPulse((current) => current + 1)
+  }, [validationState])
 
   const openDrawer = (nextDrawer: DrawerState) => {
     hapticLight()
@@ -221,38 +294,94 @@ export default function WalletSwap() {
     setDrawer(nextDrawer)
   }
 
+  const selectFromAsset = (asset: SwapAsset) => {
+    hapticLight()
+    focusFromAsset(asset.assetId)
+  }
+
+  const selectToAsset = (_target: AssetTarget, asset: SwapAsset) => {
+    hapticLight()
+    setConfirmError('')
+    setToAssetId(asset.assetId)
+    if (asset.assetId === fromAsset.assetId) setFromAssetId(toAsset?.assetId ?? fromAsset.assetId)
+    setDrawer(null)
+  }
+
+  const swapSides = () => {
+    if (!toAsset) return
+    hapticLight()
+    setAmount('0')
+    setGiveAmount('')
+    setSwapTurn((current) => current + 1)
+    setFromAssetId(toAsset.assetId)
+    setToAssetId(fromAsset.assetId)
+  }
+
+  const pressKey = (key: string) => {
+    setConfirmError('')
+    const maxDecimals = amountMode === 'fiat' ? fiatDecimals() : fromAsset.decimals
+    const canApplyKey = (current: string) => {
+      if (key === 'Back') return current !== '0'
+      const base = current === '0' && key !== '.' ? '' : current
+      if (key === '.') return maxDecimals > 0 && !base.includes('.')
+      const decimalIndex = base.indexOf('.')
+      return decimalIndex < 0 || base.length - decimalIndex - 1 < maxDecimals
+    }
+
+    if (!canApplyKey(amount)) return
+    hapticTap()
+
+    if (key === 'Back') {
+      setAmount((current) => current.slice(0, -1) || '0')
+      return
+    }
+    setAmount((current) => {
+      const base = current === '0' && key !== '.' ? '' : current
+      if (key === '.') return maxDecimals > 0 && !base.includes('.') ? `${base}.` : current
+      const decimalIndex = base.indexOf('.')
+      if (decimalIndex >= 0 && base.length - decimalIndex - 1 >= maxDecimals) return current
+      return `${base}${key}`.slice(0, 10)
+    })
+  }
+
+  const toggleAmountMode = () => {
+    hapticLight()
+    setAmountMode((current) => (current === 'asset' ? 'fiat' : 'asset'))
+  }
+
   const handleBack = () => {
-    if (step === 'compose') {
+    if (step === 'compose' && !openedWithPreselectedAsset.current) {
       setStep('select-from')
       return
     }
     goBack()
   }
 
-  const handleSuccessDone = () => {
-    setSuccessText('')
+  const handleSuccessDone = useCallback(() => {
+    setSuccessQuote(undefined)
     navigate(Pages.Wallet)
-  }
+  }, [navigate])
 
   useEffect(() => {
-    if (!successText) return
+    if (!successQuote) return
     const timer = window.setTimeout(handleSuccessDone, 3000)
     return () => window.clearTimeout(timer)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [successText])
+  }, [handleSuccessDone, successQuote])
 
   const confirmSwap = async () => {
     if (!plan || !toAsset || confirming || !canContinue) return
+
     setConfirmError('')
     setConfirming(true)
     try {
-      await createSwap(plan)
-      setConfirming(false)
+      await createSwap(plan, buildQuoteSnapshot(plan, quote, config.currency))
       setDrawer(null)
-      setSuccessText(`${fromAsset.ticker} to ${toAsset.ticker} — waiting for the solver to fill it`)
-    } catch (err) {
+      setSuccessQuote(quote)
+      hapticLight()
+    } catch (error) {
+      setConfirmError(extractError(error))
+    } finally {
       setConfirming(false)
-      setConfirmError(extractError(err))
     }
   }
 
@@ -262,37 +391,16 @@ export default function WalletSwap() {
     setCancelling(swap.id)
     try {
       await cancelSwap(swap.id)
-    } catch (err) {
-      setConfirmError(extractError(err))
+    } catch (error) {
+      setConfirmError(extractError(error))
     } finally {
       setCancelling('')
     }
   }
 
-  const stageTransition = prefersReduced ? { duration: 0 } : { duration: 0.28, ease: EASE_IN_OUT_QUINT_TUPLE }
-  const receiveAssets = useMemo(
-    () => swapAssets.filter((asset) => Boolean(findMarket(markets, fromAsset.assetId, asset.assetId)?.market)),
-    [swapAssets, markets, fromAsset.assetId],
+  const receiveAssets = swapAssets.filter((asset) =>
+    Boolean(findMarket(markets, fromAsset.assetId, asset.assetId)?.market),
   )
-  const fmtSwapAmount = (assetId: string, atomic: string): string => {
-    const asset = assetById(assetId)
-    return asset ? `${prettyCurrencyAssetAmount(BigInt(atomic), asset.decimals, asset.ticker)} ${asset.ticker}` : atomic
-  }
-
-  if (showKeypad) {
-    return (
-      <Keyboard
-        asset={fromAsset}
-        // seed the keypad with the current entry (atomic units per contract)
-        initialValue={amount ? toAtomic(amount, fromAsset.decimals) : undefined}
-        back={() => setShowKeypad(false)}
-        onSave={(value) => {
-          setAmount(value)
-          setShowKeypad(false)
-        }}
-      />
-    )
-  }
 
   return (
     <>
@@ -310,100 +418,67 @@ export default function WalletSwap() {
                   exit={prefersReduced ? undefined : { opacity: 0, x: -16 }}
                   transition={stageTransition}
                 >
-                  {/* an outage only blocks creating swaps; existing swaps stay
-                      listed so pending funds remain cancellable */}
                   {swapAvailable ? (
                     <SwapAssetList
                       title='Choose asset to swap'
-                      subtitle='Select the asset you want to trade from.'
-                      assets={swapAssets}
+                      search={search}
+                      assets={filteredAssets}
+                      empty={filteredAssets.length === 0}
+                      onSearch={setSearch}
                       onSelect={selectFromAsset}
                     />
                   ) : (
                     <SwapUnavailableState />
                   )}
-                  {swaps.length > 0 ? (
-                    <div className='swap-asset-list-panel'>
-                      <div className='swap-step-heading'>
-                        <p>Your swaps</p>
-                      </div>
-                      <div className='swap-token-list'>
-                        {swaps.map((swap) => {
-                          const from = assetById(swap.fromAsset)
-                          const to = assetById(swap.toAsset)
-                          const fromAmount = fmtSwapAmount(swap.fromAsset, swap.fromAmount)
-                          const toAmount = fmtSwapAmount(swap.toAsset, swap.toAmount)
-                          // recoverable (swept) deposits cannot be cancelled cooperatively,
-                          // so no button; a persisted 'cancelling' can be retried
-                          const cancellable = swap.status === 'pending' || swap.status === 'cancelling'
-                          return (
-                            <div key={swap.id} className='swap-token-row'>
-                              <span className='swap-token-row__copy'>
-                                <span>
-                                  {from?.ticker ?? '?'} to {to?.ticker ?? '?'}
-                                </span>
-                                <small>
-                                  {fromAmount} for ≥ {toAmount}
-                                </small>
-                              </span>
-                              {cancellable ? (
-                                <button
-                                  type='button'
-                                  className='swap-cancel-button'
-                                  disabled={Boolean(cancelling)}
-                                  onClick={() => handleCancelSwap(swap)}
-                                >
-                                  {cancelling === swap.id
-                                    ? 'Cancelling…'
-                                    : swap.status === 'cancelling'
-                                      ? 'Retry cancel'
-                                      : 'Cancel'}
-                                </button>
-                              ) : null}
-                              <strong>{statusLabels[swap.status]}</strong>
-                            </div>
-                          )
-                        })}
-                      </div>
-                      {confirmError ? <p className='swap-confirm-error'>{confirmError}</p> : null}
-                    </div>
+                  {swaps.length ? (
+                    <PendingSwaps
+                      swaps={swaps}
+                      assets={swapAssets}
+                      cancelling={cancelling}
+                      error={confirmError}
+                      onCancel={handleCancelSwap}
+                    />
                   ) : null}
                 </motion.section>
               ) : (
                 <motion.section
                   key='compose'
                   className='swap-flow-stage'
-                  transition={stageTransition}
-                  animate={{ opacity: 1, x: 0 }}
                   initial={prefersReduced ? false : { opacity: 0, x: 18 }}
+                  animate={{ opacity: 1, x: 0 }}
                   exit={prefersReduced ? undefined : { opacity: 0, x: 18 }}
+                  transition={stageTransition}
                 >
-                  <SwapForm
+                  <SwapComposer
                     amount={amount}
-                    toAsset={toAsset}
+                    amountMode={amountMode}
+                    currency={config.currency}
+                    bitcoinUnit={config.unit}
+                    quote={quote}
                     fromAsset={fromAsset}
+                    toAsset={toAsset}
+                    onAmountFocus={() => {}}
+                    onModeToggle={toggleAmountMode}
+                    onOpenReceiveDrawer={() => openDrawer('to')}
                     onSwapSides={swapSides}
-                    onOpenAssetPicker={() => openDrawer('to')}
-                    onChangeAmount={setAmount}
+                    validationState={validationState}
+                    validationText={validationMessage}
+                    invalidPulse={invalidPulse}
                     quoteLoading={quoteLoading}
-                    validationMessage={validationMessage}
-                    onShowKeypad={() => setShowKeypad(true)}
-                    receiveAmount={receiveLabel ?? '—'}
+                    swapTurn={swapTurn}
                   />
+                  <Keypad amount={amount} onPress={pressKey} />
+                  <Button label='Continue' disabled={!canContinue} onClick={() => openDrawer('review')} />
                 </motion.section>
               )}
             </AnimatePresence>
           </div>
         </Padded>
       </Content>
-      {step === 'compose' ? (
-        <ButtonsOnBottom>
-          <Button label='Continue' disabled={!canContinue} onClick={() => openDrawer('review')} />
-        </ButtonsOnBottom>
-      ) : null}
 
       <AssetPickerDrawer
         open={drawer === 'to'}
+        target='to'
         assets={receiveAssets}
         selectedId={toAsset?.assetId}
         onOpenChange={(open) => {
@@ -414,26 +489,879 @@ export default function WalletSwap() {
 
       <ReviewDrawer
         open={drawer === 'review'}
-        review={review}
+        quote={quote}
         canConfirm={canContinue}
         confirming={confirming}
         error={confirmError}
         quoteLoading={quoteLoading}
         onOpenChange={(open) => {
-          // keep the drawer up while the swap is being created so a late
-          // failure still has a surface to report on
-          if (!open && !confirming) setDrawer(null)
+          if (!open) setDrawer(null)
         }}
         onConfirm={confirmSwap}
       />
-
-      <WalletSuccessSplash
-        show={Boolean(successText)}
-        headline='Swap created'
-        text={successText}
-        ariaLabel='Swap created. Tap to go home.'
-        onDone={handleSuccessDone}
-      />
+      <SwapSuccessOverlay quote={successQuote} onDone={handleSuccessDone} />
     </>
   )
+}
+
+function SwapUnavailableState() {
+  return (
+    <div className='swap-unavailable-state'>
+      <span className='swap-unavailable-state__icon'>
+        <SwapIcon />
+      </span>
+      <div>
+        <p>Swaps are unavailable</p>
+        <span>Add another supported asset to swap between balances.</span>
+      </div>
+    </div>
+  )
+}
+
+function PendingSwaps({
+  swaps,
+  assets,
+  cancelling,
+  error,
+  onCancel,
+}: {
+  swaps: AssetSwap[]
+  assets: SwapAsset[]
+  cancelling: string
+  error: string
+  onCancel: (swap: AssetSwap) => void
+}) {
+  const assetById = (assetId: string) => assets.find((asset) => asset.assetId === assetId)
+  const formatAmount = (assetId: string, atomic: string) => {
+    const asset = assetById(assetId)
+    return asset ? `${prettyCurrencyAssetAmount(BigInt(atomic), asset.decimals, asset.ticker)} ${asset.ticker}` : atomic
+  }
+
+  return (
+    <div className='swap-asset-list-panel'>
+      <div className='swap-step-heading'>
+        <p>Your swaps</p>
+      </div>
+      <div className='swap-token-list'>
+        {swaps.map((swap) => {
+          const from = assetById(swap.fromAsset)
+          const to = assetById(swap.toAsset)
+          const cancellable = swap.status === 'pending' || swap.status === 'cancelling'
+          return (
+            <div key={swap.id} className='swap-token-row'>
+              <span className='swap-token-row__copy'>
+                <span>
+                  {swap.quote?.fromTicker ?? from?.ticker ?? '?'} to {swap.quote?.toTicker ?? to?.ticker ?? '?'}
+                </span>
+                <small>
+                  {formatAmount(swap.fromAsset, swap.fromAmount)} for ≥ {formatAmount(swap.toAsset, swap.toAmount)}
+                </small>
+              </span>
+              {cancellable ? (
+                <button
+                  type='button'
+                  className='swap-cancel-button'
+                  disabled={Boolean(cancelling)}
+                  onClick={() => onCancel(swap)}
+                >
+                  {cancelling === swap.id ? 'Cancelling…' : swap.status === 'cancelling' ? 'Retry cancel' : 'Cancel'}
+                </button>
+              ) : null}
+              <strong>{statusLabels[swap.status]}</strong>
+            </div>
+          )
+        })}
+      </div>
+      {error ? <p className='swap-confirm-error'>{error}</p> : null}
+    </div>
+  )
+}
+
+function SwapAssetList({
+  title,
+  search,
+  assets,
+  empty,
+  selectedId,
+  onSearch,
+  onSelect,
+}: {
+  title: string
+  search: string
+  assets: SwapAsset[]
+  empty: boolean
+  selectedId?: string
+  onSearch: (value: string) => void
+  onSelect: (asset: SwapAsset) => void
+}) {
+  const prefersReduced = useReducedMotion()
+
+  return (
+    <div className='swap-asset-list-panel'>
+      <div className='swap-step-heading'>
+        <p>{title}</p>
+        <span>Select the asset you want to trade from.</span>
+      </div>
+      <label className='swap-search-field'>
+        <span>Search assets</span>
+        <input
+          type='search'
+          value={search}
+          placeholder='Search assets'
+          autoComplete='off'
+          spellCheck={false}
+          onChange={(event) => onSearch(event.target.value)}
+        />
+      </label>
+      <div className='swap-token-list swap-token-list--page'>
+        {empty ? (
+          <div className='swap-empty-state'>No assets match this search</div>
+        ) : (
+          assets.map((asset, index) => (
+            <motion.div
+              key={asset.assetId}
+              initial={prefersReduced ? false : { opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={
+                prefersReduced ? { duration: 0 } : { duration: 0.22, delay: index * 0.035, ease: EASE_OUT_QUINT_TUPLE }
+              }
+            >
+              <SwapAssetRow asset={asset} active={selectedId === asset.assetId} onClick={() => onSelect(asset)} />
+            </motion.div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SwapComposer({
+  amount,
+  amountMode,
+  currency,
+  bitcoinUnit,
+  quote,
+  fromAsset,
+  toAsset,
+  onAmountFocus,
+  onModeToggle,
+  onOpenReceiveDrawer,
+  onSwapSides,
+  validationState,
+  validationText,
+  invalidPulse,
+  quoteLoading,
+  swapTurn,
+}: {
+  amount: string
+  amountMode: AmountMode
+  currency: Currencies
+  bitcoinUnit: Unit
+  quote: SwapQuote
+  fromAsset: SwapAsset
+  toAsset?: SwapAsset
+  onAmountFocus: () => void
+  onModeToggle: () => void
+  onOpenReceiveDrawer: () => void
+  onSwapSides: () => void
+  validationState: SwapValidationState
+  validationText: string
+  invalidPulse: number
+  quoteLoading: boolean
+  swapTurn: number
+}) {
+  const prefersReduced = useReducedMotion()
+  const amountLabel =
+    amountMode === 'fiat' ? formatCurrencyInputAmount(amount, currency, bitcoinUnit) : `${amount} ${fromAsset.ticker}`
+  const subAmountLabel = amountMode === 'fiat' ? `${quote.fromAmount} ${fromAsset.ticker}` : quote.fromFiat
+  const nextAmountModeLabel = amountMode === 'fiat' ? 'asset amount' : `${currency} amount`
+  const validationMessage = validationText
+
+  return (
+    <div className='swap-composer'>
+      <div className='swap-input-card'>
+        <div className='swap-input-card__asset'>
+          <TokenAvatar asset={fromAsset} size={36} />
+          <div className='swap-input-card__asset-copy'>
+            <span>{fromAsset.name}</span>
+            <small>{formatAssetBalance(fromAsset)}</small>
+          </div>
+        </div>
+        <div className='swap-amount-stack'>
+          <motion.button
+            key={invalidPulse}
+            type='button'
+            className={
+              validationState === 'idle' ? 'swap-amount-display' : 'swap-amount-display swap-amount-display--invalid'
+            }
+            onClick={onAmountFocus}
+            aria-label='Swap amount'
+            animate={prefersReduced || validationState === 'idle' ? undefined : { x: [0, -7, 6, -4, 2, 0] }}
+            transition={
+              prefersReduced || validationState === 'idle' ? undefined : { duration: 0.32, ease: EASE_OUT_QUINT_TUPLE }
+            }
+          >
+            <AnimatedAmountValue value={amountLabel} reducedMotion={prefersReduced} />
+          </motion.button>
+          <AnimatePresence initial={false}>
+            {validationMessage ? (
+              <motion.p
+                key={validationMessage}
+                className='swap-input-error'
+                initial={prefersReduced ? false : { opacity: 0, y: 4, scale: 0.96 }}
+                animate={prefersReduced ? undefined : { opacity: 1, y: 0, scale: 1 }}
+                exit={prefersReduced ? undefined : { opacity: 0, y: 4, scale: 0.96 }}
+                transition={{ duration: prefersReduced ? 0 : 0.16, ease: EASE_OUT_QUINT_TUPLE }}
+              >
+                {validationMessage}
+              </motion.p>
+            ) : null}
+          </AnimatePresence>
+        </div>
+        <motion.button
+          type='button'
+          className='swap-amount-secondary'
+          layout
+          onClick={onModeToggle}
+          aria-label={`Show ${nextAmountModeLabel} first`}
+          transition={{ duration: prefersReduced ? 0 : 0.18, ease: EASE_IN_OUT_QUINT_TUPLE }}
+        >
+          <AnimatedSecondaryAmountValue value={subAmountLabel} reducedMotion={prefersReduced} />
+          <motion.span
+            className='swap-amount-secondary__icon'
+            layout='position'
+            animate={{ rotate: amountMode === 'fiat' ? 0 : 180 }}
+            transition={{ duration: prefersReduced ? 0 : 0.22, ease: EASE_IN_OUT_QUINT_TUPLE }}
+            aria-hidden='true'
+          >
+            <ArrowUpDownIcon />
+          </motion.span>
+        </motion.button>
+      </div>
+
+      <motion.button
+        type='button'
+        className='swap-flip-button'
+        aria-label='Switch swap direction'
+        animate={{ rotate: swapTurn * 180 }}
+        transition={{ duration: 0.22, ease: EASE_IN_OUT_QUINT_TUPLE }}
+        disabled={!toAsset}
+        onClick={onSwapSides}
+      >
+        <SwapIcon />
+      </motion.button>
+
+      <button type='button' className='swap-receive-card' onClick={onOpenReceiveDrawer}>
+        {toAsset ? (
+          <>
+            <TokenAvatar asset={toAsset} size={36} />
+            <div>
+              <span>Receive {toAsset.ticker}</span>
+              <small>
+                {quoteLoading ? <SwapSkeletonText width='5.75rem' /> : `${quote.toAmount} ${toAsset.ticker}`}
+              </small>
+            </div>
+            <strong>{quoteLoading ? <SwapSkeletonText width='3.75rem' /> : quote.toFiat}</strong>
+          </>
+        ) : (
+          <>
+            <span className='swap-receive-card__empty'>+</span>
+            <div>
+              <span>Receive</span>
+              <small>Choose asset</small>
+            </div>
+            <ChevronDownIcon />
+          </>
+        )}
+      </button>
+    </div>
+  )
+}
+
+function SwapSkeletonText({ width }: { width: string }) {
+  return <span className='swap-skeleton-text' style={{ width }} aria-hidden='true' />
+}
+
+function AnimatedAmountValue({ value, reducedMotion }: { value: string; reducedMotion: boolean }) {
+  const previousValueRef = useRef(value)
+  const exitingIdRef = useRef(0)
+  const [exitingCharacters, setExitingCharacters] = useState<ExitingAmountCharacter[]>([])
+  const characters = Array.from(value)
+  const previousCharacters = Array.from(previousValueRef.current)
+  const shouldAnimate = previousValueRef.current !== value
+  const isAdding = value.length > previousValueRef.current.length
+
+  useEffect(() => {
+    const previousCharactersForExit = Array.from(previousValueRef.current)
+    const nextCharacters = Array.from(value)
+    const isDeleting = nextCharacters.length < previousCharactersForExit.length
+
+    if (isDeleting) {
+      const removedCharacters = previousCharactersForExit.slice(nextCharacters.length).map((character) => ({
+        character,
+        id: exitingIdRef.current++,
+        slotClassName: amountCharacterSlotClassName(character),
+      }))
+      setExitingCharacters(removedCharacters)
+      const timer = window.setTimeout(() => setExitingCharacters([]), 180)
+      previousValueRef.current = value
+      return () => window.clearTimeout(timer)
+    }
+
+    setExitingCharacters([])
+    previousValueRef.current = value
+  }, [value])
+
+  return (
+    <span className='swap-amount-value' aria-label={value}>
+      <AnimatePresence initial={false}>
+        {characters.map((character, characterIndex) => {
+          const characterChanged = previousCharacters[characterIndex] !== character
+          const entering = shouldAnimate && (characterChanged || characterIndex >= previousCharacters.length)
+          return (
+            <motion.span
+              key={amountCharacterSlotKey(character, characterIndex, characters)}
+              className={amountCharacterSlotClassName(character)}
+              initial={reducedMotion ? false : { opacity: 0, y: isAdding ? 12 : 7 }}
+              animate={reducedMotion ? undefined : { opacity: 1, y: 0 }}
+              exit={reducedMotion ? undefined : { opacity: 0, y: -7 }}
+              transition={
+                reducedMotion ? { duration: 0 } : { duration: isAdding ? 0.28 : 0.16, ease: EASE_OUT_QUINT_TUPLE }
+              }
+            >
+              <AnimatePresence mode='popLayout' initial={shouldAnimate}>
+                <motion.span
+                  key={character}
+                  className={
+                    entering && !reducedMotion
+                      ? 'swap-amount-character swap-amount-character--entering'
+                      : 'swap-amount-character'
+                  }
+                  initial={reducedMotion ? false : { opacity: 0, y: isAdding ? 12 : 7 }}
+                  animate={reducedMotion ? undefined : { opacity: 1, y: 0 }}
+                  exit={reducedMotion ? undefined : { opacity: 0, y: -6 }}
+                  transition={
+                    reducedMotion ? { duration: 0 } : { duration: isAdding ? 0.28 : 0.16, ease: EASE_OUT_QUINT_TUPLE }
+                  }
+                  aria-hidden='true'
+                >
+                  {character === ' ' ? '\u00a0' : character}
+                </motion.span>
+              </AnimatePresence>
+            </motion.span>
+          )
+        })}
+      </AnimatePresence>
+      {exitingCharacters.map(({ character, id, slotClassName }) => (
+        <span key={`exiting-${id}`} className={`${slotClassName} swap-amount-character-slot--exiting`}>
+          <span className='swap-amount-character swap-amount-character--exiting' aria-hidden='true'>
+            {character === ' ' ? '\u00a0' : character}
+          </span>
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function amountCharacterSlotKey(character: string, characterIndex: number, source: string[]): string {
+  if (/\d/.test(character)) {
+    const digitPosition = source.slice(0, characterIndex).filter((candidate) => /\d/.test(candidate)).length
+    return `digit-${digitPosition}`
+  }
+
+  if (character === '.') return 'decimal-point'
+  if (character === ' ')
+    return `space-${source.slice(0, characterIndex).filter((candidate) => candidate === ' ').length}`
+  return `symbol-${character}`
+}
+
+function amountCharacterSlotClassName(character: string): string {
+  if (character === ' ') return 'swap-amount-character-slot swap-amount-character-slot--space'
+  if (/\d/.test(character)) return 'swap-amount-character-slot swap-amount-character-slot--digit'
+  return 'swap-amount-character-slot'
+}
+
+function AnimatedSecondaryAmountValue({ value, reducedMotion }: { value: string; reducedMotion: boolean }) {
+  return (
+    <span className='swap-amount-value swap-amount-value--secondary' aria-label={value}>
+      <AnimatePresence mode='wait' initial={false}>
+        <motion.span
+          key={value}
+          initial={reducedMotion ? false : { opacity: 0, y: 5 }}
+          animate={reducedMotion ? undefined : { opacity: 1, y: 0 }}
+          exit={reducedMotion ? undefined : { opacity: 0, y: -5 }}
+          transition={reducedMotion ? { duration: 0 } : { duration: 0.14, ease: EASE_OUT_QUINT_TUPLE }}
+          aria-hidden='true'
+        >
+          {value}
+        </motion.span>
+      </AnimatePresence>
+    </span>
+  )
+}
+
+function SwapAssetRow({ asset, active, onClick }: { asset: SwapAsset; active?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type='button'
+      className={active ? 'swap-token-row swap-token-row--active' : 'swap-token-row'}
+      onClick={onClick}
+    >
+      <TokenAvatar asset={asset} size={40} />
+      <span className='swap-token-row__copy'>
+        <span>{asset.name}</span>
+        <small>{formatAssetBalance(asset)}</small>
+      </span>
+      {asset.fiatText ? <strong>{asset.fiatText}</strong> : null}
+    </button>
+  )
+}
+
+function TokenAvatar({ asset, size }: { asset: SwapAsset; size: number }) {
+  const tokenLogoTicker = getTokenLogoTicker(asset.ticker)
+  if (tokenLogoTicker) {
+    return (
+      <span className='swap-token-avatar' style={{ width: size, height: size }}>
+        <TokenLogo ticker={tokenLogoTicker} />
+      </span>
+    )
+  }
+  return <AssetAvatar icon={asset.icon} name={asset.name} ticker={asset.ticker} size={size} />
+}
+
+function Keypad({ amount, onPress }: { amount: string; onPress: (key: string) => void }) {
+  return (
+    <motion.div
+      className='swap-keypad-shell'
+      aria-label={`Swap keypad for ${amount || '0'}`}
+      initial={{ opacity: 0, y: 14 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: EASE_OUT_QUINT_TUPLE }}
+    >
+      <div className='swap-keypad'>
+        {keypadKeys.map((key) => (
+          <button
+            key={key}
+            type='button'
+            onClick={() => onPress(key)}
+            aria-label={key === 'Back' ? 'Delete digit' : key}
+          >
+            {key === 'Back' ? '<' : key}
+          </button>
+        ))}
+      </div>
+    </motion.div>
+  )
+}
+
+function AssetPickerDrawer({
+  open,
+  target,
+  assets,
+  selectedId,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean
+  target: AssetTarget
+  assets: SwapAsset[]
+  selectedId?: string
+  onOpenChange: (open: boolean) => void
+  onSelect: (target: AssetTarget, asset: SwapAsset) => void
+}) {
+  const [query, setQuery] = useState('')
+  const filteredAssets = useMemo(() => filterAssets(assets, query), [assets, query])
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className='swap-drawer-content swap-review-drawer-content'>
+        <DrawerHeader className='swap-picker-header'>
+          <DrawerTitle>{target === 'from' ? 'Choose asset to swap' : 'Choose asset to receive'}</DrawerTitle>
+          <DrawerDescription>Pick the asset for this side of the swap.</DrawerDescription>
+        </DrawerHeader>
+        <div className='swap-drawer-body'>
+          <label className='swap-search-field'>
+            <span>Search assets</span>
+            <input
+              type='search'
+              value={query}
+              placeholder='Search assets'
+              autoComplete='off'
+              spellCheck={false}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </label>
+          <div className='swap-token-list'>
+            {filteredAssets.map((asset) => (
+              <SwapAssetRow
+                key={asset.assetId}
+                asset={asset}
+                active={selectedId === asset.assetId}
+                onClick={() => onSelect(target, asset)}
+              />
+            ))}
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+function ReviewDrawer({
+  open,
+  quote,
+  canConfirm,
+  confirming,
+  error,
+  quoteLoading,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean
+  quote: SwapQuote
+  canConfirm: boolean
+  confirming: boolean
+  error: string
+  quoteLoading: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+}) {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className='swap-drawer-content'>
+        <DrawerHeader className='swap-review-header'>
+          <DrawerTitle>Review swap</DrawerTitle>
+          <DrawerDescription>Check the route and estimated totals.</DrawerDescription>
+        </DrawerHeader>
+        <div className='swap-review-drawer-body'>
+          <ReviewSummary quote={quote} loading={quoteLoading} />
+          <QuoteDetails quote={quote} loading={quoteLoading} />
+        </div>
+        <div className='swap-review-action'>
+          <AnimatePresence initial={false}>
+            {error ? (
+              <motion.p
+                className='swap-confirm-error'
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 6 }}
+                transition={{ duration: 0.2, ease: EASE_OUT_QUINT_TUPLE }}
+              >
+                {error}
+              </motion.p>
+            ) : null}
+          </AnimatePresence>
+          <Button label='Confirm swap' disabled={!canConfirm || confirming} loading={confirming} onClick={onConfirm} />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+function SwapSuccessOverlay({ quote, onDone }: { quote?: SwapQuote; onDone: () => void }) {
+  return (
+    <WalletSuccessSplash
+      show={Boolean(quote)}
+      headline='Swap created'
+      text={quote ? `${quote.fromAsset.ticker} to ${quote.toAsset?.ticker} · Waiting for fill` : undefined}
+      ariaLabel='Swap created. Tap to go home.'
+      onDone={onDone}
+    />
+  )
+}
+
+function ReviewSummary({ quote, loading }: { quote: SwapQuote; loading: boolean }) {
+  return (
+    <div className='swap-review-card'>
+      <div className='swap-review-hero'>
+        <div className='swap-review-avatars'>
+          <TokenAvatar asset={quote.fromAsset} size={48} />
+          {quote.toAsset ? <TokenAvatar asset={quote.toAsset} size={48} /> : null}
+        </div>
+        <div>
+          <span>Swap route</span>
+          <h3 className='text-heading-sm'>
+            {quote.fromAsset.ticker} to {quote.toAsset?.ticker ?? 'asset'}
+          </h3>
+        </div>
+      </div>
+      <MetricRow label='Swap' value={`${quote.fromAmount} ${quote.fromAsset.ticker}`} loading={loading} />
+      <MetricRow
+        label='Receive'
+        value={quote.toAsset ? `${quote.toAmount} ${quote.toAsset.ticker}` : 'Choose asset'}
+        loading={loading}
+      />
+      <MetricRow label='Fees' value={quote.feeFiat} loading={loading} />
+    </div>
+  )
+}
+
+function QuoteDetails({ quote, loading }: { quote: SwapQuote; loading: boolean }) {
+  return (
+    <div className='swap-detail-card'>
+      <MetricRow
+        label={<RateLabel />}
+        value={quote.toAsset ? `1 ${quote.fromAsset.ticker} = ${quote.rateLabel} ${quote.toAsset.ticker}` : 'Pending'}
+        loading={loading}
+      />
+    </div>
+  )
+}
+
+function RateLabel() {
+  const tooltipId = useId()
+  const prefersReduced = useReducedMotion()
+  const dismissTimer = useRef<number>()
+  const [tooltipOpen, setTooltipOpen] = useState(false)
+
+  const clearDismissTimer = useCallback(() => {
+    if (!dismissTimer.current) return
+    window.clearTimeout(dismissTimer.current)
+    dismissTimer.current = undefined
+  }, [])
+
+  const showTooltip = useCallback(
+    (autoDismiss: boolean) => {
+      clearDismissTimer()
+      setTooltipOpen(true)
+      if (!autoDismiss) return
+      dismissTimer.current = window.setTimeout(() => {
+        setTooltipOpen(false)
+        dismissTimer.current = undefined
+      }, rateNoteAutoDismissMs)
+    },
+    [clearDismissTimer],
+  )
+
+  const hideTooltip = useCallback(() => {
+    clearDismissTimer()
+    setTooltipOpen(false)
+  }, [clearDismissTimer])
+
+  useEffect(() => clearDismissTimer, [clearDismissTimer])
+
+  return (
+    <div className='swap-rate-label'>
+      Rate
+      <span className='swap-rate-disclosure'>
+        <button
+          type='button'
+          aria-label={rateNote}
+          aria-describedby={tooltipOpen ? tooltipId : undefined}
+          title={rateNote}
+          className='swap-rate-info'
+          onClick={() => showTooltip(true)}
+          onBlur={hideTooltip}
+          onPointerEnter={(event) => {
+            if (event.pointerType === 'mouse') showTooltip(false)
+          }}
+          onPointerLeave={(event) => {
+            if (event.pointerType === 'mouse') hideTooltip()
+          }}
+        >
+          <InfoIcon />
+        </button>
+        <AnimatePresence>
+          {tooltipOpen ? (
+            <motion.div
+              id={tooltipId}
+              role='tooltip'
+              className='swap-rate-tooltip'
+              initial={prefersReduced ? false : { opacity: 0, y: 4, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 2, scale: 0.98 }}
+              transition={prefersReduced ? { duration: 0 } : { duration: 0.18, ease: EASE_OUT_QUINT_TUPLE }}
+            >
+              {rateNote}
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </span>
+    </div>
+  )
+}
+
+function MetricRow({ label, value, loading }: { label: ReactNode; value: string; loading?: boolean }) {
+  return (
+    <div className='swap-metric-row'>
+      <span>{label}</span>
+      <span>{loading ? <SwapSkeletonText width='7rem' /> : value}</span>
+    </div>
+  )
+}
+
+function buildQuoteFromPlan(
+  plan: OfferPlan | null,
+  amount: string,
+  mode: AmountMode,
+  fromAsset: SwapAsset,
+  toAsset: SwapAsset | undefined,
+  unitOfAccountUsd: number,
+  currency: Currencies,
+  bitcoinUnit: Unit,
+): SwapQuote {
+  const parsed = Number(amount) || 0
+  const fromUsd = estimateSwapUsd(fromAsset)
+  const toUsd = toAsset ? estimateSwapUsd(toAsset) : 0
+  const fromUsdNumber = mode === 'fiat' ? parsed * unitOfAccountUsd : parsed * fromUsd
+  const estimatedFromUnits = mode === 'fiat' && fromUsd > 0 ? fromUsdNumber / fromUsd : parsed
+  const fromUnits = plan ? Number(plan.deposit.display) : estimatedFromUnits
+  const received = plan ? Number(plan.receive.display) : 0
+  const selectedCurrencyAmount = unitOfAccountUsd > 0 ? (fromUnits * fromUsd) / unitOfAccountUsd : 0
+  const receivedCurrencyAmount = unitOfAccountUsd > 0 ? (received * toUsd) / unitOfAccountUsd : 0
+  const rate = fromUnits > 0 ? received / fromUnits : 0
+  const feeAmount = selectedCurrencyAmount * ((plan?.market.fee_bps ?? 0) / 10_000)
+  const formatOptions = { bitcoinUnit }
+
+  return {
+    fromAsset,
+    toAsset,
+    fromAmount: prettyNumber(fromUnits, swapAmountDecimals(fromUnits)),
+    fromFiat: prettyFiatAmount(selectedCurrencyAmount, currency, formatOptions),
+    toAmount: prettyNumber(received, swapAmountDecimals(received)),
+    toFiat: prettyFiatAmount(receivedCurrencyAmount, currency, formatOptions),
+    feeFiat: prettyFiatAmount(feeAmount, currency, formatOptions),
+    rateLabel: prettyNumber(rate, swapAmountDecimals(rate)),
+    fromFiatValue: selectedCurrencyAmount,
+    toFiatValue: receivedCurrencyAmount,
+  }
+}
+
+function amountInAssetUnits(amount: string, mode: AmountMode, fromAsset: SwapAsset, unitOfAccountUsd: number): string {
+  if (mode === 'asset') return amount
+  const assetUsd = estimateSwapUsd(fromAsset)
+  if (!assetUsd) return ''
+  return prettyNumber(((Number(amount) || 0) * unitOfAccountUsd) / assetUsd, fromAsset.decimals)
+}
+
+function amountForQuote(amount: string, fromAsset: SwapAsset, btcEntryPrecision: number): string {
+  if (fromAsset.assetId !== BTC_ASSET_ID || btcEntryPrecision > 0) return amount
+  return fromAtomic(BigInt(amount.split('.')[0].replace(/\D/g, '') || '0'), 8)
+}
+
+function swapValidationMessage({
+  amount,
+  fromAsset,
+  pairAvailable,
+  plan,
+  planError,
+  solvable,
+  status,
+}: {
+  amount: string
+  fromAsset: SwapAsset
+  pairAvailable: boolean
+  plan: OfferPlan | null
+  planError: ReturnType<typeof validatePlan>
+  solvable: boolean | undefined
+  status: string
+}): string {
+  if (!Number(amount)) return ''
+  if (!pairAvailable || solvable === false) return 'Swap unavailable for this pair'
+  if (status === 'error') return 'Quote unavailable'
+  if (!plan) return ''
+  switch (planError) {
+    case 'insufficient-balance':
+      return 'Insufficient balance'
+    case 'side-disabled':
+      return 'Swap unavailable for this pair'
+    case 'below-min':
+      return `Minimum ${plan.limits.min?.display ?? ''} ${fromAsset.ticker}`.trim()
+    case 'above-max':
+      return `Maximum ${plan.limits.max?.display ?? ''} ${fromAsset.ticker}`.trim()
+    case 'below-dust':
+      return 'Amount too small'
+    default:
+      return ''
+  }
+}
+
+function buildQuoteSnapshot(plan: OfferPlan, quote: SwapQuote, currency: Currencies): AssetSwapQuoteSnapshot {
+  return {
+    fromName: quote.fromAsset.name,
+    fromTicker: quote.fromAsset.ticker,
+    fromDecimals: plan.deposit.asset.decimals,
+    toName: quote.toAsset?.name ?? plan.receive.asset.name,
+    toTicker: quote.toAsset?.ticker ?? plan.receive.asset.ticker,
+    toDecimals: plan.receive.asset.decimals,
+    feeBps: plan.market.fee_bps,
+    rate: quote.rateLabel,
+    fiatCurrency: currency,
+    fromFiatAmount: quote.fromFiatValue,
+    toFiatAmount: quote.toFiatValue,
+    quotedAt: Date.now(),
+  }
+}
+
+function formatCurrencyInputAmount(amount: string, currency: Currencies, bitcoinUnit: Unit): string {
+  const normalized = amount || '0'
+  const fractionDigits = normalized.includes('.') ? (normalized.split('.')[1]?.length ?? 0) : 0
+  const parts = formatFiatAmountParts(Number(normalized) || 0, currency, {
+    bitcoinUnit,
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
+  })
+  const formattedAmount = normalized.endsWith('.') ? `${parts.amount}.` : parts.amount
+  return parts.unit ? `${formattedAmount} ${parts.unit}` : formattedAmount
+}
+
+function swapAmountDecimals(value: number): number {
+  if (value >= 1000) return 2
+  if (value >= 1) return 4
+  return 8
+}
+
+function estimateSwapUsd(asset: SwapAsset): number {
+  return Number.isFinite(asset.usdPrice) ? (asset.usdPrice ?? 0) : 0
+}
+
+function estimateRowUsdPrice(
+  row: PortfolioRow,
+  fiat: Currencies,
+  fromFiatAmount: (amount: number, currency: Currencies) => number,
+  toFiat: (satoshis?: number) => number,
+  toFiatAmount: (satoshis: number, currency: Currencies) => number,
+): number {
+  const ticker = row.ticker.trim().toUpperCase()
+  const convertFiat = (amount: number, from: Currencies, to: Currencies) =>
+    toFiatAmount(fromFiatAmount(amount, from), to)
+  if (row.assetId === 'btc' || ticker === 'BTC') return convertFiat(toFiat(100_000_000), fiat, Currencies.USD)
+  if (ticker === 'USD' || ticker === 'USDT' || ticker === 'USDC' || ticker === 'AUSD')
+    return convertFiat(1, Currencies.USD, Currencies.USD)
+  if (ticker === 'CHF') return convertFiat(1, Currencies.CHF, Currencies.USD)
+
+  const rawBalance = typeof row.balance === 'bigint' ? Number(row.balance) : row.balance
+  const unitBalance = rawBalance / 10 ** row.decimals
+  if (!unitBalance || !row.hasFiatPrice) return 0
+
+  return convertFiat(row.fiatAmount / unitBalance, fiat, Currencies.USD)
+}
+
+function filterAssets(assets: SwapAsset[], query: string): SwapAsset[] {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return assets
+  return assets.filter((asset) => {
+    return asset.name.toLowerCase().includes(normalized) || asset.ticker.toLowerCase().includes(normalized)
+  })
+}
+
+function resolveInitialFromAssetId(assets: SwapAsset[], requestedAssetId?: string): string | undefined {
+  if (requestedAssetId) return assets.find((asset) => asset.assetId === requestedAssetId)?.assetId
+  return firstPositiveBalanceAsset(assets)?.assetId ?? assets[0]?.assetId
+}
+
+function firstPositiveBalanceAsset(assets: SwapAsset[]): SwapAsset | undefined {
+  return assets.find((asset) => {
+    const balance = typeof asset.balance === 'bigint' ? asset.balance : BigInt(asset.balance)
+    return balance > BigInt(0)
+  })
+}
+
+function formatAssetBalance(asset: SwapAsset): string {
+  const rawBalance = typeof asset.balance === 'bigint' ? asset.balance : BigInt(asset.balance)
+  return `${prettyCurrencyAssetAmount(rawBalance, asset.decimals, asset.ticker)} ${asset.ticker}`
+}
+
+function getTokenLogoTicker(ticker: string | undefined) {
+  return tokenLogoTickerForTicker(ticker)
 }

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -224,7 +224,7 @@ export default function WalletSwap() {
   const validationMessage = swapValidationMessage({
     amount,
     fromAsset,
-    pairAvailable: Boolean(pair?.market),
+    pairAvailable: toAsset ? Boolean(pair?.market) : undefined,
     plan,
     planError,
     solvable: solvable ?? undefined,
@@ -1250,13 +1250,14 @@ function swapValidationMessage({
 }: {
   amount: string
   fromAsset: SwapAsset
-  pairAvailable: boolean
+  pairAvailable: boolean | undefined
   plan: OfferPlan | null
   planError: ReturnType<typeof validatePlan>
   solvable: boolean | undefined
   status: string
 }): string {
   if (!Number(amount)) return ''
+  if (pairAvailable === undefined) return ''
   if (!pairAvailable || solvable === false) return 'Swap unavailable for this pair'
   if (status === 'error') return 'Quote unavailable'
   if (!plan) return ''

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -24,14 +24,22 @@ import { AspContext } from '../../providers/asp'
 import Reminder from '../../components/Reminder'
 import { LimitsContext } from '../../providers/limits'
 import { getInputsToSettle } from '../../lib/asp'
+import SwapTransactionSummary from '../../components/SwapTransactionSummary'
+import { formatSwapAssetAmount, swapStatusLabel } from '../../lib/swapDisplay'
+import { FiatContext } from '../../providers/fiat'
+import { designatedAccountCurrency, fiatAccountAssetSatoshis } from '../../lib/accountAssets'
+import { AssetsContext } from '../../providers/assets'
 
 export default function Transaction() {
   const { utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { txInfo } = useContext(FlowContext)
+  const { fromFiatAmount } = useContext(FiatContext)
+  const { isRegistered } = useContext(AssetsContext)
   const { aspInfo, calcBestMarketHour } = useContext(AspContext)
   const { assetMetadataCache, settlePreconfirmed, vtxos, vtxoManager, wallet, svcWallet } = useContext(WalletContext)
 
   const tx = txInfo
+  const swapTx = tx?.type === 'swap'
   const issuanceTx = tx ? isIssuance(tx) : false
   const burnTx = tx ? isBurn(tx) : false
   const boardingTx = Boolean(tx?.boardingTxid)
@@ -91,6 +99,16 @@ export default function Transaction() {
 
   if (!tx) return <></>
 
+  const accountAssetValues = tx.assets?.map((asset) => {
+    const metadata = assetMetadataCache.get(asset.assetId)?.metadata
+    const currency = isRegistered(asset.assetId) ? designatedAccountCurrency(aspInfo.network, asset.assetId) : undefined
+    return fiatAccountAssetSatoshis(BigInt(asset.amount), metadata?.decimals ?? 8, currency, fromFiatAmount)
+  })
+  const accountValueSatoshis =
+    accountAssetValues?.length && accountAssetValues.every((value) => value !== undefined)
+      ? accountAssetValues.reduce((total, value) => total + value, 0)
+      : undefined
+
   const status = expiredBoardingTx
     ? 'Expired'
     : unconfirmedBoardingTx
@@ -101,20 +119,49 @@ export default function Transaction() {
           ? 'Settled'
           : 'Preconfirmed'
 
-  const details: DetailsProps = {
-    direction: issuanceTx ? 'Issuance' : burnTx ? 'Burn' : tx.type === 'sent' ? 'Sent' : 'Received',
-    when: tx.createdAt ? prettyAgo(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed',
-    date: tx.createdAt ? prettyDate(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed',
-    status,
-    type: boardingTx ? 'Boarding' : 'Offchain',
-    txid: tx.boardingTxid || tx.redeemTxid || tx.roundTxid || '',
-    isOffchainTx: !tx.boardingTxid && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
-    assetId: tx.assets?.[0]?.assetId,
-    wallet: wallet,
-    satoshis: tx.type === 'sent' ? tx.amount - defaultFee : tx.amount,
-    fees: tx.type === 'sent' ? defaultFee : 0,
-    total: tx.amount,
-  }
+  const fees = tx.type === 'sent' ? defaultFee : 0
+  const accountTransferSatoshis = accountValueSatoshis === undefined ? undefined : Math.abs(accountValueSatoshis)
+  const transferSatoshis = accountTransferSatoshis ?? (tx.type === 'sent' ? tx.amount - defaultFee : tx.amount)
+  const when = tx.createdAt ? prettyAgo(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed'
+  const date = tx.createdAt ? prettyDate(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed'
+  const txid = tx.boardingTxid || tx.redeemTxid || tx.roundTxid || ''
+
+  const details: DetailsProps = swapTx
+    ? {
+        date,
+        feesLabel:
+          tx.assetSwap?.feeBps === undefined
+            ? 'Not available'
+            : `${prettyCurrencyAssetAmount(BigInt(tx.assetSwap.feeBps), 2, '')}%`,
+        status: swapStatusLabel(tx),
+        swapFrom: formatSwapAssetAmount(tx, 'from'),
+        swapTo: formatSwapAssetAmount(tx, 'to'),
+        txid,
+        type: 'Asset swap',
+        wallet,
+        when,
+      }
+    : {
+        assetId: tx.assets?.[0]?.assetId,
+        date,
+        direction: issuanceTx ? 'Issuance' : burnTx ? 'Burn' : tx.type === 'sent' ? 'Sent' : 'Received',
+        fees,
+        isOffchainTx: !tx.boardingTxid && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
+        satoshis: transferSatoshis,
+        status,
+        total: accountTransferSatoshis === undefined ? tx.amount : transferSatoshis + fees,
+        txid,
+        type: boardingTx ? 'Boarding' : 'Offchain',
+        wallet,
+        when,
+      }
+
+  const swapFromIcon = tx.assetSwap?.fromAssetId
+    ? assetMetadataCache.get(tx.assetSwap.fromAssetId)?.metadata?.icon
+    : undefined
+  const swapToIcon = tx.assetSwap?.toAssetId
+    ? assetMetadataCache.get(tx.assetSwap.toAssetId)?.metadata?.icon
+    : undefined
 
   const Body = () => (
     <Content>
@@ -139,7 +186,10 @@ export default function Transaction() {
               <TextSecondary>Transaction settled successfully</TextSecondary>
             </Info>
           ) : null}
-          {tx.assets?.length ? (
+          {swapTx && tx.assetSwap ? (
+            <SwapTransactionSummary fromIcon={swapFromIcon} toIcon={swapToIcon} tx={tx} />
+          ) : null}
+          {!swapTx && tx.assets?.length ? (
             <div className='transaction-detail__assets'>
               {tx.assets.map((a) => {
                 const meta = assetMetadataCache.get(a.assetId)?.metadata
@@ -147,8 +197,12 @@ export default function Transaction() {
                 const name = meta?.name
                 const icon = meta?.icon
                 const decimals = meta?.decimals ?? 8
-                const accountTicker = accountTickerForAssetTicker(ticker)
+                const designatedCurrency = isRegistered(a.assetId)
+                  ? designatedAccountCurrency(aspInfo.network, a.assetId)
+                  : undefined
+                const accountTicker = accountTickerForAssetTicker(designatedCurrency)
                 const label = accountTicker ?? name ?? `${a.assetId.slice(0, 8)}...`
+                const amountLabel = accountTicker ?? ticker
                 const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? ticker)
                 return (
                   <div key={a.assetId} className='transaction-detail-asset'>
@@ -161,7 +215,7 @@ export default function Transaction() {
                     </span>
                     <div className='transaction-detail-asset__copy'>
                       <span className='transaction-detail-asset__amount'>
-                        {prettyCurrencyAssetAmount(BigInt(a.amount), decimals, accountTicker ?? ticker)} {label}
+                        {prettyCurrencyAssetAmount(BigInt(a.amount), decimals, amountLabel)} {label}
                       </span>
                       {name && ticker && !accountTicker ? (
                         <span className='transaction-detail-asset__name'>{name}</span>
@@ -185,6 +239,8 @@ export default function Transaction() {
     hasInputsToSettle &&
     utxoTxsAllowed() &&
     vtxoTxsAllowed() &&
+    !unconfirmedBoardingTx &&
+    !expiredBoardingTx &&
     amountAboveDust &&
     !settling
 

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -84,6 +84,7 @@ function setupTestEnvironment() {
     dispatchEvent: vi.fn(),
   }))
   vi.mocked(detectJSCapabilities).mockResolvedValue({ isSupported: true })
+  vi.stubEnv('VITE_DEV_MNEMONIC', '')
   vi.stubEnv('VITE_DEV_NSEC', '')
 }
 

--- a/src/test/components/transactions-list.test.tsx
+++ b/src/test/components/transactions-list.test.tsx
@@ -6,8 +6,12 @@ import { FiatContext } from '../../providers/fiat'
 import { FlowContext } from '../../providers/flow'
 import { NavigationContext } from '../../providers/navigation'
 import { WalletContext } from '../../providers/wallet'
+import { AspContext } from '../../providers/asp'
+import { AssetsContext } from '../../providers/assets'
 import { Currencies, Tx } from '../../lib/types'
+import { MUTINYNET_DEPIX_ASSET_ID } from '../../lib/accountAssets'
 import {
+  mockAspContextValue,
   mockConfigContextValue,
   mockFiatContextValue,
   mockFlowContextValue,
@@ -16,6 +20,57 @@ import {
 } from '../screens/mocks'
 
 describe('TransactionsList', () => {
+  it('formats designated account activity with the underlying asset decimals', () => {
+    const tx: Tx = {
+      amount: 330,
+      boardingTxid: '',
+      createdAt: 1_700_000_000,
+      explorable: undefined,
+      preconfirmed: false,
+      redeemTxid: '',
+      roundTxid: 'depix-send',
+      settled: true,
+      type: 'sent',
+      assets: [{ assetId: MUTINYNET_DEPIX_ASSET_ID, amount: BigInt(-200_000_000_000) }],
+    }
+
+    render(
+      <AspContext.Provider
+        value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' } } as any}
+      >
+        <AssetsContext.Provider value={{ isRegistered: () => true } as any}>
+          <NavigationContext.Provider value={mockNavigationContextValue}>
+            <ConfigContext.Provider value={mockConfigContextValue}>
+              <FiatContext.Provider value={mockFiatContextValue}>
+                <FlowContext.Provider value={mockFlowContextValue}>
+                  <WalletContext.Provider
+                    value={
+                      {
+                        ...mockWalletContextValue,
+                        txs: [tx],
+                        assetMetadataCache: new Map([
+                          [
+                            MUTINYNET_DEPIX_ASSET_ID,
+                            { metadata: { decimals: 8, name: 'Decentralized Pix', ticker: 'DEPIX' } },
+                          ],
+                        ]),
+                      } as any
+                    }
+                  >
+                    <TransactionsList mode='static' />
+                  </WalletContext.Provider>
+                </FlowContext.Provider>
+              </FiatContext.Provider>
+            </ConfigContext.Provider>
+          </NavigationContext.Provider>
+        </AssetsContext.Provider>
+      </AspContext.Provider>,
+    )
+
+    expect(screen.getByText('-2,000.00 BRL')).toBeInTheDocument()
+    expect(screen.queryByText('-2,000,000,000.00 BRL')).not.toBeInTheDocument()
+  })
+
   it('shows one configured-unit amount for an arbitrary swap pair', () => {
     const swapTx: Tx = {
       amount: 0,

--- a/src/test/components/transactions-list.test.tsx
+++ b/src/test/components/transactions-list.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import TransactionsList from '../../components/TransactionsList'
+import { ConfigContext } from '../../providers/config'
+import { FiatContext } from '../../providers/fiat'
+import { FlowContext } from '../../providers/flow'
+import { NavigationContext } from '../../providers/navigation'
+import { WalletContext } from '../../providers/wallet'
+import { Currencies, Tx } from '../../lib/types'
+import {
+  mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockNavigationContextValue,
+  mockWalletContextValue,
+} from '../screens/mocks'
+
+describe('TransactionsList', () => {
+  it('shows one configured-unit amount for an arbitrary swap pair', () => {
+    const swapTx: Tx = {
+      amount: 0,
+      boardingTxid: '',
+      createdAt: 1_700_000_000,
+      explorable: undefined,
+      preconfirmed: false,
+      assetSwap: {
+        fiatAmount: 100,
+        fromAmount: BigInt(12_345),
+        fromAssetId: 'asset-alpha',
+        fromDecimals: 2,
+        fromTicker: 'ALP',
+        status: 'completed',
+        toAmount: BigInt(67_890),
+        toAssetId: 'asset-beta',
+        toDecimals: 3,
+        toTicker: 'BET',
+      },
+      redeemTxid: '',
+      roundTxid: 'fill-txid',
+      settled: true,
+      type: 'swap',
+    }
+    const localConfigContextValue = {
+      ...mockConfigContextValue,
+      config: { ...mockConfigContextValue.config, currency: Currencies.USD },
+    }
+
+    const { container } = render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <ConfigContext.Provider value={localConfigContextValue}>
+          <FiatContext.Provider value={mockFiatContextValue}>
+            <FlowContext.Provider value={mockFlowContextValue}>
+              <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [swapTx] }}>
+                <TransactionsList mode='static' />
+              </WalletContext.Provider>
+            </FlowContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByText('Swap')).toBeInTheDocument()
+    expect(screen.getByText(/ALP to BET/)).toBeInTheDocument()
+    expect(screen.getByText('$100.00')).toBeInTheDocument()
+    expect(screen.queryByText(/123.45 ALP/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/67.89 BET/)).not.toBeInTheDocument()
+    expect(container.querySelectorAll('.swap-route-icon__fallback')).toHaveLength(2)
+  })
+
+  it('falls back to the transaction amount when any asset lacks account pricing', () => {
+    const tx: Tx = {
+      amount: 330,
+      boardingTxid: '',
+      createdAt: 1_700_000_000,
+      explorable: undefined,
+      preconfirmed: false,
+      redeemTxid: '',
+      roundTxid: 'mixed-asset-transaction',
+      settled: true,
+      type: 'received',
+      assets: [
+        { assetId: 'usdt-asset', amount: BigInt(10_000) },
+        { assetId: 'unknown-asset', amount: BigInt(50) },
+      ],
+    }
+    const fiatContextValue = {
+      ...mockFiatContextValue,
+      fromFiatAmount: (amount: number) => amount * 100,
+      toFiat: (satoshis?: number) => (satoshis ?? 0) / 100,
+    }
+    const walletContextValue = {
+      ...mockWalletContextValue,
+      txs: [tx],
+      assetMetadataCache: new Map([
+        [
+          'usdt-asset',
+          {
+            metadata: {
+              decimals: 2,
+              name: 'Tether USD',
+              ticker: 'USDT',
+            },
+          },
+        ],
+      ]),
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <ConfigContext.Provider value={mockConfigContextValue}>
+          <FiatContext.Provider value={fiatContextValue}>
+            <FlowContext.Provider value={mockFlowContextValue}>
+              <WalletContext.Provider value={walletContextValue as any}>
+                <TransactionsList mode='static' />
+              </WalletContext.Provider>
+            </FlowContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByText('€3.30')).toBeInTheDocument()
+    expect(screen.queryByText('€100.00')).not.toBeInTheDocument()
+  })
+})

--- a/src/test/hooks/usePortfolioFiat.test.tsx
+++ b/src/test/hooks/usePortfolioFiat.test.tsx
@@ -1,56 +1,95 @@
 import { renderHook } from '@testing-library/react'
-import { ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
+import { usePortfolioFiat } from '../../hooks/usePortfolioFiat'
+import { MUTINYNET_DEPIX_ASSET_ID, MUTINYNET_USDT_ASSET_ID } from '../../lib/accountAssets'
 import { Currencies } from '../../lib/types'
+import { AspContext } from '../../providers/asp'
+import { AssetsContext } from '../../providers/assets'
 import { FiatContext } from '../../providers/fiat'
 import { WalletContext } from '../../providers/wallet'
-import { usePortfolioFiat } from '../../hooks/usePortfolioFiat'
-import { mockFiatContextValue, mockWalletContextValue } from '../screens/mocks'
+import { mockAspContextValue, mockFiatContextValue, mockWalletContextValue } from '../screens/mocks'
 
-describe('usePortfolioFiat', () => {
-  it('converts fiat-like asset balances into the selected currency totals', () => {
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <FiatContext.Provider
-        value={{
-          ...mockFiatContextValue,
-          fromFiatAmount: (amount: number, currency: Currencies) => (currency === Currencies.CHF ? amount * 2000 : 0),
-          toFiat: (sats?: number) => sats ?? 0,
-        }}
-      >
-        <WalletContext.Provider
+const assetDetails = (assetId: string, ticker: string, decimals = 2) => ({
+  assetId,
+  cachedAt: Date.now(),
+  metadata: { decimals, name: ticker, ticker },
+  supply: BigInt(1_000_000),
+})
+
+function wrapper({
+  children,
+  network = 'mutinynet',
+  registered = true,
+}: {
+  children: ReactNode
+  network?: string
+  registered?: boolean
+}) {
+  const assetBalances = [
+    { assetId: MUTINYNET_USDT_ASSET_ID, amount: BigInt(1_234) },
+    { assetId: MUTINYNET_DEPIX_ASSET_ID, amount: BigInt(2_000) },
+  ]
+  const assetMetadataCache = new Map([
+    [MUTINYNET_USDT_ASSET_ID, assetDetails(MUTINYNET_USDT_ASSET_ID, 'USDT')],
+    [MUTINYNET_DEPIX_ASSET_ID, assetDetails(MUTINYNET_DEPIX_ASSET_ID, 'DEPIX')],
+  ])
+  return (
+    <AspContext.Provider
+      value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network } } as any}
+    >
+      <AssetsContext.Provider value={{ isRegistered: () => registered }}>
+        <FiatContext.Provider
           value={{
-            ...mockWalletContextValue,
-            balance: 1000,
-            assetBalances: [{ assetId: 'chf-asset', amount: BigInt(2000) }],
-            assetMetadataCache: new Map([
-              [
-                'chf-asset',
-                {
-                  metadata: {
-                    decimals: 2,
-                    name: 'Swiss franc',
-                    ticker: 'CHF',
-                  },
-                  assetId: 'chf-asset',
-                  supply: BigInt(1000000),
-                  cachedAt: Date.now(),
-                },
-              ],
-            ]),
+            ...mockFiatContextValue,
+            fromFiatAmount: (amount: number, currency: Currencies) =>
+              currency === Currencies.USD ? amount * 1_000 : currency === Currencies.BRL ? amount * 200 : 0,
+            toFiat: (sats?: number) => sats ?? 0,
           }}
         >
-          {children}
-        </WalletContext.Provider>
-      </FiatContext.Provider>
-    )
+          <WalletContext.Provider
+            value={{ ...mockWalletContextValue, balance: 500, assetBalances, assetMetadataCache } as any}
+          >
+            {children}
+          </WalletContext.Provider>
+        </FiatContext.Provider>
+      </AssetsContext.Provider>
+    </AspContext.Provider>
+  )
+}
 
+describe('usePortfolioFiat', () => {
+  it('creates separate verified Mutinynet USD and BRL accounts and includes both in the total', () => {
     const { result } = renderHook(() => usePortfolioFiat(), { wrapper })
-    const chfRow = result.current.rows.find((row) => row.assetId === 'chf-asset')
 
-    expect(chfRow?.fiatAmount).toBe(40000)
-    expect(chfRow?.satsEquivalent).toBe(40000)
-    expect(chfRow?.hasFiatPrice).toBe(true)
-    expect(result.current.totalFiat).toBe(41000)
-    expect(result.current.totalSats).toBe(41000)
+    expect(result.current.rows.find((row) => row.assetId === MUTINYNET_USDT_ASSET_ID)).toMatchObject({
+      name: 'USD',
+      ticker: 'USD',
+      balance: BigInt(1_234),
+      sourceAsset: { assetId: MUTINYNET_USDT_ASSET_ID, balance: BigInt(1_234), decimals: 2 },
+    })
+    expect(result.current.rows.find((row) => row.assetId === MUTINYNET_DEPIX_ASSET_ID)).toMatchObject({
+      name: 'BRL',
+      ticker: 'BRL',
+      balance: BigInt(2_000),
+      sourceAsset: { assetId: MUTINYNET_DEPIX_ASSET_ID, balance: BigInt(2_000), decimals: 2 },
+    })
+    expect(result.current.totalSats).toBe(16_840)
+  })
+
+  it('does not count an unverified asset toward the portfolio total', () => {
+    const unverifiedWrapper = ({ children }: { children: ReactNode }) => wrapper({ children, registered: false })
+    const { result } = renderHook(() => usePortfolioFiat(), { wrapper: unverifiedWrapper })
+
+    expect(result.current.totalSats).toBe(500)
+    expect(result.current.rows.find((row) => row.assetId === MUTINYNET_USDT_ASSET_ID)?.ticker).toBe('USDT')
+  })
+
+  it('does not apply Mutinynet designations on Mainnet', () => {
+    const mainnetWrapper = ({ children }: { children: ReactNode }) => wrapper({ children, network: 'bitcoin' })
+    const { result } = renderHook(() => usePortfolioFiat(), { wrapper: mainnetWrapper })
+
+    expect(result.current.totalSats).toBe(500)
+    expect(result.current.rows.some((row) => row.fiatCurrency)).toBe(false)
   })
 })

--- a/src/test/lib/accountAssets.test.ts
+++ b/src/test/lib/accountAssets.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  accountChartColorToken,
+  designatedAccountCurrency,
+  MUTINYNET_DEPIX_ASSET_ID,
+  MUTINYNET_USDT_ASSET_ID,
+  walletAccountTicker,
+  walletAssetLabel,
+  walletAssetPresentation,
+} from '../../lib/accountAssets'
+
+describe('wallet account asset presentation', () => {
+  it.each([
+    ['BTC', '--account-chart-btc'],
+    ['USD', '--account-chart-usd'],
+    ['CHF', '--account-chart-chf'],
+    ['BRL', '--account-chart-brl'],
+    ['CNY', '--account-chart-cny'],
+    ['EUR', '--account-chart-eur'],
+    ['GBP', '--account-chart-gbp'],
+    ['JPY', '--account-chart-jpy'],
+  ])('uses the %s flag identity color for account charts', (ticker, colorToken) => {
+    expect(accountChartColorToken(ticker)).toBe(colorToken)
+  })
+
+  it('uses the brand chart color for an unrecognized asset', () => {
+    expect(accountChartColorToken('OTHER')).toBe('--account-chart-default')
+  })
+
+  it.each(['USD', 'BRL'])('recognizes the explicit %s account label', (ticker) => {
+    expect(walletAccountTicker(ticker)).toBe(ticker)
+  })
+
+  it.each(['USDT', 'USDC', 'AUSD', 'DPIX', 'DEPIX'])('does not infer an account from the %s ticker', (ticker) => {
+    expect(walletAccountTicker(ticker)).toBeUndefined()
+  })
+
+  it('designates the two verified Mutinynet account assets only', () => {
+    expect(designatedAccountCurrency('mutinynet', MUTINYNET_USDT_ASSET_ID)).toBe('USD')
+    expect(designatedAccountCurrency('mutinynet', MUTINYNET_DEPIX_ASSET_ID)).toBe('BRL')
+    expect(designatedAccountCurrency('bitcoin', MUTINYNET_USDT_ASSET_ID)).toBeUndefined()
+  })
+
+  it('keeps issuer metadata when no explicit account designation is supplied', () => {
+    expect(
+      walletAssetPresentation({
+        name: 'Tether USD',
+        ticker: 'USDT',
+        icon: 'https://issuer.example/tether.svg',
+      }),
+    ).toEqual({ name: 'Tether USD', ticker: 'USDT', icon: 'https://issuer.example/tether.svg' })
+  })
+
+  it('uses the fallback asset name without empty ticker parentheses', () => {
+    const presentation = walletAssetPresentation(undefined, 'asset-id')
+
+    expect(walletAssetLabel(presentation)).toBe('asset-id')
+  })
+})

--- a/src/test/lib/format.test.ts
+++ b/src/test/lib/format.test.ts
@@ -68,12 +68,14 @@ describe('format utilities', () => {
     })
 
     it('should keep the trailing code for currencies without a symbol', () => {
+      expect(prettyFiatAmount(51506, Currencies.BRL)).toBe('51,506.00 BRL')
       expect(prettyFiatAmount(2500, Currencies.CHF)).toBe('2,500.00 CHF')
       expect(prettyFiatAmount(12345, Currencies.CNY)).toBe('12,345.00 CNY')
     })
 
     it('should format fiat currencies with their standard minor units', () => {
       const cases: [Currencies, string, string][] = [
+        [Currencies.BRL, '10.00 BRL', '10.80 BRL'],
         [Currencies.EUR, '€10.00', '€10.80'],
         [Currencies.USD, '$10.00', '$10.80'],
         [Currencies.CHF, '10.00 CHF', '10.80 CHF'],
@@ -202,6 +204,7 @@ describe('format utilities', () => {
     })
 
     it('should keep the trailing code when masking fiat without a symbol', () => {
+      expect(prettyFiatHide(100, Currencies.BRL)).toBe('········ BRL')
       expect(prettyFiatHide(100, Currencies.CHF)).toBe('········ CHF')
       expect(prettyFiatHide(100, Currencies.CNY)).toBe('········ CNY')
     })

--- a/src/test/lib/marketData.test.ts
+++ b/src/test/lib/marketData.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { buildConstantMarketSeries } from '../../lib/marketData'
+
+describe('buildConstantMarketSeries', () => {
+  it('samples the full window densely enough to reach the chart edges', () => {
+    const series = buildConstantMarketSeries(1, 600, 1_000)
+
+    expect(series).toHaveLength(101)
+    expect(series[0]).toEqual({ time: 400, value: 1 })
+    expect(series[1]).toEqual({ time: 406, value: 1 })
+    expect(series[50]).toEqual({ time: 700, value: 1 })
+    expect(series[100]).toEqual({ time: 1_000, value: 1 })
+  })
+
+  it('uses a stable one-day window for the all-time constant series', () => {
+    const series = buildConstantMarketSeries(1, -1, 100_000)
+
+    expect(series).toHaveLength(101)
+    expect(series[0]).toEqual({ time: 13_600, value: 1 })
+    expect(series[50]).toEqual({ time: 56_800, value: 1 })
+    expect(series[100]).toEqual({ time: 100_000, value: 1 })
+  })
+})

--- a/src/test/lib/swap/store.test.ts
+++ b/src/test/lib/swap/store.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { addAssetSwap, getAssetSwaps, updateAssetSwap, AssetSwap } from '../../../lib/swap/store'
+import {
+  addAssetSwap,
+  getAssetSwaps,
+  mergeAssetSwapActivity,
+  updateAssetSwap,
+  AssetSwap,
+} from '../../../lib/swap/store'
+import type { Tx } from '../../../lib/types'
+import { MUTINYNET_USDT_ASSET_ID } from '../../../lib/accountAssets'
 
 const swap = (id: string): AssetSwap => ({
   id,
@@ -35,5 +43,76 @@ describe('asset swap store', () => {
     expect(getAssetSwaps()).toEqual([])
     localStorage.setItem('assetSwaps', '{not json')
     expect(getAssetSwaps()).toEqual([])
+  })
+
+  it('collapses linked funding and fill rows into one swap activity with the actual fill and quote metadata', () => {
+    const fulfilled = {
+      ...swap('funding-txid'),
+      status: 'fulfilled' as const,
+      createdAt: 2_000,
+      spentTxid: 'fill-txid',
+      completedAt: 2_000,
+      quote: {
+        fromName: 'USD',
+        fromTicker: 'USD',
+        fromDecimals: 2,
+        toName: 'BRL',
+        toTicker: 'BRL',
+        toDecimals: 2,
+        feeBps: 30,
+        rate: '5.41',
+        fiatCurrency: 'USD',
+        fromFiatAmount: 100,
+        toFiatAmount: 541,
+        quotedAt: 1_000,
+      },
+    }
+    const tx = (redeemTxid: string, assets?: Tx['assets']): Tx => ({
+      amount: 330,
+      assets,
+      boardingTxid: '',
+      createdAt: 1,
+      explorable: redeemTxid,
+      preconfirmed: false,
+      redeemTxid,
+      roundTxid: '',
+      settled: true,
+      type: 'received',
+    })
+    const fillAmount = BigInt(54_321)
+    const unrelated = tx('unrelated-txid')
+
+    const activity = mergeAssetSwapActivity(
+      [tx('funding-txid'), tx('fill-txid', [{ assetId: fulfilled.toAsset, amount: fillAmount }]), unrelated],
+      [fulfilled],
+    )
+
+    expect(activity).toHaveLength(2)
+    expect(activity[0]).toMatchObject({
+      type: 'swap',
+      redeemTxid: 'fill-txid',
+      assetSwap: {
+        fundingTxid: 'funding-txid',
+        fillTxid: 'fill-txid',
+        fromTicker: 'USD',
+        toTicker: 'BRL',
+        toAmount: fillAmount,
+        feeBps: 30,
+        rate: '5.41',
+        fiatAmount: 100,
+        toFiatAmount: 541,
+        quotedAt: 1_000,
+        completedAt: 2_000,
+        status: 'completed',
+      },
+    })
+    expect(activity[1]).toBe(unrelated)
+  })
+
+  it('labels older Mutinynet swap records from their designated asset IDs', () => {
+    const legacySwap = { ...swap('funding-txid'), toAsset: MUTINYNET_USDT_ASSET_ID }
+    const [activity] = mergeAssetSwapActivity([], [legacySwap], 'mutinynet')
+
+    expect(activity.assetSwap).toMatchObject({ fromTicker: 'BTC', toTicker: 'USD' })
   })
 })

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -175,6 +175,7 @@ export const mockWalletContextValue = {
 export const mockFlowContextValue = {
   txInfo: mockTxInfo,
   swapInfo: undefined,
+  swapFromAssetId: undefined,
   initInfo: emptyInitInfo,
   noteInfo: emptyNoteInfo,
   recvInfo: emptyRecvInfo,
@@ -184,6 +185,7 @@ export const mockFlowContextValue = {
   setRecvInfo: () => {},
   setSendInfo: () => {},
   setSwapInfo: () => {},
+  setSwapFromAssetId: () => {},
   setTxInfo: () => {},
   assetInfo: { assetId: '', supply: BigInt(0) },
   setAssetInfo: () => {},

--- a/src/test/screens/wallet/account-detail.test.tsx
+++ b/src/test/screens/wallet/account-detail.test.tsx
@@ -9,7 +9,7 @@ import { WalletContext } from '../../../providers/wallet'
 import { Currencies } from '../../../lib/types'
 import { AspContext } from '../../../providers/asp'
 import { AssetsContext } from '../../../providers/assets'
-import { MUTINYNET_USDT_ASSET_ID } from '../../../lib/accountAssets'
+import { MUTINYNET_DEPIX_ASSET_ID, MUTINYNET_USDT_ASSET_ID } from '../../../lib/accountAssets'
 import {
   mockConfigContextValue,
   mockAspContextValue,
@@ -25,6 +25,80 @@ vi.mock('liveline', () => ({
 }))
 
 describe('Account detail screen', () => {
+  it('keeps the BRL chart available when historical cross-rate data fails', async () => {
+    const sourceAssetId = MUTINYNET_DEPIX_ASSET_ID
+    const fetchMock = vi.fn().mockRejectedValue(new Error('BRL history unavailable'))
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn(() => ({ observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() })),
+    )
+
+    render(
+      <AspContext.Provider
+        value={{
+          ...mockAspContextValue,
+          aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' },
+        }}
+      >
+        <AssetsContext.Provider value={{ isRegistered: (assetId) => assetId === sourceAssetId }}>
+          <ConfigContext.Provider
+            value={{
+              ...mockConfigContextValue,
+              config: {
+                ...mockConfigContextValue.config,
+                currency: Currencies.EUR,
+                importedAssets: [sourceAssetId],
+              },
+            }}
+          >
+            <FiatContext.Provider value={mockFiatContextValue}>
+              <FlowContext.Provider
+                value={{
+                  ...mockFlowContextValue,
+                  assetInfo: { assetId: sourceAssetId, supply: BigInt(0) },
+                }}
+              >
+                <NavigationContext.Provider value={mockNavigationContextValue}>
+                  <WalletContext.Provider
+                    value={
+                      {
+                        ...mockWalletContextValue,
+                        assetBalances: [{ assetId: sourceAssetId, amount: BigInt(200_000_000_000) }],
+                        assetMetadataCache: new Map([
+                          [
+                            sourceAssetId,
+                            {
+                              metadata: {
+                                decimals: 8,
+                                name: 'Decentralized Pix',
+                                ticker: 'DEPIX',
+                              },
+                            },
+                          ],
+                        ]),
+                        txs: [],
+                      } as any
+                    }
+                  >
+                    <AccountDetail />
+                  </WalletContext.Provider>
+                </NavigationContext.Provider>
+              </FlowContext.Provider>
+            </FiatContext.Provider>
+          </ConfigContext.Provider>
+        </AssetsContext.Provider>
+      </AspContext.Provider>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'BRL' })).toBeInTheDocument()
+    expect(screen.getByText('2,000.00 BRL')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByTestId('liveline-chart')).toBeInTheDocument())
+    expect(Number(screen.getByTestId('liveline-chart').getAttribute('data-point-count'))).toBeGreaterThan(3)
+    expect(screen.queryByText('Price history unavailable')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalled()
+  })
+
   it('shows a USD account without exposing its underlying USDT asset', async () => {
     const sourceAssetId = MUTINYNET_USDT_ASSET_ID
     const navigate = vi.fn()

--- a/src/test/screens/wallet/account-detail.test.tsx
+++ b/src/test/screens/wallet/account-detail.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import AccountDetail from '../../../screens/Wallet/AccountDetail'
+import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import { FlowContext } from '../../../providers/flow'
+import { NavigationContext, Pages } from '../../../providers/navigation'
+import { WalletContext } from '../../../providers/wallet'
+import { Currencies } from '../../../lib/types'
+import { AspContext } from '../../../providers/asp'
+import { AssetsContext } from '../../../providers/assets'
+import { MUTINYNET_USDT_ASSET_ID } from '../../../lib/accountAssets'
+import {
+  mockConfigContextValue,
+  mockAspContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockNavigationContextValue,
+  mockTxInfo,
+  mockWalletContextValue,
+} from '../mocks'
+
+vi.mock('liveline', () => ({
+  Liveline: ({ data }: { data: unknown[] }) => <div data-testid='liveline-chart' data-point-count={data.length} />,
+}))
+
+describe('Account detail screen', () => {
+  it('shows a USD account without exposing its underlying USDT asset', async () => {
+    const sourceAssetId = MUTINYNET_USDT_ASSET_ID
+    const navigate = vi.fn()
+    const setSendInfo = vi.fn()
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn(() => ({ observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() })),
+    )
+
+    render(
+      <AspContext.Provider
+        value={{
+          ...mockAspContextValue,
+          aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' },
+        }}
+      >
+        <AssetsContext.Provider value={{ isRegistered: (assetId) => assetId === sourceAssetId }}>
+          <ConfigContext.Provider
+            value={{
+              ...mockConfigContextValue,
+              config: {
+                ...mockConfigContextValue.config,
+                currency: Currencies.USD,
+                importedAssets: [sourceAssetId],
+              },
+            }}
+          >
+            <FiatContext.Provider value={mockFiatContextValue}>
+              <FlowContext.Provider
+                value={{
+                  ...mockFlowContextValue,
+                  assetInfo: { assetId: sourceAssetId, supply: BigInt(0) },
+                  setSendInfo,
+                }}
+              >
+                <NavigationContext.Provider value={{ ...mockNavigationContextValue, navigate }}>
+                  <WalletContext.Provider
+                    value={
+                      {
+                        ...mockWalletContextValue,
+                        assetBalances: [{ assetId: sourceAssetId, amount: BigInt(10_000) }],
+                        assetMetadataCache: new Map([
+                          [
+                            sourceAssetId,
+                            {
+                              metadata: {
+                                decimals: 2,
+                                icon: 'https://issuer.example/tether.svg',
+                                name: 'Tether USD',
+                                ticker: 'USDT',
+                              },
+                            },
+                          ],
+                        ]),
+                        txs: [
+                          {
+                            ...mockTxInfo,
+                            amount: 0,
+                            assets: [{ assetId: sourceAssetId, amount: BigInt(2_500) }],
+                          },
+                        ],
+                      } as any
+                    }
+                  >
+                    <AccountDetail />
+                  </WalletContext.Provider>
+                </NavigationContext.Provider>
+              </FlowContext.Provider>
+            </FiatContext.Provider>
+          </ConfigContext.Provider>
+        </AssetsContext.Provider>
+      </AspContext.Provider>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'USD' })).toBeInTheDocument()
+    expect(screen.getByText('$1.00')).toBeInTheDocument()
+    expect(screen.getByText('100.00 USD')).toBeInTheDocument()
+    expect(screen.getByText('$100.00')).toBeInTheDocument()
+    expect(screen.getByText('$25.00')).toBeInTheDocument()
+    expect(screen.getByTestId('liveline-chart')).toBeInTheDocument()
+    expect(Number(screen.getByTestId('liveline-chart').getAttribute('data-point-count'))).toBeGreaterThan(3)
+    expect(screen.queryByText('USDT')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tether USD')).not.toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(setSendInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({
+            assetId: sourceAssetId,
+            amount: BigInt(0),
+            balance: BigInt(10_000),
+            ticker: 'USD',
+            source: { assetId: sourceAssetId, balance: BigInt(10_000), decimals: 2 },
+          }),
+        }),
+      )
+      expect(navigate).toHaveBeenCalledWith(Pages.SendForm)
+    })
+  })
+})

--- a/src/test/screens/wallet/account-market-data.test.ts
+++ b/src/test/screens/wallet/account-market-data.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { buildCrossRatePoints } from '../../../lib/marketData'
+
+describe('account market data', () => {
+  it('derives fiat cross-rates only from time-aligned market observations', () => {
+    const points = buildCrossRatePoints(
+      [
+        { time: 1_000, value: 50_000 },
+        { time: 2_000, value: 51_000 },
+      ],
+      [
+        { time: 1_010, value: 250_000 },
+        { time: 2_010, value: 255_000 },
+      ],
+    )
+
+    expect(points).toEqual([
+      { time: 1_000, value: 5 },
+      { time: 2_000, value: 5 },
+    ])
+  })
+
+  it('does not combine observations from non-overlapping periods', () => {
+    const points = buildCrossRatePoints(
+      [
+        { time: 1_000, value: 50_000 },
+        { time: 2_000, value: 51_000 },
+      ],
+      [
+        { time: 20_000, value: 250_000 },
+        { time: 21_000, value: 255_000 },
+      ],
+    )
+
+    expect(points).toEqual([])
+  })
+})

--- a/src/test/screens/wallet/bitcoin-detail.test.tsx
+++ b/src/test/screens/wallet/bitcoin-detail.test.tsx
@@ -16,26 +16,7 @@ import {
 import { Currencies, Unit } from '../../../lib/types'
 
 vi.mock('liveline', () => ({
-  Liveline: ({
-    paused,
-    formatTime,
-    tooltipY,
-    padding,
-  }: {
-    paused?: boolean
-    formatTime?: (timestamp: number) => string
-    tooltipY?: number
-    padding?: { top: number; right: number; bottom: number; left: number }
-  }) => (
-    <div
-      data-testid='liveline-chart'
-      data-paused={String(paused)}
-      data-tooltip-y={tooltipY}
-      data-padding={JSON.stringify(padding)}
-    >
-      {formatTime?.(new Date(2026, 6, 13, 14, 34).getTime() / 1000)}
-    </div>
-  ),
+  Liveline: ({ paused }: { paused?: boolean }) => <div data-testid='liveline-chart' data-paused={String(paused)} />,
 }))
 
 describe('Bitcoin detail screen', () => {
@@ -52,9 +33,11 @@ describe('Bitcoin detail screen', () => {
       vi.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
-          prices: [
-            [Date.now() - 3_600_000, 77_000],
-            [Date.now(), 78_000],
+          when: Date.now(),
+          from: 'bitcoin',
+          data: [
+            { time: Math.floor(Date.now() / 1000) - 3_600, value: 77_000 },
+            { time: Math.floor(Date.now() / 1000), value: 78_000 },
           ],
         }),
       }),
@@ -74,11 +57,9 @@ describe('Bitcoin detail screen', () => {
       </ConfigContext.Provider>,
     )
 
-    const livelineChart = screen.getByTestId('liveline-chart')
-    expect(livelineChart).toHaveAttribute('data-paused', 'false')
-    expect(livelineChart).toHaveAttribute('data-tooltip-y', '-18')
-    expect(livelineChart).toHaveAttribute('data-padding', '{"top":28,"right":32,"bottom":8,"left":12}')
-    expect(livelineChart).toHaveTextContent('Jul 13, 2026, 2:34 PM')
+    await waitFor(() => {
+      expect(screen.getByTestId('liveline-chart')).toHaveAttribute('data-paused', 'false')
+    })
 
     const chart = container.querySelector('.asset-detail-chart')
     expect(chart).not.toBeNull()
@@ -203,5 +184,32 @@ describe('Bitcoin detail screen', () => {
     })
 
     expect(screen.queryByText('$40,000.00')).not.toBeInTheDocument()
+  })
+
+  it('shows an unavailable state instead of inventing chart data', async () => {
+    vi.stubGlobal('ResizeObserver', vi.fn())
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('feed unavailable')))
+
+    render(
+      <ConfigContext.Provider
+        value={{
+          ...mockConfigContextValue,
+          config: { ...mockConfigContextValue.config, currency: Currencies.CNY },
+        }}
+      >
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <FlowContext.Provider value={mockFlowContextValue}>
+            <NavigationContext.Provider value={mockNavigationContextValue}>
+              <WalletContext.Provider value={mockWalletContextValue}>
+                <BitcoinDetail />
+              </WalletContext.Provider>
+            </NavigationContext.Provider>
+          </FlowContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    await waitFor(() => expect(screen.getByText('Price history unavailable')).toBeInTheDocument())
+    expect(screen.queryByTestId('liveline-chart')).not.toBeInTheDocument()
   })
 })

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -3,23 +3,42 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import Wallet from '../../../screens/Wallet/Index'
 import { NavigationContext, Pages } from '../../../providers/navigation'
-import { mockNavigationContextValue } from '../mocks'
+import {
+  mockAspContextValue,
+  mockConfigContextValue,
+  mockNavigationContextValue,
+  mockWalletContextValue,
+} from '../mocks'
+import { ConfigContext } from '../../../providers/config'
+import { WalletContext } from '../../../providers/wallet'
+import { AssetSwapsContext } from '../../../providers/assetSwaps'
+import { AssetsContext } from '../../../providers/assets'
+import { AspContext } from '../../../providers/asp'
+import { MUTINYNET_USDT_ASSET_ID } from '../../../lib/accountAssets'
 
 describe('Wallet screen', () => {
   it('renders the wallet screen with the correct elements', async () => {
     const user = userEvent.setup()
+    const navigate = vi.fn()
 
-    render(<Wallet />)
+    render(
+      <NavigationContext.Provider value={{ ...mockNavigationContextValue, navigate }}>
+        <AssetSwapsContext.Provider value={{ swapAvailable: true, swaps: [] } as any}>
+          <Wallet />
+        </AssetSwapsContext.Provider>
+      </NavigationContext.Provider>,
+    )
     expect(screen.getAllByText('$0.00').length).toBeGreaterThan(0)
     expect(screen.getByText('Send')).toBeInTheDocument()
     expect(screen.getByText('Receive')).toBeInTheDocument()
     expect(screen.getByTestId('home-action-swap')).toBeEnabled()
     await user.click(screen.getByTestId('home-action-swap'))
-    expect(screen.getByTestId('swap-coming-soon-sheet')).toBeInTheDocument()
-    expect(screen.getByText('Assets')).toBeInTheDocument()
+    expect(navigate).toHaveBeenCalledWith(Pages.WalletSwap)
+    expect(screen.getByText('Accounts')).toBeInTheDocument()
     expect(screen.getByText('Bitcoin')).toBeInTheDocument()
     expect(screen.getByText('Recent activity')).toBeInTheDocument()
-    expect(screen.getByText('0 BTC')).toBeInTheDocument()
+    expect(screen.getByText('Do more with your money')).toBeInTheDocument()
+    expect(screen.queryByText('Borrow against your bitcoin')).not.toBeInTheDocument()
   })
 
   it('opens the bitcoin detail page from the bitcoin asset row', async () => {
@@ -34,5 +53,74 @@ describe('Wallet screen', () => {
 
     await user.click(screen.getByTestId(/^asset-row-BTC-/))
     expect(navigate).toHaveBeenCalledWith(Pages.BitcoinDetail)
+  })
+
+  it('shows the verified Mutinynet USDT asset as the USD account', () => {
+    render(
+      <AspContext.Provider
+        value={
+          {
+            ...mockAspContextValue,
+            aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' },
+          } as any
+        }
+      >
+        <AssetsContext.Provider value={{ isRegistered: (assetId) => assetId === MUTINYNET_USDT_ASSET_ID }}>
+          <ConfigContext.Provider value={mockConfigContextValue as any}>
+            <WalletContext.Provider
+              value={
+                {
+                  ...mockWalletContextValue,
+                  assetBalances: [{ assetId: MUTINYNET_USDT_ASSET_ID, amount: BigInt(1_000) }],
+                  assetMetadataCache: new Map([
+                    [MUTINYNET_USDT_ASSET_ID, { metadata: { decimals: 2, name: 'Tether USD', ticker: 'USDT' } }],
+                  ]),
+                } as any
+              }
+            >
+              <Wallet />
+            </WalletContext.Provider>
+          </ConfigContext.Provider>
+        </AssetsContext.Provider>
+      </AspContext.Provider>,
+    )
+
+    expect(screen.getByText('USD')).toBeInTheDocument()
+    expect(screen.getByText('10.00 USD')).toBeInTheDocument()
+    expect(screen.queryByText('USDT')).not.toBeInTheDocument()
+  })
+
+  it('keeps non-fiat assets on the asset administration detail screen', async () => {
+    const user = userEvent.setup()
+    const navigate = vi.fn()
+    const assetId = 'custom-asset'
+
+    render(
+      <NavigationContext.Provider value={{ ...mockNavigationContextValue, navigate }}>
+        <ConfigContext.Provider
+          value={{
+            ...mockConfigContextValue,
+            config: { ...mockConfigContextValue.config, importedAssets: [assetId] },
+          }}
+        >
+          <WalletContext.Provider
+            value={
+              {
+                ...mockWalletContextValue,
+                assetBalances: [{ assetId, amount: BigInt(1_000) }],
+                assetMetadataCache: new Map([
+                  [assetId, { metadata: { decimals: 2, name: 'Custom asset', ticker: 'TKN' } }],
+                ]),
+              } as any
+            }
+          >
+            <Wallet />
+          </WalletContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    await user.click(screen.getByTestId(/^asset-row-TKN-/))
+    expect(navigate).toHaveBeenCalledWith(Pages.AppAssetDetail)
   })
 })

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -250,4 +250,45 @@ describe('Send screen', () => {
 
     await waitFor(() => expect(setSendInfo).toHaveBeenCalledWith(expect.objectContaining({ satoshis: 10000 })))
   })
+
+  it('converts a USD account amount into its designated asset units', async () => {
+    const setSendInfo = vi.fn()
+    const account = {
+      assetId: 'usdt',
+      ticker: 'USD' as const,
+      balance: BigInt(10_000),
+      decimals: 2,
+      amount: BigInt(0),
+      source: { assetId: 'usdt', balance: BigInt(1_000_000), decimals: 4 },
+    }
+
+    renderSendForm({
+      flowContext: {
+        ...mockFlowContextValue,
+        sendInfo: { ...emptySendInfo, account },
+        setSendInfo,
+      },
+      walletContext: {
+        ...mockWalletContextValue,
+        svcWallet: {
+          ...mockSvcWallet,
+          getAddress: () => 'tark1mockoffchain',
+          getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+          getBalance: () => Promise.resolve({ available: 1_000_000 }),
+        } as any,
+      },
+    })
+
+    const amountInput = document.querySelector('input[name="send-amount"]') as HTMLInputElement
+    fireEvent.change(amountInput, { target: { value: '80' } })
+
+    await waitFor(() =>
+      expect(setSendInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({ amount: BigInt(8_000) }),
+          assets: [{ assetId: 'usdt', amount: BigInt(800_000) }],
+        }),
+      ),
+    )
+  })
 })

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -160,10 +160,14 @@ describe('Wallet swap flow', () => {
     expect(setSwapFromAssetId).toHaveBeenCalledWith(undefined)
   })
 
-  it('opens directly with USD selected when launched from the USDT-backed account', () => {
+  it('does not report an unavailable pair before the receive asset is selected', async () => {
     renderSwap({ flow: { swapFromAssetId: USDT_ID, setSwapFromAssetId: vi.fn() } })
     expect(screen.getByLabelText('Swap amount')).toBeInTheDocument()
     expect(screen.getAllByText('USD').length).toBeGreaterThan(0)
+
+    await userEvent.click(screen.getByRole('button', { name: '1' }))
+
+    expect(screen.queryByText('Swap unavailable for this pair')).not.toBeInTheDocument()
   })
 
   it('submits the live PR 784 offer plan and a historical display snapshot', async () => {

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -1,145 +1,193 @@
+import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'
 import WalletSwap from '../../../screens/Wallet/Swap/Index'
 import { AspContext } from '../../../providers/asp'
+import { AssetsContext } from '../../../providers/assets'
 import { AssetSwapsContext } from '../../../providers/assetSwaps'
 import { ConfigContext } from '../../../providers/config'
-import { NavigationContext } from '../../../providers/navigation'
+import { FiatContext } from '../../../providers/fiat'
+import { FlowContext } from '../../../providers/flow'
+import { NavigationContext, Pages } from '../../../providers/navigation'
 import { WalletContext } from '../../../providers/wallet'
-import { AssetSwap } from '../../../lib/swap/store'
-import { Unit } from '../../../lib/types'
+import type { AssetSwap } from '../../../lib/swap/store'
 import {
   mockAspContextValue,
   mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
   mockNavigationContextValue,
   mockWalletContextValue,
 } from '../mocks'
-
-import { btcDepix, btcUsdt, USDT_ID } from '../../lib/swap/fixtures'
+import { btcDepix, btcUsdt, DEPIX_ID, USDT_ID } from '../../lib/swap/fixtures'
 
 const fetchMocker = createFetchMock(vi)
 fetchMocker.enableMocks()
 
 const pendingSwap: AssetSwap = {
-  id: 'txid1',
+  id: 'funding-txid',
   fromAsset: 'btc',
   toAsset: USDT_ID,
   fromAmount: '10000',
-  toAmount: '992',
+  toAmount: '997',
   swapAddress: 'tark1q...',
-  swapPkScript: '5120' + 'ab'.repeat(32),
+  swapPkScript: `5120${'ab'.repeat(32)}`,
   offerHex: '0100',
-  fundingTxid: 'txid1',
+  fundingTxid: 'funding-txid',
   status: 'pending',
   createdAt: 1,
+  quote: {
+    fromName: 'Bitcoin',
+    fromTicker: 'BTC',
+    fromDecimals: 8,
+    toName: 'USD',
+    toTicker: 'USD',
+    toDecimals: 2,
+    feeBps: 30,
+    rate: '99700',
+    fiatCurrency: 'USD',
+    fromFiatAmount: 10,
+    toFiatAmount: 9.97,
+    quotedAt: 1,
+  },
 }
 
-const mockAssetSwapsValue = {
-  markets: [btcUsdt, btcDepix],
-  swapAvailable: true,
-  swaps: [] as AssetSwap[],
-  createSwap: vi.fn().mockResolvedValue(pendingSwap),
-  cancelSwap: vi.fn().mockResolvedValue(undefined),
-}
+const createSwap = vi.fn().mockResolvedValue(pendingSwap)
+const cancelSwap = vi.fn().mockResolvedValue(undefined)
 
-const svcWallet = { getBalance: () => Promise.resolve({ available: 100_000 }) }
+function renderSwap({
+  flow = {},
+  swap = {},
+}: {
+  flow?: Record<string, unknown>
+  swap?: Record<string, unknown>
+} = {}) {
+  const navigate = vi.fn()
+  const goBack = vi.fn()
+  const assetMetadataCache = new Map([
+    [USDT_ID, { metadata: { name: 'USDT', ticker: 'USDT', decimals: 2 } }],
+    [DEPIX_ID, { metadata: { name: 'Decentralized Pix', ticker: 'DEPIX', decimals: 8 } }],
+  ])
 
-const renderSwap = (overrides: Partial<typeof mockAssetSwapsValue> = {}, unit = Unit.BTC) =>
-  render(
-    <ConfigContext.Provider
-      value={{ ...mockConfigContextValue, config: { ...mockConfigContextValue.config, unit } } as any}
+  const view = render(
+    <AspContext.Provider
+      value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' } } as any}
     >
-      <AspContext.Provider value={mockAspContextValue as any}>
-        <NavigationContext.Provider value={mockNavigationContextValue as any}>
-          <WalletContext.Provider value={{ ...mockWalletContextValue, svcWallet: svcWallet as any } as any}>
-            <AssetSwapsContext.Provider value={{ ...mockAssetSwapsValue, ...overrides }}>
-              <WalletSwap />
-            </AssetSwapsContext.Provider>
-          </WalletContext.Provider>
+      <AssetsContext.Provider value={{ isRegistered: () => true }}>
+        <NavigationContext.Provider
+          value={{ ...mockNavigationContextValue, goBack, navigate, screen: Pages.WalletSwap } as any}
+        >
+          <ConfigContext.Provider value={mockConfigContextValue as any}>
+            <FiatContext.Provider
+              value={
+                {
+                  ...mockFiatContextValue,
+                  toFiat: (sats?: number) => ((sats ?? 0) / 100_000_000) * 100_000,
+                } as any
+              }
+            >
+              <FlowContext.Provider value={{ ...mockFlowContextValue, ...flow } as any}>
+                <WalletContext.Provider
+                  value={
+                    {
+                      ...mockWalletContextValue,
+                      balance: 250_000,
+                      assetBalances: [
+                        { assetId: USDT_ID, amount: BigInt(15_000) },
+                        { assetId: DEPIX_ID, amount: BigInt(2_000_000_000) },
+                      ],
+                      assetMetadataCache,
+                      svcWallet: { getBalance: () => Promise.resolve({ available: 100_000 }) },
+                    } as any
+                  }
+                >
+                  <AssetSwapsContext.Provider
+                    value={
+                      {
+                        markets: [btcUsdt, btcDepix],
+                        swapAvailable: true,
+                        swaps: [],
+                        createSwap,
+                        cancelSwap,
+                        ...swap,
+                      } as any
+                    }
+                  >
+                    <WalletSwap />
+                  </AssetSwapsContext.Provider>
+                </WalletContext.Provider>
+              </FlowContext.Provider>
+            </FiatContext.Provider>
+          </ConfigContext.Provider>
         </NavigationContext.Provider>
-      </AspContext.Provider>
-    </ConfigContext.Provider>,
+      </AssetsContext.Provider>
+    </AspContext.Provider>,
   )
 
-describe('Swap screen', () => {
-  it('shows the unavailable state when no markets or emulator', () => {
-    renderSwap({ swapAvailable: false })
+  return { ...view, goBack, navigate }
+}
+
+describe('Wallet swap flow', () => {
+  beforeEach(() => {
+    createSwap.mockClear()
+    cancelSwap.mockClear()
+    fetchMocker.resetMocks()
+    fetchMocker.mockResponse(JSON.stringify({ bitcoin: { usd: 100_000 }, price: '500000' }))
+  })
+
+  it('shows the unavailable state when the PR 784 swap service is unavailable', () => {
+    renderSwap({ swap: { swapAvailable: false } })
     expect(screen.getByText('Swaps are unavailable')).toBeInTheDocument()
   })
 
-  it('lists btc and the market-quoted assets with balances', async () => {
+  it('shows designated Mutinynet assets as separate USD and BRL accounts', () => {
     renderSwap()
+    expect(screen.getByText('Choose asset to swap')).toBeInTheDocument()
+    expect(screen.getByText('USD')).toBeInTheDocument()
+    expect(screen.getByText('BRL')).toBeInTheDocument()
+    expect(screen.queryByText('USDT')).not.toBeInTheDocument()
+    expect(screen.queryByText('DEPIX')).not.toBeInTheDocument()
+  })
+
+  it('opens directly with bitcoin selected when launched from bitcoin detail', () => {
+    const setSwapFromAssetId = vi.fn()
+    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId } })
+
+    expect(screen.getByLabelText('Swap amount')).toBeInTheDocument()
     expect(screen.getByText('Bitcoin')).toBeInTheDocument()
-    expect(screen.getByText('USDT')).toBeInTheDocument()
-    expect(screen.getByText('Decentralized Pix')).toBeInTheDocument()
-    await waitFor(() => expect(screen.getByText('0.001 BTC')).toBeInTheDocument())
+    expect(screen.queryByText('Choose asset to swap')).not.toBeInTheDocument()
+    expect(setSwapFromAssetId).toHaveBeenCalledWith(undefined)
   })
 
-  it('quotes a btc to usdt swap and confirms it', async () => {
-    fetchMocker.mockResponse(JSON.stringify({ bitcoin: { usd: 100000 } }))
-    renderSwap()
-
-    fireEvent.click(screen.getByText('Bitcoin'))
-    await waitFor(() => expect(screen.getByText('Select asset')).toBeInTheDocument())
-
-    // pick the receive asset from the drawer
-    fireEvent.click(screen.getByText('Select asset'))
-    await waitFor(() => expect(screen.getByText('Choose asset to receive')).toBeInTheDocument())
-    fireEvent.click(screen.getByText('USDT'))
-
-    // type 0.0001 BTC in the send input
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '0.0001' } })
-
-    // debounced quote resolves: 10_000 sats -> 9.97 USDT
-    await waitFor(() => expect(screen.getAllByText('≥ 9.97 USDT').length).toBeGreaterThan(0), { timeout: 3000 })
-
-    fireEvent.click(screen.getByText('Continue'))
-    await waitFor(() => expect(screen.getByText('Review swap')).toBeInTheDocument())
-
-    fireEvent.click(screen.getByText('Confirm swap'))
-    await waitFor(() => expect(mockAssetSwapsValue.createSwap).toHaveBeenCalled())
-    const plan = mockAssetSwapsValue.createSwap.mock.calls[0][0]
-    expect(plan.deposit.atomic).toBe(BigInt(10_000))
-    expect(plan.receive.atomic).toBe(BigInt(997))
+  it('opens directly with USD selected when launched from the USDT-backed account', () => {
+    renderSwap({ flow: { swapFromAssetId: USDT_ID, setSwapFromAssetId: vi.fn() } })
+    expect(screen.getByLabelText('Swap amount')).toBeInTheDocument()
+    expect(screen.getAllByText('USD').length).toBeGreaterThan(0)
   })
 
-  it('only offers receive assets that share a market with the from asset', async () => {
-    renderSwap()
-    fireEvent.click(screen.getByText('USDT'))
-    await waitFor(() => expect(screen.getByText('Select asset')).toBeInTheDocument())
-    fireEvent.click(screen.getByText('Select asset'))
-    await waitFor(() => expect(screen.getByText('Choose asset to receive')).toBeInTheDocument())
-    // no USDT/DePix market: only btc can be received against USDT
-    expect(screen.getAllByText('Bitcoin').length).toBeGreaterThan(0)
-    expect(screen.queryByText('Decentralized Pix')).not.toBeInTheDocument()
+  it('submits the live PR 784 offer plan and a historical display snapshot', async () => {
+    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() } })
+
+    fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
+    fireEvent.click(screen.getByRole('button', { name: /USD/i }))
+    await userEvent.click(screen.getByRole('button', { name: '5' }))
+    await userEvent.click(screen.getByRole('button', { name: '0' }))
+
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    await waitFor(() => expect(continueButton).toBeEnabled(), { timeout: 3_000 })
+    fireEvent.click(continueButton)
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm swap' }))
+
+    await waitFor(() => expect(createSwap).toHaveBeenCalledOnce())
+    expect(createSwap.mock.calls[0][0].deposit.atomic).toBe(BigInt(50_000))
+    expect(createSwap.mock.calls[0][1]).toMatchObject({ fromTicker: 'BTC', toTicker: 'USD', feeBps: 30 })
   })
 
-  it('types whole sats when the display unit is sats', async () => {
-    fetchMocker.mockResponse(JSON.stringify({ bitcoin: { usd: 100000 } }))
-    renderSwap({}, Unit.SATS)
-    await waitFor(() => expect(screen.getByText('100K sats')).toBeInTheDocument())
-    fireEvent.click(screen.getByText('Bitcoin'))
-    await waitFor(() => expect(screen.getByText('Select asset')).toBeInTheDocument())
-    fireEvent.click(screen.getByText('Select asset'))
-    await waitFor(() => expect(screen.getByText('Choose asset to receive')).toBeInTheDocument())
-    fireEvent.click(screen.getByText('USDT'))
-
-    // the send label follows the configured unit and whole sats are accepted
-    expect(screen.getByText('Send sats')).toBeInTheDocument()
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '1000' } })
-    expect(screen.getByRole('textbox')).toHaveValue('1000')
-
-    // 1000 sats -> 0.99 USDT
-    await waitFor(() => expect(screen.getAllByText('≥ 0.99 USDT').length).toBeGreaterThan(0), { timeout: 3000 })
-  })
-
-  it('lists swaps and cancels a pending one', async () => {
-    renderSwap({ swaps: [pendingSwap] })
-    expect(screen.getByText('Your swaps')).toBeInTheDocument()
-    expect(screen.getByText('BTC to USDT')).toBeInTheDocument()
-    expect(screen.getByText('Pending')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('Cancel'))
-    await waitFor(() => expect(mockAssetSwapsValue.cancelSwap).toHaveBeenCalledWith('txid1'))
+  it('keeps PR 784 pending-swap cancellation available', async () => {
+    renderSwap({ swap: { swaps: [pendingSwap] } })
+    expect(screen.getByText('BTC to USD')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(cancelSwap).toHaveBeenCalledWith('funding-txid'))
   })
 })

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -5,6 +5,8 @@ import { FlowContext } from '../../../providers/flow'
 import { LimitsContext } from '../../../providers/limits'
 import {
   mockAspContextValue,
+  mockConfigContextValue,
+  mockFiatContextValue,
   mockFlowContextValue,
   mockIssuanceTxInfo,
   mockLimitsContextValue,
@@ -16,6 +18,11 @@ import {
 import { AspContext } from '../../../providers/asp'
 import { WalletContext } from '../../../providers/wallet'
 import { NavigationContext } from '../../../providers/navigation'
+import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import { Currencies } from '../../../lib/types'
+import { AssetsContext } from '../../../providers/assets'
+import { MUTINYNET_USDT_ASSET_ID } from '../../../lib/accountAssets'
 
 describe('Transaction screen', () => {
   it('renders the settled transaction screen correctly', async () => {
@@ -278,5 +285,287 @@ describe('Transaction screen', () => {
     // Should show "Burn" instead of "Sent"
     expect(screen.getByText('Burn')).toBeInTheDocument()
     expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+  })
+
+  it('renders a swap as an asset-pair receipt without send-only fields', () => {
+    const swapTxInfo = {
+      ...mockTxInfo,
+      amount: 0,
+      boardingTxid: '',
+      assetSwap: {
+        fromAmount: BigInt(12_345),
+        fromAssetId: 'asset-alpha',
+        fromDecimals: 2,
+        fromTicker: 'ALP',
+        toAmount: BigInt(67_890),
+        toAssetId: 'asset-beta',
+        toDecimals: 3,
+        toTicker: 'BET',
+        fiatAmount: 100,
+        feeBps: 30,
+        status: 'completed' as const,
+      },
+      roundTxid: 'fill-txid',
+      settled: true,
+      type: 'swap',
+    }
+    const localFlowContextValue = { ...mockFlowContextValue, txInfo: swapTxInfo }
+    const localWalletContextValue = { ...mockWalletContextValue, txs: [swapTxInfo] }
+    const localConfigContextValue = {
+      ...mockConfigContextValue,
+      config: { ...mockConfigContextValue.config, currency: Currencies.USD },
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <ConfigContext.Provider value={localConfigContextValue}>
+          <FiatContext.Provider value={mockFiatContextValue}>
+            <AspContext.Provider value={mockAspContextValue}>
+              <FlowContext.Provider value={localFlowContextValue}>
+                <WalletContext.Provider value={localWalletContextValue}>
+                  <LimitsContext.Provider value={mockLimitsContextValue}>
+                    <Transaction />
+                  </LimitsContext.Provider>
+                </WalletContext.Provider>
+              </FlowContext.Provider>
+            </AspContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Swap' })).toBeInTheDocument()
+    expect(screen.getByText('ALP to BET')).toBeInTheDocument()
+    expect(screen.getByText('$100.00')).toBeInTheDocument()
+    expect(screen.getByTestId('From')).toHaveTextContent('123.45 ALP')
+    expect(screen.getByTestId('To')).toHaveTextContent('67.89 BET')
+    expect(screen.getAllByText('Completed')).toHaveLength(1)
+    expect(screen.getByText('Asset swap')).toBeInTheDocument()
+    expect(screen.getByTestId('Transaction ID')).toHaveTextContent('fill-txid')
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
+    expect(screen.queryByText('Amount')).not.toBeInTheDocument()
+    expect(screen.getByTestId('Network fees')).toHaveTextContent('0.3%')
+    expect(screen.queryByText('Total')).not.toBeInTheDocument()
+  })
+
+  it('masks swap asset amounts when balances are hidden', () => {
+    const swapTxInfo = {
+      ...mockTxInfo,
+      amount: 0,
+      boardingTxid: '',
+      assetSwap: {
+        fromAmount: BigInt(12_345),
+        fromAssetId: 'asset-alpha',
+        fromDecimals: 2,
+        fromTicker: 'ALP',
+        toAmount: BigInt(67_890),
+        toAssetId: 'asset-beta',
+        toDecimals: 3,
+        toTicker: 'BET',
+        fiatAmount: 100,
+        status: 'completed' as const,
+      },
+      roundTxid: 'fill-txid',
+      settled: true,
+      type: 'swap',
+    }
+    const localConfigContextValue = {
+      ...mockConfigContextValue,
+      config: { ...mockConfigContextValue.config, currency: Currencies.USD, showBalance: false },
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <ConfigContext.Provider value={localConfigContextValue}>
+          <FiatContext.Provider value={mockFiatContextValue}>
+            <AspContext.Provider value={mockAspContextValue}>
+              <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo: swapTxInfo }}>
+                <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [swapTxInfo] }}>
+                  <LimitsContext.Provider value={mockLimitsContextValue}>
+                    <Transaction />
+                  </LimitsContext.Provider>
+                </WalletContext.Provider>
+              </FlowContext.Provider>
+            </AspContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByTestId('From')).toHaveTextContent('········ ALP')
+    expect(screen.getByTestId('To')).toHaveTextContent('········ BET')
+    expect(screen.queryByText('123.45 ALP')).not.toBeInTheDocument()
+    expect(screen.queryByText('67.89 BET')).not.toBeInTheDocument()
+  })
+
+  it('uses the persisted wallet-facing tickers in swap details', () => {
+    const txInfo = {
+      ...mockTxInfo,
+      type: 'swap',
+      assetSwap: {
+        fromTicker: 'USD',
+        toTicker: 'BRL',
+        status: 'completed' as const,
+      },
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <AspContext.Provider value={mockAspContextValue}>
+          <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo }}>
+            <WalletContext.Provider value={mockWalletContextValue}>
+              <LimitsContext.Provider value={mockLimitsContextValue}>
+                <Transaction />
+              </LimitsContext.Provider>
+            </WalletContext.Provider>
+          </FlowContext.Provider>
+        </AspContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByText('USD to BRL')).toBeInTheDocument()
+    expect(screen.queryByText(/USDT|DEPIX/)).not.toBeInTheDocument()
+  })
+
+  it.each([
+    {
+      assetAmount: BigInt(10_000),
+      assetLabel: '100.00 USD',
+      direction: 'Received',
+      total: '$100.00',
+      type: 'received',
+    },
+    {
+      assetAmount: BigInt(-10_000),
+      assetLabel: '-100.00 USD',
+      direction: 'Sent',
+      total: '$100.00',
+      type: 'sent',
+    },
+  ])(
+    'values a $direction USD transaction from its absolute account amount instead of its bitcoin dust amount',
+    ({ assetAmount, assetLabel, direction, total, type }) => {
+      const assetId = MUTINYNET_USDT_ASSET_ID
+      const txInfo = {
+        ...mockTxInfo,
+        amount: 330,
+        assets: [{ assetId, amount: assetAmount }],
+        type,
+      }
+      const walletContextValue = {
+        ...mockWalletContextValue,
+        txs: [txInfo],
+        assetMetadataCache: new Map([
+          [
+            assetId,
+            {
+              metadata: {
+                decimals: 2,
+                name: 'Tether USD',
+                ticker: 'USDT',
+              },
+            },
+          ],
+        ]),
+      }
+      const fiatContextValue = {
+        ...mockFiatContextValue,
+        fromFiatAmount: (amount: number) => amount * 100,
+        toFiat: (satoshis?: number) => (satoshis ?? 0) / 100,
+      }
+
+      render(
+        <ConfigContext.Provider
+          value={{
+            ...mockConfigContextValue,
+            config: { ...mockConfigContextValue.config, currency: Currencies.USD },
+          }}
+        >
+          <FiatContext.Provider value={fiatContextValue}>
+            <NavigationContext.Provider value={mockNavigationContextValue}>
+              <AspContext.Provider
+                value={
+                  {
+                    ...mockAspContextValue,
+                    aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' },
+                  } as any
+                }
+              >
+                <AssetsContext.Provider value={{ isRegistered: (id) => id === MUTINYNET_USDT_ASSET_ID }}>
+                  <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo }}>
+                    <WalletContext.Provider value={walletContextValue as any}>
+                      <LimitsContext.Provider value={mockLimitsContextValue}>
+                        <Transaction />
+                      </LimitsContext.Provider>
+                    </WalletContext.Provider>
+                  </FlowContext.Provider>
+                </AssetsContext.Provider>
+              </AspContext.Provider>
+            </NavigationContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>,
+      )
+
+      expect(screen.getByText(direction)).toBeInTheDocument()
+      expect(screen.getByText(assetLabel)).toBeInTheDocument()
+      expect(screen.getByTestId('Amount')).toHaveTextContent('$100.00')
+      expect(screen.getByTestId('Total')).toHaveTextContent(total)
+      expect(screen.queryByText('Tether USD')).not.toBeInTheDocument()
+    },
+  )
+
+  it('falls back to the transaction amount when a mixed asset cannot be valued as an account', () => {
+    const txInfo = {
+      ...mockTxInfo,
+      amount: 330,
+      assets: [
+        { assetId: 'usdt-asset', amount: BigInt(10_000) },
+        { assetId: 'unknown-asset', amount: BigInt(50) },
+      ],
+      type: 'received',
+    }
+    const walletContextValue = {
+      ...mockWalletContextValue,
+      txs: [txInfo],
+      assetMetadataCache: new Map([
+        [
+          'usdt-asset',
+          {
+            metadata: {
+              decimals: 2,
+              name: 'Tether USD',
+              ticker: 'USDT',
+            },
+          },
+        ],
+      ]),
+    }
+    const fiatContextValue = {
+      ...mockFiatContextValue,
+      fromFiatAmount: (amount: number) => amount * 100,
+      toFiat: (satoshis?: number) => (satoshis ?? 0) / 100,
+    }
+
+    render(
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={fiatContextValue}>
+          <NavigationContext.Provider value={mockNavigationContextValue}>
+            <AspContext.Provider value={mockAspContextValue}>
+              <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo }}>
+                <WalletContext.Provider value={walletContextValue as any}>
+                  <LimitsContext.Provider value={mockLimitsContextValue}>
+                    <Transaction />
+                  </LimitsContext.Provider>
+                </WalletContext.Provider>
+              </FlowContext.Provider>
+            </AspContext.Provider>
+          </NavigationContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    expect(screen.getByTestId('Amount')).toHaveTextContent('€3.30')
+    expect(screen.getByTestId('Total')).toHaveTextContent('€3.30')
+    expect(screen.queryByText('€100.00')).not.toBeInTheDocument()
   })
 })

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -75,6 +75,17 @@
   --yellow-900: #423810;
   --yellow-950: #221c08;
 
+  /* Account chart identity — exact primary colors from each currency flag. */
+  --account-chart-btc: var(--orange-500);
+  --account-chart-usd: #3c3b6e;
+  --account-chart-chf: #d52b1e;
+  --account-chart-brl: #009b3a;
+  --account-chart-cny: #de2910;
+  --account-chart-eur: #003399;
+  --account-chart-gbp: #012169;
+  --account-chart-jpy: #bc002d;
+  --account-chart-default: var(--purple-700);
+
   /* Convenience aliases (backward compat with existing code) */
   --purple: var(--purple-700);
   --purple10: color-mix(in srgb, var(--purple-700) 8%, transparent);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,7 +9,6 @@ interface ImportMetaEnv {
   readonly VITE_DEV_NSEC?: string
   readonly VITE_DEV_RESET_WALLET_ON_BOOT?: string
   readonly VITE_DEV_AUTO_INIT?: string
-  readonly VITE_DEV_MNEMONIC?: string
   readonly VITE_BOLTZ_URL?: string
   readonly VITE_DELEGATOR_URL?: string
   readonly VITE_LNURL_SERVER_URL?: string


### PR DESCRIPTION
## Context

This is a stacked PR on top of #784. It ports the updated UI and UX from #727 onto #784's current covenant-based swap implementation. The review diff contains one commit beyond #784's current head; it is intentionally not based on `master`.

## Summary

- Restores the PR 727 wallet presentation: portfolio hero, Accounts section, account detail views, historical charts, redesigned activity rows and receipts, send/receive success presentation, motion, and haptics.
- Keeps #784's real solver discovery, quote building, validation, covenant funding, cancellation, recovery, monitoring, and completion behavior.
- Keeps the existing Sonner success toast after a fulfilled swap.
- Uses the PR 727 swap UI and navigation while submitting #784's real offer plan and quote snapshot. No delayed fake execution, synthetic balance mutations, or prototype transaction store is carried over.
- Preselects bitcoin when Swap is opened from the bitcoin detail view and preselects the designated currency asset when opened from a currency account.

## Verified currency accounts

Currency accounts are explicit asset designations, not ticker-based aggregation:

- Mutinynet USDT `f121ac9b7656797cc68d1e8fecacfbaa2069ec1461edf0bf2f3c37404cb9791a0000` is presented as USD.
- Mutinynet DEPIX `47004bf4a5fbdb2221f708030528de68ea28f5980044e546b7bb5a352457d1f30000` is presented as BRL.
- Each account has one designated backing asset.
- Only verified, designated assets contribute to the portfolio fiat total.
- Mainnet receives no designation until the asset registry publishes one.
- Unverified and unassigned assets remain visible as their original issuer assets without contributing to the verified portfolio total.

Registry source: https://github.com/ArkLabsHQ/asset-registry

## Swap activity

- Persists the quote snapshot needed for durable swap presentation: asset names, tickers, decimals, fee bps, quoted rate, historical fiat values, quote timestamp, and completion timestamp.
- Connects the funding transaction and the transaction spending that funded output through the persisted funding/spend identifiers from the offer flow.
- Displays a connected funding/fill pair as one Swap activity row instead of separate Send and Receive rows.
- Uses the actual received amount from the fill transaction when available.
- Preserves pending, completed, cancelling, cancelled, and recoverable states from #784.
- Leaves unrelated wallet activity unchanged.

## Affected areas

- Wallet and account presentation: `AssetsSection`, `BitcoinDetail`, new `AccountDetail`, portfolio fiat calculation, market data, and explicit account-asset resolution.
- Swap flow: `Wallet/Swap`, flow/navigation providers, asset swap provider, and success presentation.
- Activity: transaction list, swap route/summary components, swap persistence metadata, and transaction receipt.
- Send/receive: form/detail currency presentation, QR presentation, and success screens.
- Styling: wallet, account, chart, activity, receipt, success, and swap styles in the existing token system.
- Tests: account designation, verified portfolio totals, market data, swap persistence, swap submission/preselection, activity collapsing, account details, transaction receipts, send flow, and wallet home.

## Verification

- `bun run test:unit` — 56 files passed; 389 tests passed; 3 skipped.
- `bunx tsc --noEmit` — passed.
- `bun run build` — passed.
- Pre-commit formatting and ESLint — passed.
- `git diff --check` — passed.
- Manually verified the Mutinynet wallet in Arc's Work profile at mobile width.
- Verified bitcoin detail → Swap starts from bitcoin.
- Verified USD account detail → Swap starts from USD/USDT.
- Verified a live USD → BTC solver quote reaches the review step; confirmation was intentionally not submitted.

## Visual comparison

The UI source and prior deployment are documented in #727. This branch was also verified side-by-side against that build in Arc. The deployment generated for this PR should be used for final reviewer comparison because it includes #784's current functionality beneath the ported UI.



## Live preview

- Mutinynet integrated build: https://codex-port-pr727-ui-onto-pr7.arkade-wallet.pages.dev
- Original PR 727 comparison: https://wt-port-swap-ui-20260707.arkade-wallet.pages.dev
