### PR TITLE
test: Split e2e suite across four CI jobs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,8 +7,35 @@ on:
     branches: [master, next]
 jobs:
   test:
-    timeout-minutes: 45
+    name: E2E (${{ matrix.group }} / ${{ matrix.project }})
+    timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ["Mobile Chrome", "Google Chrome"]
+        group: [assets-send, core]
+        include:
+          - group: assets-send
+            test_files: >-
+              src/test/e2e/asset.test.ts
+              src/test/e2e/send.test.ts
+          - group: core
+            test_files: >-
+              src/test/e2e/backup.test.ts
+              src/test/e2e/bip21.test.ts
+              src/test/e2e/delegate.test.ts
+              src/test/e2e/form.test.ts
+              src/test/e2e/init.test.ts
+              src/test/e2e/keyboard.test.ts
+              src/test/e2e/lnurl.test.ts
+              src/test/e2e/lock.test.ts
+              src/test/e2e/nostr.test.ts
+              src/test/e2e/pwa.test.ts
+              src/test/e2e/receive.test.ts
+              src/test/e2e/restore.test.ts
+              src/test/e2e/serverdown.test.ts
+              src/test/e2e/swap.test.ts
     steps:
     - uses: actions/checkout@v4
       with:
@@ -30,7 +57,7 @@ jobs:
     - name: Verify environment
       run: pnpm regtest:setup
     - name: Run Playwright tests
-      run: sleep 5 && pnpm run test:e2e
+      run: sleep 5 && pnpm run test:e2e --project="${{ matrix.project }}" ${{ matrix.test_files }}
       env:
         CI: true
     - name: Capture logs on failure

--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ Access the playwright code generator tool with:
 pnpm run test:codegen
 ```
 
+On CI the suite runs as four parallel jobs: two browser projects (`Mobile Chrome`,
+`Google Chrome`) times two file groups defined in `.github/workflows/playwright.yml`:
+
+- `assets-send`: `asset.test.ts`, `send.test.ts`
+- `core`: every other file in `src/test/e2e/`
+
+The groups list files explicitly, so **a new test file must be added to one of them**,
+otherwise it will never run on CI.
+
 ## Troubleshooting
 ### `address already in use` (Port 5000) on macOS
 macOS AirPlay Receiver uses port 5000 by default, which conflicts with the regtest stack.

--- a/src/test/e2e/send.test.ts
+++ b/src/test/e2e/send.test.ts
@@ -350,63 +350,65 @@ test('should send sats (some and max) to onchain address with collaborative exit
   // set fees
   execSync('docker exec -t arkd arkd fees intent --onchain-output "200.0"')
 
-  // create wallet
-  await createWallet(page)
-  await fundWallet(page, 1800)
+  try {
+    // create wallet
+    await createWallet(page)
+    await fundWallet(page, 1800)
 
-  const someOnchainAddress = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+    const someOnchainAddress = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
 
-  // send page
-  await prePay(page, someOnchainAddress, isMobile, 900)
+    // send page
+    await prePay(page, someOnchainAddress, isMobile, 900)
 
-  // details page
-  await expect(page.getByTestId('Amount')).toContainText('700 sats')
-  const fees = await page.getByTestId('Network fees').textContent()
-  expect(fees).not.toBeNull()
-  const feesNumber = parseInt(fees!.replace(/[^0-9]/g, ''), 10)
-  expect(feesNumber).toBeGreaterThan(0)
-  const totalSent = 700 + feesNumber
+    // details page
+    await expect(page.getByTestId('Amount')).toContainText('700 sats')
+    const fees = await page.getByTestId('Network fees').textContent()
+    expect(fees).not.toBeNull()
+    const feesNumber = parseInt(fees!.replace(/[^0-9]/g, ''), 10)
+    expect(feesNumber).toBeGreaterThan(0)
+    const totalSent = 700 + feesNumber
 
-  await page.getByText('Tap to Sign').click()
-  await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
-  await page.waitForSelector('text=Payment sent!', { timeout: 30000 })
-  await expect(page.getByText(`${totalSent} sats sent successfully`)).toBeVisible()
+    await page.getByText('Tap to Sign').click()
+    await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
+    await page.waitForSelector('text=Payment sent!', { timeout: 30000 })
+    await expect(page.getByText(`${totalSent} sats sent successfully`)).toBeVisible()
 
-  // main page
-  await page.getByText('Sounds good').click()
-  await expect(page.getByText('Received')).toBeVisible()
-  await page.waitForSelector('text=Sent', { timeout: 10000 })
-  await expect(page.getByText(`- ${totalSent} sats`)).toBeVisible()
+    // main page
+    await page.getByText('Sounds good').click()
+    await expect(page.getByText('Received')).toBeVisible()
+    await page.waitForSelector('text=Sent', { timeout: 10000 })
+    await expect(page.getByText(`- ${totalSent} sats`)).toBeVisible()
 
-  const balance = 1800 - totalSent
+    const balance = 1800 - totalSent
 
-  // go to send page
-  await page.getByText('Send').click()
+    // go to send page
+    await page.getByText('Send').click()
 
-  // fill address
-  await page.locator('input[name="send-address"]').fill(someOnchainAddress)
+    // fill address
+    await page.locator('input[name="send-address"]').fill(someOnchainAddress)
 
-  // click max
-  await page.waitForSelector(`text=${prettyNumber(balance)} sats available`, { timeout: 2100 })
-  await page.getByTestId('input-amount-max').click()
-  await page.waitForSelector('text=Fees will be deducted from the amount sent', { timeout: 2000 })
-  const inputAmount = await page.locator('input[name="send-amount"]').inputValue()
-  expect(inputAmount).toBe(balance.toString())
+    // click max
+    await page.waitForSelector(`text=${prettyNumber(balance)} sats available`, { timeout: 2100 })
+    await page.getByTestId('input-amount-max').click()
+    await page.waitForSelector('text=Fees will be deducted from the amount sent', { timeout: 2000 })
+    const inputAmount = await page.locator('input[name="send-amount"]').inputValue()
+    expect(inputAmount).toBe(balance.toString())
 
-  // continue to send
-  await page.getByText('Continue').click()
+    // continue to send
+    await page.getByText('Continue').click()
 
-  // details page
-  await expect(page.getByTestId('Total')).toContainText(`${balance} sats`)
+    // details page
+    await expect(page.getByTestId('Total')).toContainText(`${balance} sats`)
 
-  await page.getByText('Tap to Sign').click()
-  await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
-  await page.waitForSelector(`text=${balance} sats sent successfully`, { timeout: 20000 })
+    await page.getByText('Tap to Sign').click()
+    await page.getByTestId('loading-logo').waitFor({ timeout: 3000 })
+    await page.waitForSelector(`text=${balance} sats sent successfully`, { timeout: 20000 })
 
-  // main page
-  await page.getByText('Sounds good').click()
-  await page.waitForSelector(`text=- ${balance} sats`, { timeout: 10000 })
-
-  // clear fees
-  execSync('docker exec -t arkd arkd fees clear')
+    // main page
+    await page.getByText('Sounds good').click()
+    await page.waitForSelector(`text=- ${balance} sats`, { timeout: 10000 })
+  } finally {
+    // clear fees
+    execSync('docker exec -t arkd arkd fees clear')
+  }
 })


### PR DESCRIPTION
Experimental and opinionated take based on the work done in https://github.com/arkade-os/ts-sdk/pull/626

Matrix over browser project x file group, plus a try/finally around the arkd fee override in send.test.ts so a failure cannot leak it into later tests.

Note that Playwright is a hefty dependency that accounts for a great amount of time, thus there is only so much we can gain from naive splitting.