### PR TITLE
fix vertical alignment of nsec input

### DIFF
--- a/src/components/InputNsec.tsx
+++ b/src/components/InputNsec.tsx
@@ -12,7 +12,7 @@ export default function InputNsec({ error, onChange }: InputNsecProps) {
   }
   return (
     <InputContainer error={error} label='Recovery phrase or private key'>
-      <input name='private-key' onChange={handleChange} style={{ width: '100%' }} />
+      <input name='private-key' onChange={handleChange} style={{ padding: '0.25rem 0', width: '100%' }} />
     </InputContainer>
   )
 }


### PR DESCRIPTION
Before / After

<img width="1001" height="329" alt="Screenshot 2026-07-20 at 11 24 17" src="https://github.com/user-attachments/assets/b5180276-7f20-4342-a793-99fd203f5bfa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the private-key input’s vertical spacing for improved visual alignment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->