### PR TITLE
Show asset ID alongside ticker in Virtual Coins list

### DIFF
--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -256,7 +256,7 @@ export default function Vtxos() {
       ? vtxo.assets.map((a) => {
           const meta = assetMetadataCache.get(a.assetId)?.metadata
           const decimals = meta?.decimals ?? 8
-          const shortId = `${a.assetId.slice(0, 8)}...`
+          const shortId = shortAssetId(a.assetId)
           const label = meta?.ticker ? `${meta.ticker} (${shortId})` : shortId
           return `${prettyAssetAmount(a.amount, decimals)} ${label}`
         })
@@ -389,4 +389,9 @@ export default function Vtxos() {
       ) : null}
     </>
   )
+}
+
+function shortAssetId(id: string): string {
+  if (id.length <= 12) return id
+  return `${id.slice(0, 6)}…${id.slice(-4)}`
 }

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -256,7 +256,7 @@ export default function Vtxos() {
       ? vtxo.assets.map((a) => {
           const meta = assetMetadataCache.get(a.assetId)?.metadata
           const decimals = meta?.decimals ?? 8
-          const shortId = shortAssetId(a.assetId)
+          const shortId = `${a.assetId.slice(0, 8)}...`
           const label = meta?.ticker ? `${meta.ticker} (${shortId})` : shortId
           return `${prettyAssetAmount(a.amount, decimals)} ${label}`
         })
@@ -389,9 +389,4 @@ export default function Vtxos() {
       ) : null}
     </>
   )
-}
-
-function shortAssetId(id: string): string {
-  if (id.length <= 12) return id
-  return `${id.slice(0, 6)}…${id.slice(-4)}`
 }

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -256,7 +256,8 @@ export default function Vtxos() {
       ? vtxo.assets.map((a) => {
           const meta = assetMetadataCache.get(a.assetId)?.metadata
           const decimals = meta?.decimals ?? 8
-          const label = meta?.ticker ?? `${a.assetId.slice(0, 8)}...`
+          const shortId = `${a.assetId.slice(0, 8)}...`
+          const label = meta?.ticker ? `${meta.ticker} (${shortId})` : shortId
           return `${prettyAssetAmount(a.amount, decimals)} ${label}`
         })
       : []


### PR DESCRIPTION
## Summary

In Settings → Advanced → Virtual coins, each VTXO's asset line showed only the self-reported ticker (e.g. `12.34 TST`) whenever metadata was cached — with no way to tell which underlying asset ID that ticker actually referred to.

This adds the truncated asset ID alongside the ticker, so the same coin now reads `12.34 TST (9ed89062...)`. When no metadata is cached, the line already fell back to the truncated ID and is unchanged.

## Test plan

- [x] `tsc --noEmit`
- [x] `pnpm test:unit` (321 passed)
- [x] `pnpm lint` / `pnpm format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUQWiNVnjj2dtcLLFR9pWf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset labels in the VTXO settings view now include a shortened asset ID alongside the ticker, making assets easier to distinguish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->