### PR TITLE
Show asset ID and link outpoints to the Arkade explorer in Virtual Coins

### DIFF
--- a/src/lib/explorers.ts
+++ b/src/lib/explorers.ts
@@ -67,11 +67,6 @@ export const getAssetURL = (assetId: string, wallet: Wallet) => {
   return base ? `${base}/asset/${assetId}` : ''
 }
 
-export const getVtxoURL = (txid: string, vout: number, wallet: Wallet) => {
-  const base = getVmempoolURL(wallet.network as NetworkName)
-  return base ? `${base}/txout/${txid}:${vout}` : ''
-}
-
 export const openInNewTab = (txid: string, wallet: Wallet) => {
   window.open(getTxIdURL(txid, wallet), '_blank', 'noreferrer')
 }
@@ -83,10 +78,5 @@ export const openOffchainTxInNewTab = (txid: string, wallet: Wallet) => {
 
 export const openAssetInNewTab = (assetId: string, wallet: Wallet) => {
   const url = getAssetURL(assetId, wallet)
-  if (url) window.open(url, '_blank', 'noreferrer')
-}
-
-export const openVtxoInNewTab = (txid: string, vout: number, wallet: Wallet) => {
-  const url = getVtxoURL(txid, vout, wallet)
   if (url) window.open(url, '_blank', 'noreferrer')
 }

--- a/src/lib/explorers.ts
+++ b/src/lib/explorers.ts
@@ -69,7 +69,7 @@ export const getAssetURL = (assetId: string, wallet: Wallet) => {
 
 export const getVtxoURL = (txid: string, vout: number, wallet: Wallet) => {
   const base = getVmempoolURL(wallet.network as NetworkName)
-  return base ? `${base}/tx/${txid}#vout=${vout}` : ''
+  return base ? `${base}/txout/${txid}:${vout}` : ''
 }
 
 export const openInNewTab = (txid: string, wallet: Wallet) => {

--- a/src/lib/explorers.ts
+++ b/src/lib/explorers.ts
@@ -67,6 +67,11 @@ export const getAssetURL = (assetId: string, wallet: Wallet) => {
   return base ? `${base}/asset/${assetId}` : ''
 }
 
+export const getVtxoURL = (txid: string, vout: number, wallet: Wallet) => {
+  const base = getVmempoolURL(wallet.network as NetworkName)
+  return base ? `${base}/tx/${txid}#vout=${vout}` : ''
+}
+
 export const openInNewTab = (txid: string, wallet: Wallet) => {
   window.open(getTxIdURL(txid, wallet), '_blank', 'noreferrer')
 }
@@ -78,5 +83,10 @@ export const openOffchainTxInNewTab = (txid: string, wallet: Wallet) => {
 
 export const openAssetInNewTab = (assetId: string, wallet: Wallet) => {
   const url = getAssetURL(assetId, wallet)
+  if (url) window.open(url, '_blank', 'noreferrer')
+}
+
+export const openVtxoInNewTab = (txid: string, vout: number, wallet: Wallet) => {
+  const url = getVtxoURL(txid, vout, wallet)
   if (url) window.open(url, '_blank', 'noreferrer')
 }

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -27,7 +27,7 @@ import { consoleError } from '../../lib/logs'
 import * as Sentry from '@sentry/react'
 import Grid from '../../components/Grid'
 import { prettyAssetAmount } from '../../lib/assets'
-import { getAssetURL, getVtxoURL, openAssetInNewTab, openVtxoInNewTab } from '../../lib/explorers'
+import { getAssetURL, getOffchainTxURL } from '../../lib/explorers'
 import ExternalLinkIcon from '../../icons/ExternalLink'
 
 export default function Vtxos() {
@@ -208,15 +208,24 @@ export default function Vtxos() {
     ),
   }
 
+  const ExplorerLinkIcon = ({ url }: { url: string }) => (
+    <span
+      onClick={() => window.open(url, '_blank', 'noreferrer')}
+      style={{ cursor: 'pointer', color: 'var(--neutral-500)' }}
+    >
+      <ExternalLinkIcon small />
+    </span>
+  )
+
   const CoinLine = ({
     amount,
-    outpoint,
+    txid,
     assets,
     tags,
     expiry,
   }: {
     amount: string
-    outpoint?: { txid: string; vout: number }
+    txid?: string
     assets?: { text: string; assetId: string }[]
     tags: React.ReactNode
     expiry: string
@@ -228,6 +237,7 @@ export default function Vtxos() {
       padding: '0',
       width: '100%',
     }
+    const txUrl = txid ? getOffchainTxURL(txid, wallet) : ''
     return (
       <div style={style}>
         <Grid>
@@ -236,14 +246,7 @@ export default function Vtxos() {
               <FlexCol gap='0.25rem'>
                 <FlexRow gap='0.25rem' centered>
                   <Text>{amount}</Text>
-                  {outpoint && getVtxoURL(outpoint.txid, outpoint.vout, wallet) ? (
-                    <span
-                      onClick={() => openVtxoInNewTab(outpoint.txid, outpoint.vout, wallet)}
-                      style={{ cursor: 'pointer', color: 'var(--neutral-500)' }}
-                    >
-                      <ExternalLinkIcon small />
-                    </span>
-                  ) : null}
+                  {txUrl ? <ExplorerLinkIcon url={txUrl} /> : null}
                 </FlexRow>
                 {assets?.map((a) => {
                   const url = getAssetURL(a.assetId, wallet)
@@ -252,14 +255,7 @@ export default function Vtxos() {
                       <Text color='neutral-500' smaller>
                         {a.text}
                       </Text>
-                      {url ? (
-                        <span
-                          onClick={() => openAssetInNewTab(a.assetId, wallet)}
-                          style={{ cursor: 'pointer', color: 'var(--neutral-500)' }}
-                        >
-                          <ExternalLinkIcon small />
-                        </span>
-                      ) : null}
+                      {url ? <ExplorerLinkIcon url={url} /> : null}
                     </FlexRow>
                   )
                 })}
@@ -303,13 +299,7 @@ export default function Vtxos() {
       </FlexRow>
     )
     return (
-      <CoinLine
-        amount={`${satsAmount} sats`}
-        outpoint={{ txid: vtxo.txid, vout: vtxo.vout }}
-        assets={assetsAmounts}
-        tags={tags}
-        expiry={expiry}
-      />
+      <CoinLine amount={`${satsAmount} sats`} txid={vtxo.txid} assets={assetsAmounts} tags={tags} expiry={expiry} />
     )
   }
 

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -27,7 +27,7 @@ import { consoleError } from '../../lib/logs'
 import * as Sentry from '@sentry/react'
 import Grid from '../../components/Grid'
 import { prettyAssetAmount } from '../../lib/assets'
-import { getAssetURL, openAssetInNewTab } from '../../lib/explorers'
+import { getAssetURL, getVtxoURL, openAssetInNewTab, openVtxoInNewTab } from '../../lib/explorers'
 import ExternalLinkIcon from '../../icons/ExternalLink'
 
 export default function Vtxos() {
@@ -210,11 +210,13 @@ export default function Vtxos() {
 
   const CoinLine = ({
     amount,
+    outpoint,
     assets,
     tags,
     expiry,
   }: {
     amount: string
+    outpoint?: { txid: string; vout: number }
     assets?: { text: string; assetId: string }[]
     tags: React.ReactNode
     expiry: string
@@ -232,7 +234,17 @@ export default function Vtxos() {
           <div>
             <div>
               <FlexCol gap='0.25rem'>
-                <Text>{amount}</Text>
+                <FlexRow gap='0.25rem' centered>
+                  <Text>{amount}</Text>
+                  {outpoint && getVtxoURL(outpoint.txid, outpoint.vout, wallet) ? (
+                    <span
+                      onClick={() => openVtxoInNewTab(outpoint.txid, outpoint.vout, wallet)}
+                      style={{ cursor: 'pointer', color: 'var(--neutral-500)' }}
+                    >
+                      <ExternalLinkIcon small />
+                    </span>
+                  ) : null}
+                </FlexRow>
                 {assets?.map((a) => {
                   const url = getAssetURL(a.assetId, wallet)
                   return (
@@ -290,7 +302,15 @@ export default function Vtxos() {
                 : null}
       </FlexRow>
     )
-    return <CoinLine amount={`${satsAmount} sats`} assets={assetsAmounts} tags={tags} expiry={expiry} />
+    return (
+      <CoinLine
+        amount={`${satsAmount} sats`}
+        outpoint={{ txid: vtxo.txid, vout: vtxo.vout }}
+        assets={assetsAmounts}
+        tags={tags}
+        expiry={expiry}
+      />
+    )
   }
 
   const UtxoLine = ({ utxo }: { utxo: ExtendedCoin }) => {

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -27,6 +27,8 @@ import { consoleError } from '../../lib/logs'
 import * as Sentry from '@sentry/react'
 import Grid from '../../components/Grid'
 import { prettyAssetAmount } from '../../lib/assets'
+import { getAssetURL, openAssetInNewTab } from '../../lib/explorers'
+import ExternalLinkIcon from '../../icons/ExternalLink'
 
 export default function Vtxos() {
   const { aspInfo, calcBestMarketHour } = useContext(AspContext)
@@ -213,7 +215,7 @@ export default function Vtxos() {
     expiry,
   }: {
     amount: string
-    assets?: string[]
+    assets?: { text: string; assetId: string }[]
     tags: React.ReactNode
     expiry: string
   }) => {
@@ -231,11 +233,24 @@ export default function Vtxos() {
             <div>
               <FlexCol gap='0.25rem'>
                 <Text>{amount}</Text>
-                {assets?.map((a) => (
-                  <Text key={a} color='neutral-500' smaller>
-                    {a}
-                  </Text>
-                ))}
+                {assets?.map((a) => {
+                  const url = getAssetURL(a.assetId, wallet)
+                  return (
+                    <FlexRow key={a.assetId} gap='0.25rem' centered>
+                      <Text color='neutral-500' smaller>
+                        {a.text}
+                      </Text>
+                      {url ? (
+                        <span
+                          onClick={() => openAssetInNewTab(a.assetId, wallet)}
+                          style={{ cursor: 'pointer', color: 'var(--neutral-500)' }}
+                        >
+                          <ExternalLinkIcon small />
+                        </span>
+                      ) : null}
+                    </FlexRow>
+                  )
+                })}
               </FlexCol>
             </div>
             <div>{tags}</div>
@@ -258,7 +273,7 @@ export default function Vtxos() {
           const decimals = meta?.decimals ?? 8
           const shortId = `${a.assetId.slice(0, 8)}...`
           const label = meta?.ticker ? `${meta.ticker} (${shortId})` : shortId
-          return `${prettyAssetAmount(a.amount, decimals)} ${label}`
+          return { text: `${prettyAssetAmount(a.amount, decimals)} ${label}`, assetId: a.assetId }
         })
       : []
     const expiry = vtxo.virtualStatus?.batchExpiry ? prettyAgo(vtxo.virtualStatus.batchExpiry) : 'Unknown'


### PR DESCRIPTION
## Summary

Two related improvements to Settings → Advanced → Virtual coins:

1. **Show asset ID alongside ticker.** Each VTXO's asset line showed only the self-reported ticker (e.g. `12.34 TST`) whenever metadata was cached — with no way to tell which underlying asset ID that ticker actually referred to. It now shows the first 4 bytes of the asset ID too: `12.34 TST (9ed89062...)`.

2. **Link to the Arkade explorer.** Each virtual coin lacked a link to its transaction on the Arkade explorer, and each asset line lacked a link to its asset page. Both now carry the same external-link icon used in the transaction detail view:
   - The coin's amount line opens its transaction (`getOffchainTxURL`, same helper already used elsewhere in the app — the explorer has no vout-specific route, confirmed against [ArkLabsHQ/arkade-explorer](https://github.com/ArkLabsHQ/arkade-explorer)'s actual route table).
   - Each asset line opens the asset's page (`/asset/{assetId}`).

   Both links render only when the current network has a configured vmempool explorer (same gating as the existing transaction detail view). Boarding UTXOs are unaffected — they belong to a different (onchain) explorer.

## Test plan

- [x] `tsc --noEmit`
- [x] `pnpm test:unit` (321 passed)
- [x] `pnpm lint` / `pnpm format:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added links from transaction IDs and asset IDs to their corresponding external explorer pages.
  * Added explorer link icons beside transaction amounts and individual asset entries when available.
  * Enabled VTXO entries to provide direct access to related transaction details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->