### PR TITLE
fix(swaps): keep BTC ticker in route labels

### DIFF
--- a/src/lib/swapDisplay.ts
+++ b/src/lib/swapDisplay.ts
@@ -32,9 +32,16 @@ export function swapStatusLabel(tx: Tx): string {
   return 'Completed'
 }
 
+export function swapRouteTicker(assetId: string | undefined, ticker: string | undefined): string | undefined {
+  return assetId === 'btc' ? 'BTC' : (walletAccountTicker(ticker) ?? ticker)
+}
+
 export function swapRouteLabel(tx: Tx): string {
-  return [tx.assetSwap?.fromTicker, tx.assetSwap?.toTicker]
-    .map((ticker) => walletAccountTicker(ticker) ?? ticker)
+  return [
+    { assetId: tx.assetSwap?.fromAssetId, ticker: tx.assetSwap?.fromTicker },
+    { assetId: tx.assetSwap?.toAssetId, ticker: tx.assetSwap?.toTicker },
+  ]
+    .map(({ assetId, ticker }) => swapRouteTicker(assetId, ticker))
     .filter(Boolean)
     .join(' to ')
 }
@@ -96,8 +103,8 @@ export function swapPriceRateLabel(tx: Tx): string | undefined {
   const fromUnits = new Decimal(fromAmount.toString()).div(Decimal.pow(10, fromRateDecimals))
   const toUnits = new Decimal(toAmount.toString()).div(Decimal.pow(10, toRateDecimals))
   const rate = toUnits.div(fromUnits)
-  const fromTicker = swap.fromAssetId === 'btc' ? 'BTC' : (walletAccountTicker(swap.fromTicker) ?? swap.fromTicker)
-  const toTicker = swap.toAssetId === 'btc' ? 'BTC' : (walletAccountTicker(swap.toTicker) ?? swap.toTicker)
+  const fromTicker = swapRouteTicker(swap.fromAssetId, swap.fromTicker)
+  const toTicker = swapRouteTicker(swap.toAssetId, swap.toTicker)
   // deliberately a coarser 2-bucket precision than swapAmountDecimals — a
   // receipt only needs enough precision to eyeball, not display-grid parity
   return `1 ${fromTicker} = ${prettyNumber(rate, rate.lt(1) ? 8 : 2, true, 2)} ${toTicker}`

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -26,6 +26,7 @@ import {
   prettyNumber,
 } from '../../../lib/format'
 import { hapticLight, hapticSubtle, hapticTap } from '../../../lib/haptics'
+import { swapRouteTicker } from '../../../lib/swapDisplay'
 import { BTC_ASSET_ID, findMarket, makeCachedFeedFetch, QUOTE_OPTIONS, validatePlan } from '../../../lib/swap/markets'
 import { type AssetSwap, type AssetSwapQuoteSnapshot, type AssetSwapStatus } from '../../../lib/swap/store'
 import { Currencies, Unit } from '../../../lib/types'
@@ -558,7 +559,8 @@ function PendingSwaps({
             <div key={swap.id} className='swap-token-row'>
               <span className='swap-token-row__copy'>
                 <span>
-                  {swap.quote?.fromTicker ?? from?.ticker ?? '?'} to {swap.quote?.toTicker ?? to?.ticker ?? '?'}
+                  {swapRouteTicker(swap.fromAsset, swap.quote?.fromTicker ?? from?.ticker) ?? '?'} to{' '}
+                  {swapRouteTicker(swap.toAsset, swap.quote?.toTicker ?? to?.ticker) ?? '?'}
                 </span>
                 <small>
                   {formatAmount(swap.fromAsset, swap.fromAmount)} for ≥ {formatAmount(swap.toAsset, swap.toAmount)}
@@ -1076,7 +1078,11 @@ function SwapSuccessOverlay({ quote, onDone }: { quote?: SwapQuote; onDone: () =
     <WalletSuccessSplash
       show={Boolean(quote)}
       headline='Swap created'
-      text={quote ? `${quote.fromAsset.ticker} to ${quote.toAsset?.ticker} · Waiting for fill` : undefined}
+      text={
+        quote
+          ? `${swapRouteTicker(quote.fromAsset.assetId, quote.fromAsset.ticker)} to ${swapRouteTicker(quote.toAsset?.assetId, quote.toAsset?.ticker)} · Waiting for fill`
+          : undefined
+      }
       ariaLabel='Swap created. Tap to go home.'
       onDone={onDone}
     />
@@ -1094,7 +1100,8 @@ function ReviewSummary({ quote, loading }: { quote: SwapQuote; loading: boolean 
         <div>
           <span>Swap route</span>
           <h3 className='text-heading-sm'>
-            {quote.fromAsset.ticker} to {quote.toAsset?.ticker ?? 'asset'}
+            {swapRouteTicker(quote.fromAsset.assetId, quote.fromAsset.ticker)} to{' '}
+            {swapRouteTicker(quote.toAsset?.assetId, quote.toAsset?.ticker) ?? 'asset'}
           </h3>
         </div>
       </div>
@@ -1261,18 +1268,12 @@ function buildQuoteFromPlan(
     feeLabel: toAsset ? `${formatAssetQuantity(feeReceived, toAsset.decimals)} ${toAsset.ticker}` : '',
     // the rate is always quoted per whole BTC even though amounts display in
     // sats — "1 sats = 0.0000006 USD" is technically correct but unreadable
-    rateFromTicker: protocolTicker(fromAsset),
-    rateToTicker: toAsset ? protocolTicker(toAsset) : '',
+    rateFromTicker: swapRouteTicker(fromAsset.assetId, fromAsset.ticker) ?? '',
+    rateToTicker: toAsset ? (swapRouteTicker(toAsset.assetId, toAsset.ticker) ?? '') : '',
     rateLabel: prettyNumber(rate, swapAmountDecimals(rate)),
     fromFiatValue: selectedCurrencyAmount,
     toFiatValue: receivedCurrencyAmount,
   }
-}
-
-/** The asset's ticker for contexts where BTC must read as "BTC" rather than
- * its swap-entry unit ("sats"/"₿") — quoted rates and token logos. */
-function protocolTicker(asset: SwapAsset): string {
-  return asset.assetId === BTC_ASSET_ID ? 'BTC' : asset.ticker
 }
 
 /** BTC's USD price and the solver's plan.*.display are both in whole-BTC

--- a/src/test/components/transactions-list.test.tsx
+++ b/src/test/components/transactions-list.test.tsx
@@ -8,7 +8,7 @@ import { NavigationContext } from '../../providers/navigation'
 import { WalletContext } from '../../providers/wallet'
 import { AspContext } from '../../providers/asp'
 import { AssetsContext } from '../../providers/assets'
-import { Currencies, Tx } from '../../lib/types'
+import { Currencies, Tx, Unit } from '../../lib/types'
 import { MUTINYNET_DEPIX_ASSET_ID } from '../../lib/accountAssets'
 import {
   mockAspContextValue,
@@ -150,7 +150,9 @@ describe('TransactionsList', () => {
 
     const { container } = render(
       <NavigationContext.Provider value={mockNavigationContextValue}>
-        <ConfigContext.Provider value={mockConfigContextValue}>
+        <ConfigContext.Provider
+          value={{ ...mockConfigContextValue, config: { ...mockConfigContextValue.config, unit: Unit.BIP177 } }}
+        >
           <FiatContext.Provider value={mockFiatContextValue}>
             <FlowContext.Provider value={mockFlowContextValue}>
               <WalletContext.Provider value={{ ...mockWalletContextValue, isVerifiedAsset: () => true, txs: [swapTx] }}>
@@ -162,6 +164,7 @@ describe('TransactionsList', () => {
       </NavigationContext.Provider>,
     )
 
+    expect(screen.getByText(/BTC to BET/)).toBeInTheDocument()
     expect(container.querySelector('circle[fill="var(--orange-500)"]')).toBeInTheDocument()
     expect(container.querySelectorAll('.swap-route-icon__fallback')).toHaveLength(1)
   })

--- a/src/test/lib/swapDisplay.test.ts
+++ b/src/test/lib/swapDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { swapUnitOfAccountAmount } from '../../lib/swapDisplay'
+import { swapRouteLabel, swapUnitOfAccountAmount } from '../../lib/swapDisplay'
 import { Currencies, Tx, Unit } from '../../lib/types'
 
 const PRICE = 63_750 // USD per whole BTC
@@ -38,6 +38,22 @@ const btcCurrencySwap = (): Tx =>
       status: 'completed',
     },
   }) as unknown as Tx
+
+describe('swapRouteLabel', () => {
+  it('uses the BTC ticker for either bitcoin leg regardless of its persisted denomination', () => {
+    expect(swapRouteLabel(btcCurrencySwap())).toBe('BTC to USD')
+
+    const reverse = btcCurrencySwap()
+    reverse.assetSwap = {
+      ...reverse.assetSwap!,
+      fromAssetId: 'usd-asset',
+      fromTicker: 'USD',
+      toAssetId: 'btc',
+      toTicker: 'sats',
+    }
+    expect(swapRouteLabel(reverse)).toBe('USD to BTC')
+  })
+})
 
 describe('swapUnitOfAccountAmount', () => {
   it('does not inflate a BTC-denominated snapshot by 1e8 when viewed in a fiat currency', () => {

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -221,6 +221,7 @@ describe('Wallet swap flow', () => {
     const continueButton = screen.getByRole('button', { name: 'Continue' })
     await waitFor(() => expect(continueButton).toBeEnabled(), { timeout: 3_000 })
     fireEvent.click(continueButton)
+    expect(screen.getByRole('heading', { name: 'BTC to USD' })).toBeInTheDocument()
     // the review drawer's rate is quoted per whole BTC, not per satoshi
     expect(screen.getByText(/^1 BTC = /)).toBeInTheDocument()
     // the fee is shown in the receive asset (USD), not the wallet's display
@@ -229,6 +230,7 @@ describe('Wallet swap flow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Confirm swap' }))
 
     await waitFor(() => expect(createSwap).toHaveBeenCalledOnce())
+    expect(screen.getByText('BTC to USD · Waiting for fill')).toBeInTheDocument()
     const plan = createSwap.mock.calls[0][0]
     expect(plan.deposit.atomic).toBe(BigInt(10_000))
     // 10_000 sats * 0.1 cents/sat * (10000 - 30)bps = 997 cents
@@ -258,6 +260,7 @@ describe('Wallet swap flow', () => {
     // the review drawer's Swap/Receive/Fees are all in sats — none may carry a
     // fractional part ("532.333 sats" is not a representable amount)
     expect(screen.getByText('Confirm swap')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'USD to BTC' })).toBeInTheDocument()
     expect(screen.queryByText(/\d\.\d+ sats/)).not.toBeInTheDocument()
   })
 
@@ -502,7 +505,10 @@ describe('Wallet swap flow', () => {
   })
 
   it('keeps PR 784 pending-swap cancellation available', async () => {
-    renderSwap({ swap: { swaps: [pendingSwap] } })
+    renderSwap({
+      config: { unit: Unit.BIP177 },
+      swap: { swaps: [{ ...pendingSwap, quote: { ...pendingSwap.quote!, fromTicker: 'sats' } }] },
+    })
     expect(screen.getByText('BTC to USD')).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     await waitFor(() => expect(cancelSwap).toHaveBeenCalledWith('funding-txid'))


### PR DESCRIPTION
## Summary

- render bitcoin as the canonical BTC ticker in activity, review, success, pending-swap, and rate labels
- identify bitcoin by asset ID so forward and reverse routes are independent of persisted or configured denominations
- preserve sats and ₿ for numeric amounts only

Closes #805

Because this PR targets #784 instead of the default branch, GitHub will apply the automatic close when #784 reaches master. The issue is ready to close manually as soon as this PR merges into #784.

## Testing

- bun run test -- src/test/lib/swapDisplay.test.ts src/test/components/transactions-list.test.tsx src/test/screens/wallet/swap.test.tsx (30 passed)
- bun run test:unit (428 passed, 3 skipped)
- bun run lint
- bunx tsc --noEmit
- Prettier and git diff --check
- Arc Work profile: verified a synthetic persisted sats swap renders BTC to USD while the account amount renders ₿0; restored the original local state afterward

## Affected files

- src/lib/swapDisplay.ts: shared asset-ID-aware route ticker
- src/screens/Wallet/Swap/Index.tsx: canonical route labels across swap surfaces
- src/test/components/transactions-list.test.tsx: activity-list BIP177 regression
- src/test/lib/swapDisplay.test.ts: forward and reverse persisted-denomination regressions
- src/test/screens/wallet/swap.test.tsx: review, success, pending, and reverse-route coverage

## Base

Targets the head branch of #784 so the fix can land in the in-progress swap PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized swap route labels and ticker displays across wallet swap screens.
  * BTC routes now consistently display as “BTC,” including when amounts use satoshi units.
  * Updated swap lists, review panels, success messages, and rate details for clearer route information.

* **Bug Fixes**
  * Corrected BTC-to-fiat and fiat-to-BTC labels when persisted swap data uses differing unit formats.

* **Tests**
  * Added coverage for BTC route labels and swap review states across supported unit configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->