### PR TITLE
fix(wallet): restore BRL chart history

### DIFF
--- a/src/lib/marketData.ts
+++ b/src/lib/marketData.ts
@@ -2,6 +2,7 @@ import { LivelinePoint } from 'liveline'
 import { Currencies } from './types'
 
 const host = 'https://price-chart-proxy.arkade.money'
+const binanceHost = 'https://data-api.binance.vision/api/v3/klines'
 
 const DEFAULT_CONSTANT_SERIES_WINDOW_SECS = 86_400
 const CONSTANT_SERIES_INTERVALS = 100
@@ -20,6 +21,15 @@ const PERIOD_WINDOWS = [
   { label: 'oneYear', secs: 31_536_000 },
   { label: 'all', secs: -1 },
 ]
+
+const BRL_KLINES: Record<string, { interval: string; limit: number }> = {
+  oneHour: { interval: '1m', limit: 60 },
+  oneDay: { interval: '15m', limit: 96 },
+  oneWeek: { interval: '1h', limit: 168 },
+  oneMonth: { interval: '4h', limit: 180 },
+  oneYear: { interval: '1d', limit: 365 },
+  all: { interval: '1w', limit: 1000 },
+}
 
 const secsToPeriod = (secs: number): string => {
   const window = PERIOD_WINDOWS.find((w) => w.secs === secs)
@@ -46,12 +56,40 @@ export const fetchHistoricalMarketData = async (
   fiat: Currencies,
   signal?: AbortSignal,
 ): Promise<LivelinePoint[]> => {
+  if (fiat === Currencies.BRL) {
+    try {
+      return await fetchBrlMarketData(secs, signal)
+    } catch (err) {
+      if (signal?.aborted) throw err
+    }
+  }
+
   const period = secsToPeriod(secs)
   const params = new URLSearchParams({ period, fiat })
   const resp = await fetch(`${host}?${params.toString()}`, { signal })
   if (!resp.ok) throw new Error(`Market data fetch failed: ${resp.status}`)
   const data = await resp.json()
   return isValidHistoricalMarketDataResponse(data) ? data.data : []
+}
+
+const fetchBrlMarketData = async (secs: number, signal?: AbortSignal): Promise<LivelinePoint[]> => {
+  const { interval, limit } = BRL_KLINES[secsToPeriod(secs)]
+  const params = new URLSearchParams({ symbol: 'BTCBRL', interval, limit: limit.toString() })
+  const resp = await fetch(`${binanceHost}?${params.toString()}`, { signal })
+  if (!resp.ok) throw new Error(`BRL market data fetch failed: ${resp.status}`)
+
+  const data = await resp.json()
+  if (!Array.isArray(data)) throw new Error('Invalid BRL market data response')
+
+  const points = data.flatMap((candle): LivelinePoint[] => {
+    if (!Array.isArray(candle)) return []
+    const time = Math.floor(Number(candle[0]) / 1000)
+    const value = Number(candle[4])
+    return Number.isFinite(time) && time > 0 && Number.isFinite(value) && value > 0 ? [{ time, value }] : []
+  })
+
+  if (points.length < 2) throw new Error('Invalid BRL market data response')
+  return points
 }
 
 export const buildCrossRatePoints = (sourcePoints: LivelinePoint[], marketPoints: LivelinePoint[]): LivelinePoint[] => {

--- a/src/test/lib/marketData.test.ts
+++ b/src/test/lib/marketData.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
-import { buildConstantMarketSeries } from '../../lib/marketData'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildConstantMarketSeries, fetchHistoricalMarketData } from '../../lib/marketData'
+import { Currencies } from '../../lib/types'
 
 describe('buildConstantMarketSeries', () => {
   it('samples the full window densely enough to reach the chart edges', () => {
@@ -19,5 +20,52 @@ describe('buildConstantMarketSeries', () => {
     expect(series[0]).toEqual({ time: 13_600, value: 1 })
     expect(series[50]).toEqual({ time: 56_800, value: 1 })
     expect(series[100]).toEqual({ time: 100_000, value: 1 })
+  })
+})
+
+describe('fetchHistoricalMarketData', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('loads fresh BRL history from the public BTCBRL market', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        [1_000_000, '1', '1', '1', '320000.00'],
+        [2_000_000, '1', '1', '1', '321000.00'],
+      ],
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchHistoricalMarketData(604_800, Currencies.BRL)).resolves.toEqual([
+      { time: 1_000, value: 320_000 },
+      { time: 2_000, value: 321_000 },
+    ])
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://data-api.binance.vision/api/v3/klines?symbol=BTCBRL&interval=1h&limit=168',
+      { signal: undefined },
+    )
+  })
+
+  it('falls back to the chart proxy when the public BTCBRL market is unavailable', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          when: 2_000_000,
+          from: 'coingecko',
+          data: [
+            { time: 1_000, value: 320_000 },
+            { time: 2_000, value: 321_000 },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchHistoricalMarketData(604_800, Currencies.BRL)).resolves.toHaveLength(2)
+    expect(fetchMock).toHaveBeenLastCalledWith('https://price-chart-proxy.arkade.money?period=oneWeek&fiat=BRL', {
+      signal: undefined,
+    })
   })
 })


### PR DESCRIPTION
## Summary

- fetch BTC/BRL candles from Binance's public market-data endpoint for BRL chart ranges
- fall back to the existing Arkade chart proxy when Binance is unavailable
- preserve abort behavior and all existing USD/EUR/other-currency paths
- add regression coverage for BRL parsing and fallback behavior

This is intentionally stacked on #784.

Closes #807.

## Root cause

The current BRL proxy path uses CoinGecko and is being rate-limited. The wallet then receives no usable history and renders its constant current-price fallback, producing the flat 0% chart reported in #807. Current prices still work, which is why only the history appeared broken.

## Visual verification

Verified in Arc's Work profile with the funded local wallet and display currency set to BRL. The 1W chart rendered a varying BTC/BRL history with a +2.65% delta instead of a flat line.

## Testing

- `bun run test:unit` — 59 files passed; 432 tests passed, 3 skipped
- `bun run lint`
- `bun run build`
- live BRL history checks for 1H, 1D, 1W, 1M, 1Y, and All
- Arc Work-profile verification of the rendered BRL chart

## Affected files

- `src/lib/marketData.ts` — BRL data source, validation, and fallback
- `src/test/lib/marketData.test.ts` — BRL success and fallback tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying historical BRL market data.
  * BRL price history is retrieved and converted into chart-ready time and value points.
  * Added fallback handling when the public market data source is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->