### PR TITLE
Update buy/sell bitcoin upsell card description

### DIFF
--- a/src/screens/Wallet/UpsellsSection.tsx
+++ b/src/screens/Wallet/UpsellsSection.tsx
@@ -53,7 +53,7 @@ export default function UpsellsSection() {
         <UpsellCard
           icon={<CoinsIcon size={20} />}
           title='Buy or sell bitcoin'
-          description='Convert between bitcoin and your local currency.'
+          description='Use a bank transfer in CHF or EUR via SEPA.'
           testId='upsell-buy-sell'
           onClick={handleBuySell}
         />


### PR DESCRIPTION
## Summary
Updated the description text on the buy/sell bitcoin upsell card to provide more specific information about supported payment methods.

## Changes
- Modified the upsell card description from a generic "Convert between bitcoin and your local currency" to a more specific "Use a bank transfer in CHF or EUR via SEPA"
- This change clarifies the exact payment methods and currencies supported for users in the wallet screen

## Details
The updated description now explicitly mentions:
- Supported currencies: CHF and EUR
- Payment method: Bank transfer via SEPA
- This provides clearer expectations for users before they interact with the buy/sell feature

https://claude.ai/code/session_01XxLK31sE7aGje5f5a48UM4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the “Buy or sell bitcoin” card to clarify that CHF/EUR bank transfers are supported via SEPA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->