### PR TITLE
Polish send asset picker amounts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1600,9 +1600,8 @@ html.palette-dark .input-shell:focus-within {
 }
 
 .send-asset-option__amount {
-  color: var(--fg);
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
   font-size: 0.9375rem;
-  font-weight: 500;
   line-height: 1.25rem;
 }
 


### PR DESCRIPTION
## Summary

- use the existing muted foreground treatment for balances in the send asset picker
- inherit the regular text weight while preserving Tiero's 15px amount sizing
- intentionally stack this one-file UI polish on PR #784

## Visual verification

**Original ticket**

![Original send asset picker](https://github.com/user-attachments/assets/84481256-bf04-4b9a-b901-93a450ce0473)

**Updated Mutinynet preview**

- [Open the deployed wallet preview](https://wt-compare-send-picker-20260.arkade-wallet.pages.dev)
- verified in the Codex in-app browser with the funded development wallet on Mutinynet
- before/after screenshots are included in the task handoff

## Testing

- `bun run test:unit src/test/screens/wallet/send.test.tsx` (9 tests passed)
- `bun run lint`
- `bun run build`
- `git diff --check`

## Affected files

- `src/index.css` — mute `.send-asset-option__amount` and remove its medium weight override

Relates to #810.