### PR TITLE
feat(swaps): move cancellation into activity receipts

### DIFF
--- a/src/components/ActivityFilter.tsx
+++ b/src/components/ActivityFilter.tsx
@@ -1,0 +1,45 @@
+import { motion } from 'framer-motion'
+import { EASE_IN_OUT_QUINT_TUPLE } from '../lib/animations'
+import { hapticSubtle } from '../lib/haptics'
+import { useReducedMotion } from '../hooks/useReducedMotion'
+
+export type ActivityFilterValue = 'all' | 'swaps'
+
+export default function ActivityFilter({
+  value,
+  onChange,
+}: {
+  value: ActivityFilterValue
+  onChange: (value: ActivityFilterValue) => void
+}) {
+  const prefersReduced = useReducedMotion()
+
+  const selectFilter = (next: ActivityFilterValue) => {
+    if (next === value) return
+    hapticSubtle()
+    onChange(next)
+  }
+
+  return (
+    <div className='activity-filter' role='group' aria-label='Filter activity'>
+      {(['all', 'swaps'] as const).map((option) => (
+        <button
+          key={option}
+          type='button'
+          className='activity-filter__option'
+          aria-pressed={value === option}
+          onClick={() => selectFilter(option)}
+        >
+          {value === option ? (
+            <motion.span
+              layoutId='activity-filter-selection'
+              className='activity-filter__selection'
+              transition={prefersReduced ? { duration: 0 } : { duration: 0.18, ease: EASE_IN_OUT_QUINT_TUPLE }}
+            />
+          ) : null}
+          <span className='activity-filter__label'>{option === 'all' ? 'All' : 'Swaps'}</span>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -273,19 +273,27 @@ function SwapAmountInfo({
 interface TransactionsListProps {
   /** Show only transactions for a specific asset. Use 'btc' for bitcoin-only activity. */
   assetIdFilter?: string | string[]
+  /** Show only transactions of this type. */
+  typeFilter?: Tx['type']
   /** 'virtual' (default) uses virtualization; 'static' renders a simple list. */
   mode?: 'virtual' | 'static'
   /** Max number of transactions to show (only applies when mode='static'). */
   limit?: number
 }
 
-export default function TransactionsList({ assetIdFilter, mode = 'virtual', limit }: TransactionsListProps) {
+export default function TransactionsList({
+  assetIdFilter,
+  typeFilter,
+  mode = 'virtual',
+  limit,
+}: TransactionsListProps) {
   const { setTxInfo } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
   const { assetMetadataCache, txs: allTxs } = useContext(WalletContext)
   const visibleTxs = allTxs
     .filter((tx) => !shouldHideDevAssetTx(tx, assetMetadataCache))
     .filter((tx) => matchesAssetFilter(tx, assetIdFilter))
+    .filter((tx) => !typeFilter || tx.type === typeFilter)
   const txs = mode === 'static' && limit ? visibleTxs.slice(0, limit) : visibleTxs
 
   const focusedRef = useRef(false)

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -484,7 +484,7 @@ function accountInfoForAssetId(
   return { ticker: currency as TokenLogoTicker, label: currency }
 }
 
-function shouldHideDevAssetTx(
+export function shouldHideDevAssetTx(
   tx: Tx,
   assetMetadataCache: Map<string, { metadata?: { name?: string; ticker?: string } }>,
 ): boolean {

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -433,7 +433,7 @@ export default function TransactionsList({
   )
 }
 
-function matchesAssetFilter(tx: Tx, assetIdFilter?: string | string[]): boolean {
+export function matchesAssetFilter(tx: Tx, assetIdFilter?: string | string[]): boolean {
   if (!assetIdFilter) return true
   if (tx.type === 'swap' && tx.assetSwap) {
     const swapAssetIds = [tx.assetSwap.fromAssetId, tx.assetSwap.toAssetId].filter((assetId): assetId is string =>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -59,7 +59,7 @@ function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>)
     <div
       data-slot='alert-dialog-header'
       className={cn(
-        'grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]',
+        'flex flex-col place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]',
         className,
       )}
       {...props}
@@ -72,7 +72,7 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>)
     <div
       data-slot='alert-dialog-footer'
       className={cn(
-        '-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
+        'flex flex-col-reverse gap-2 rounded-b-xl border-t pt-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
         className,
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -879,6 +879,57 @@ iframe {
   width: 100%;
 }
 
+.activity-filter {
+  position: relative;
+  display: inline-flex;
+  min-height: 2.75rem;
+  margin-bottom: 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--neutral-50);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 6%, transparent);
+}
+
+.activity-filter__option {
+  position: relative;
+  display: inline-flex;
+  min-width: 4.5rem;
+  min-height: 2.75rem;
+  border: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: color-mix(in srgb, var(--fg) 64%, transparent);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.activity-filter__option[aria-pressed='true'] {
+  color: var(--fg);
+}
+
+.activity-filter__option:focus-visible {
+  outline: 2px solid var(--purple-700);
+  outline-offset: 2px;
+}
+
+.activity-filter__selection {
+  position: absolute;
+  inset: 0.25rem;
+  border-radius: inherit;
+  background: var(--bg);
+  box-shadow: var(--shadow-sm);
+}
+
+.activity-filter__label {
+  position: relative;
+  z-index: 1;
+}
+
 .activity-list--compact {
   margin-top: -0.125rem;
 }
@@ -4006,26 +4057,4 @@ html.palette-dark .settings-row--danger .settings-row__chevron {
     opacity: 1;
     transform: translate3d(0, 0, 0) scale(1);
   }
-}
-
-.swap-cancel-button {
-  border: 0;
-  flex: 0 0 auto;
-  min-height: 2rem;
-  border-radius: 999px;
-  background: var(--neutral-50);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg) 5%, transparent);
-  color: color-mix(in srgb, var(--fg) 72%, transparent);
-  font: inherit;
-  font-size: var(--text-xs);
-  font-weight: 500;
-  line-height: 1;
-  padding: 0 0.75rem;
-  cursor: pointer;
-  touch-action: manipulation;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.swap-cancel-button:disabled {
-  opacity: 0.5;
 }

--- a/src/lib/swap/restore.ts
+++ b/src/lib/swap/restore.ts
@@ -49,7 +49,7 @@ export const unscannedSwapCandidates = (txs: Tx[], existingIds: ReadonlySet<stri
 
 /** The cancel spend returns the deposit: a BTC offer gets its sats back (no
  * want-asset delivered), an asset offer gets the asset back. */
-function isCancelSpend(offer: Offer, spend: Tx): boolean {
+export function isCancelSpend(offer: Offer, spend: Tx): boolean {
   if (offer.wantAsset) {
     const wantId = offer.wantAsset.toString()
     return !spend.assets?.some((a) => a.assetId === wantId && a.amount > BigInt(0))

--- a/src/lib/swap/store.ts
+++ b/src/lib/swap/store.ts
@@ -44,7 +44,7 @@ export const getAssetSwaps = (): AssetSwap[] => {
     if (!Array.isArray(parsed)) return []
     // insertion order is not chronological — the restore scan rebuilds records
     // in tx-scan order — so sort at read to keep newest-first canonical for
-    // every consumer (the Your swaps list, the activity merge)
+    // every consumer (including the activity merge)
     return parsed
       .filter((s) => s && typeof s.id === 'string' && typeof s.offerHex === 'string')
       .sort((a, b) => b.createdAt - a.createdAt)

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -192,7 +192,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
         } else if (state === 'swept') {
           setSwaps(updateAssetSwap(id, { status: 'recoverable' }))
           return
-        } else if (state) {
+        } else if (state && getAssetSwaps().find((candidate) => candidate.id === id)?.status === 'cancelling') {
           setSwaps(updateAssetSwap(id, { status: swap.status }))
         }
       } catch {

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -5,10 +5,11 @@ import { DiscoveredMarket, OfferPlan } from '@arkade-os/solver-discovery'
 import { Network } from '@arkade-os/boltz-swap'
 import { AspContext } from './asp'
 import { WalletContext } from './wallet'
-import { cancelOffer, createOffer, OFFER_PACKET_TYPE } from '../lib/swap/offer'
+import { cancelOffer, createOffer, decodeOffer, OFFER_PACKET_TYPE } from '../lib/swap/offer'
 import { BTC_ASSET_ID, discoverMarkets } from '../lib/swap/markets'
-import { getScannedTxids, markTxidsScanned, restoreAssetSwaps } from '../lib/swap/restore'
+import { getScannedTxids, isCancelSpend, markTxidsScanned, restoreAssetSwaps } from '../lib/swap/restore'
 import { addAssetSwap, AssetSwap, type AssetSwapQuoteSnapshot, getAssetSwaps, updateAssetSwap } from '../lib/swap/store'
+import { getTxHistory } from '../lib/asp'
 import { getEmulatorUrlForNetwork } from '../lib/constants'
 import { consoleError } from '../lib/logs'
 import { sleep } from '../lib/sleep'
@@ -170,7 +171,14 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
     // spend as a fulfillment
     setSwaps(updateAssetSwap(id, { status: 'cancelling' }))
     try {
-      await cancelOffer(svcWallet, aspInfo.url, swap.offerHex, swap.fundingTxid, swap.swapAddress)
+      const cancelTxid = await cancelOffer(svcWallet, aspInfo.url, swap.offerHex, swap.fundingTxid, swap.swapAddress)
+      // Persist the spend ID returned by the wallet so the receipt remains
+      // complete after refresh and does not depend on a later monitor pass.
+      if (getAssetSwaps().find((candidate) => candidate.id === id)?.status === 'cancelling') {
+        setSwaps(updateAssetSwap(id, { status: 'cancelled', spentTxid: cancelTxid }))
+        toast.success('Swap cancelled, funds returned')
+        reloadWallet().catch(consoleError)
+      }
     } catch (err) {
       // the cancel tx may have broadcast before the failure surfaced; only
       // revert while the deposit is provably unspent, otherwise stay
@@ -179,7 +187,12 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
         const { vtxos } = await new RestIndexerProvider(aspInfo.url).getVtxos({ scripts: [swap.swapPkScript] })
         const deposit = vtxos.find((v) => v.txid === swap.fundingTxid)
         const state = deposit?.virtualStatus.state
-        if (state && state !== 'spent' && state !== 'swept') {
+        if (deposit && state === 'spent') {
+          if (await resolveCancellingSpend(swap, deposit.arkTxId ?? deposit.spentBy)) return
+        } else if (state === 'swept') {
+          setSwaps(updateAssetSwap(id, { status: 'recoverable' }))
+          return
+        } else if (state) {
           setSwaps(updateAssetSwap(id, { status: swap.status }))
         }
       } catch {
@@ -187,16 +200,34 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
       }
       throw err
     }
-    // the SSE monitor may have already seen the cancel spend and resolved it
-    if (getAssetSwaps().find((s) => s.id === id)?.status !== 'cancelled') {
-      setSwaps(updateAssetSwap(id, { status: 'cancelled' }))
-      toast.success('Swap cancelled, funds returned')
-      reloadWallet().catch(consoleError)
-    }
   }
 
-  // pending swaps resolve to fulfilled/recoverable; cancelling ones (including
-  // cancels interrupted by a reload) resolve to cancelled once the spend lands
+  const resolveCancellingSpend = async (swap: AssetSwap, spentTxid?: string): Promise<boolean> => {
+    if (!svcWallet || !spentTxid) return false
+    const spend = (await getTxHistory(svcWallet)).find((tx) =>
+      [tx.boardingTxid, tx.redeemTxid, tx.roundTxid].includes(spentTxid),
+    )
+    if (!spend) return false
+
+    // Re-read after the async history lookup so a completed cancelOffer call
+    // or another monitor pass always wins over this reconciliation.
+    if (getAssetSwaps().find((candidate) => candidate.id === swap.id)?.status !== 'cancelling') return true
+    const cancelled = isCancelSpend(decodeOffer(hex.decode(swap.offerHex)), spend)
+    setSwaps(
+      updateAssetSwap(swap.id, {
+        status: cancelled ? 'cancelled' : 'fulfilled',
+        spentTxid,
+        ...(cancelled ? {} : { completedAt: Date.now() }),
+      }),
+    )
+    if (cancelled) toast.success('Swap cancelled, funds returned')
+    else toast.success(`Swap completed, ${tickerFor(swap.toAsset)} received`)
+    reloadWallet().catch(consoleError)
+    return true
+  }
+
+  // Pending and cancelling swaps stay watched until their spend can be
+  // classified as fulfilled, cancelled or recoverable.
   const watchedScripts = swaps
     .filter((s) => s.status === 'pending' || s.status === 'cancelling')
     .map((s) => s.swapPkScript)
@@ -215,7 +246,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   // single getVtxos on each (re)connect since the stream has no replay; a slow
   // safety reconcile stands in for a heartbeat watchdog on hung streams
   useEffect(() => {
-    if (!watchedScripts || !aspInfo.url || !visible) return
+    if (!watchedScripts || !aspInfo.url || !visible || !svcWallet) return
     const scripts = watchedScripts.split(',')
     const indexer = new RestIndexerProvider(aspInfo.url)
     const abort = new AbortController()
@@ -237,10 +268,11 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
         if (state === 'swept') {
           setSwaps(updateAssetSwap(swap.id, { status: 'recoverable' }))
         } else if (swap.status === 'cancelling') {
-          // a spend while cancelling is our own cancel landing
-          setSwaps(updateAssetSwap(swap.id, { status: 'cancelled', spentTxid: vtxo.arkTxId ?? vtxo.spentBy }))
-          toast.success('Swap cancelled, funds returned')
-          reloadWallet().catch(consoleError)
+          // The solver may win after cancellation starts. Classify the spend
+          // from wallet history instead of assuming every race is a cancel.
+          resolveCancellingSpend(swap, vtxo.arkTxId ?? vtxo.spentBy).catch((err) =>
+            consoleError(err, 'swap cancellation reconciliation failed'),
+          )
         } else {
           setSwaps(
             updateAssetSwap(swap.id, {
@@ -301,7 +333,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
       abort.abort()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [watchedScripts, aspInfo.url, visible])
+  }, [watchedScripts, aspInfo.url, visible, svcWallet])
 
   const swapAvailable = markets.length > 0 && Boolean(emulatorUrl)
   const value = useMemo(

--- a/src/screens/Wallet/Activity.tsx
+++ b/src/screens/Wallet/Activity.tsx
@@ -6,23 +6,15 @@ import Padded from '../../components/Padded'
 import TransactionsList from '../../components/TransactionsList'
 import { WalletContext } from '../../providers/wallet'
 import { EmptyTxList } from '../../components/Empty'
-import { EASE_IN_OUT_QUINT_TUPLE, EASE_OUT_QUINT_TUPLE } from '../../lib/animations'
-import { hapticSubtle } from '../../lib/haptics'
+import { EASE_OUT_QUINT_TUPLE } from '../../lib/animations'
 import { useReducedMotion } from '../../hooks/useReducedMotion'
-
-type ActivityFilter = 'all' | 'swaps'
+import ActivityFilter, { type ActivityFilterValue } from '../../components/ActivityFilter'
 
 export default function Activity() {
   const { txs } = useContext(WalletContext)
-  const [filter, setFilter] = useState<ActivityFilter>('all')
+  const [filter, setFilter] = useState<ActivityFilterValue>('all')
   const prefersReduced = useReducedMotion()
   const hasSwaps = txs.some((tx) => tx.type === 'swap')
-
-  const selectFilter = (next: ActivityFilter) => {
-    if (next === filter) return
-    hapticSubtle()
-    setFilter(next)
-  }
 
   return (
     <>
@@ -33,30 +25,7 @@ export default function Activity() {
             <EmptyTxList />
           ) : (
             <>
-              {hasSwaps ? (
-                <div className='activity-filter' role='group' aria-label='Filter activity'>
-                  {(['all', 'swaps'] as const).map((option) => (
-                    <button
-                      key={option}
-                      type='button'
-                      className='activity-filter__option'
-                      aria-pressed={filter === option}
-                      onClick={() => selectFilter(option)}
-                    >
-                      {filter === option ? (
-                        <motion.span
-                          layoutId='activity-filter-selection'
-                          className='activity-filter__selection'
-                          transition={
-                            prefersReduced ? { duration: 0 } : { duration: 0.18, ease: EASE_IN_OUT_QUINT_TUPLE }
-                          }
-                        />
-                      ) : null}
-                      <span className='activity-filter__label'>{option === 'all' ? 'All' : 'Swaps'}</span>
-                    </button>
-                  ))}
-                </div>
-              ) : null}
+              {hasSwaps ? <ActivityFilter value={filter} onChange={setFilter} /> : null}
               <AnimatePresence mode='wait' initial={false}>
                 <motion.div
                   key={filter}

--- a/src/screens/Wallet/Activity.tsx
+++ b/src/screens/Wallet/Activity.tsx
@@ -1,19 +1,76 @@
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
 import Content from '../../components/Content'
 import Header from '../../components/Header'
 import Padded from '../../components/Padded'
 import TransactionsList from '../../components/TransactionsList'
 import { WalletContext } from '../../providers/wallet'
 import { EmptyTxList } from '../../components/Empty'
+import { EASE_IN_OUT_QUINT_TUPLE, EASE_OUT_QUINT_TUPLE } from '../../lib/animations'
+import { hapticSubtle } from '../../lib/haptics'
+import { useReducedMotion } from '../../hooks/useReducedMotion'
+
+type ActivityFilter = 'all' | 'swaps'
 
 export default function Activity() {
   const { txs } = useContext(WalletContext)
+  const [filter, setFilter] = useState<ActivityFilter>('all')
+  const prefersReduced = useReducedMotion()
+  const hasSwaps = txs.some((tx) => tx.type === 'swap')
+
+  const selectFilter = (next: ActivityFilter) => {
+    if (next === filter) return
+    hapticSubtle()
+    setFilter(next)
+  }
 
   return (
     <>
       <Header text='Activity' back />
       <Content>
-        <Padded>{!txs || txs.length === 0 ? <EmptyTxList /> : <TransactionsList />}</Padded>
+        <Padded>
+          {txs.length === 0 ? (
+            <EmptyTxList />
+          ) : (
+            <>
+              {hasSwaps ? (
+                <div className='activity-filter' role='group' aria-label='Filter activity'>
+                  {(['all', 'swaps'] as const).map((option) => (
+                    <button
+                      key={option}
+                      type='button'
+                      className='activity-filter__option'
+                      aria-pressed={filter === option}
+                      onClick={() => selectFilter(option)}
+                    >
+                      {filter === option ? (
+                        <motion.span
+                          layoutId='activity-filter-selection'
+                          className='activity-filter__selection'
+                          transition={
+                            prefersReduced ? { duration: 0 } : { duration: 0.18, ease: EASE_IN_OUT_QUINT_TUPLE }
+                          }
+                        />
+                      ) : null}
+                      <span className='activity-filter__label'>{option === 'all' ? 'All' : 'Swaps'}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+              <AnimatePresence mode='wait' initial={false}>
+                <motion.div
+                  key={filter}
+                  initial={prefersReduced ? false : { opacity: 0, y: 4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={prefersReduced ? undefined : { opacity: 0, y: 2 }}
+                  transition={prefersReduced ? { duration: 0 } : { duration: 0.16, ease: EASE_OUT_QUINT_TUPLE }}
+                >
+                  <TransactionsList typeFilter={filter === 'swaps' ? 'swap' : undefined} />
+                </motion.div>
+              </AnimatePresence>
+            </>
+          )}
+        </Padded>
       </Content>
     </>
   )

--- a/src/screens/Wallet/Activity.tsx
+++ b/src/screens/Wallet/Activity.tsx
@@ -1,9 +1,9 @@
-import { useContext, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import Content from '../../components/Content'
 import Header from '../../components/Header'
 import Padded from '../../components/Padded'
-import TransactionsList from '../../components/TransactionsList'
+import TransactionsList, { shouldHideDevAssetTx } from '../../components/TransactionsList'
 import { WalletContext } from '../../providers/wallet'
 import { EmptyTxList } from '../../components/Empty'
 import { EASE_OUT_QUINT_TUPLE } from '../../lib/animations'
@@ -11,10 +11,14 @@ import { useReducedMotion } from '../../hooks/useReducedMotion'
 import ActivityFilter, { type ActivityFilterValue } from '../../components/ActivityFilter'
 
 export default function Activity() {
-  const { txs } = useContext(WalletContext)
+  const { assetMetadataCache, txs } = useContext(WalletContext)
   const [filter, setFilter] = useState<ActivityFilterValue>('all')
   const prefersReduced = useReducedMotion()
-  const hasSwaps = txs.some((tx) => tx.type === 'swap')
+  const hasSwaps = txs.some((tx) => !shouldHideDevAssetTx(tx, assetMetadataCache) && tx.type === 'swap')
+
+  useEffect(() => {
+    if (!hasSwaps && filter !== 'all') setFilter('all')
+  }, [filter, hasSwaps])
 
   return (
     <>

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -2,19 +2,20 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { Liveline, type HoverPoint, type LivelinePoint } from 'liveline'
 import { ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import AssetAvatar from '../../components/AssetAvatar'
+import ActivityFilter, { type ActivityFilterValue } from '../../components/ActivityFilter'
 import Content from '../../components/Content'
 import Header from '../../components/Header'
 import Padded from '../../components/Padded'
 import { PrivacyAmount } from '../../components/PrivacyAmount'
 import SwapComingSoonSheet from '../../components/SwapComingSoonSheet'
 import TokenLogo, { accountTickerForAssetTicker, tokenLogoTickerForTicker } from '../../components/TokenLogo'
-import TransactionsList from '../../components/TransactionsList'
+import TransactionsList, { matchesAssetFilter } from '../../components/TransactionsList'
 import { usePortfolioFiat, type PortfolioRow } from '../../hooks/usePortfolioFiat'
 import ReceiveIcon from '../../icons/Receive'
 import ScanIcon from '../../icons/Scan'
 import SendIcon from '../../icons/Send'
 import SwapIcon from '../../icons/Swap'
-import { walletLoadInChild, walletLoadInContainer } from '../../lib/animations'
+import { EASE_OUT_QUINT_TUPLE, walletLoadInChild, walletLoadInContainer } from '../../lib/animations'
 import {
   prettyBitcoinAmount,
   prettyBitcoinHide,
@@ -36,6 +37,7 @@ import { FlowContext, emptyRecvInfo, emptySendInfo } from '../../providers/flow'
 import { NavigationContext, Pages } from '../../providers/navigation'
 import { buildConstantMarketSeries, buildCrossRatePoints, fetchHistoricalMarketData } from '../../lib/marketData'
 import { accountChartColorToken } from '../../lib/accountAssets'
+import { WalletContext } from '../../providers/wallet'
 
 const CHART_WINDOWS = [
   { label: '1H', secs: 3_600 },
@@ -68,11 +70,13 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
   const { setRecvInfo, setSendInfo, setSwapFromAssetId } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
   const { swapAvailable } = useContext(AssetSwapsContext)
+  const { txs } = useContext(WalletContext)
   const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
 
   const [chartWindow, setChartWindow] = useState(CHART_WINDOWS[2].secs)
   const [chartInteracting, setChartInteracting] = useState(false)
+  const [activityFilter, setActivityFilter] = useState<ActivityFilterValue>('all')
   const [swapSheetOpen, setSwapSheetOpen] = useState(false)
   const chartHapticState = useRef({ lastPointTime: 0, lastTriggerTime: 0 })
 
@@ -144,6 +148,8 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
       : undefined
   const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? row.ticker)
   const activityAssetFilter = isBitcoin ? 'btc' : row.assetId
+  const hasAssetSwaps = txs.some((tx) => tx.type === 'swap' && matchesAssetFilter(tx, activityAssetFilter))
+  const activeActivityFilter = hasAssetSwaps ? activityFilter : 'all'
   const priceText =
     currentUnitPrice === undefined
       ? 'Price unavailable'
@@ -413,7 +419,23 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
               <div className='asset-detail-section-header'>
                 <strong>Recent activity</strong>
               </div>
-              <TransactionsList mode='static' assetIdFilter={activityAssetFilter} limit={5} />
+              {hasAssetSwaps ? <ActivityFilter value={activityFilter} onChange={setActivityFilter} /> : null}
+              <AnimatePresence mode='wait' initial={false}>
+                <motion.div
+                  key={activeActivityFilter}
+                  initial={prefersReduced ? false : { opacity: 0, y: 4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={prefersReduced ? undefined : { opacity: 0, y: 2 }}
+                  transition={prefersReduced ? { duration: 0 } : { duration: 0.16, ease: EASE_OUT_QUINT_TUPLE }}
+                >
+                  <TransactionsList
+                    mode='static'
+                    assetIdFilter={activityAssetFilter}
+                    typeFilter={activeActivityFilter === 'swaps' ? 'swap' : undefined}
+                    limit={5}
+                  />
+                </motion.div>
+              </AnimatePresence>
             </motion.section>
           </motion.div>
         </Padded>

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -9,7 +9,7 @@ import Padded from '../../components/Padded'
 import { PrivacyAmount } from '../../components/PrivacyAmount'
 import SwapComingSoonSheet from '../../components/SwapComingSoonSheet'
 import TokenLogo, { accountTickerForAssetTicker, tokenLogoTickerForTicker } from '../../components/TokenLogo'
-import TransactionsList, { matchesAssetFilter } from '../../components/TransactionsList'
+import TransactionsList, { matchesAssetFilter, shouldHideDevAssetTx } from '../../components/TransactionsList'
 import { usePortfolioFiat, type PortfolioRow } from '../../hooks/usePortfolioFiat'
 import ReceiveIcon from '../../icons/Receive'
 import ScanIcon from '../../icons/Scan'
@@ -70,7 +70,7 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
   const { setRecvInfo, setSendInfo, setSwapFromAssetId } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
   const { swapAvailable } = useContext(AssetSwapsContext)
-  const { txs } = useContext(WalletContext)
+  const { assetMetadataCache, txs } = useContext(WalletContext)
   const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
 
@@ -148,8 +148,17 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
       : undefined
   const tokenLogoTicker = tokenLogoTickerForTicker(accountTicker ?? row.ticker)
   const activityAssetFilter = isBitcoin ? 'btc' : row.assetId
-  const hasAssetSwaps = txs.some((tx) => tx.type === 'swap' && matchesAssetFilter(tx, activityAssetFilter))
+  const hasAssetSwaps = txs.some(
+    (tx) =>
+      !shouldHideDevAssetTx(tx, assetMetadataCache) &&
+      tx.type === 'swap' &&
+      matchesAssetFilter(tx, activityAssetFilter),
+  )
   const activeActivityFilter = hasAssetSwaps ? activityFilter : 'all'
+
+  useEffect(() => {
+    if (!hasAssetSwaps && activityFilter !== 'all') setActivityFilter('all')
+  }, [activityFilter, hasAssetSwaps])
   const priceText =
     currentUnitPrice === undefined
       ? 'Price unavailable'

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -67,7 +67,7 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
   const { fromFiatAmount, toFiatAmount } = useContext(FiatContext)
   const { setRecvInfo, setSendInfo, setSwapFromAssetId } = useContext(FlowContext)
   const { navigate } = useContext(NavigationContext)
-  const { swapAvailable, swaps } = useContext(AssetSwapsContext)
+  const { swapAvailable } = useContext(AssetSwapsContext)
   const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
 
@@ -189,9 +189,7 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
 
   const handleSwap = () => {
     hapticLight()
-    // existing swaps stay reachable during outages so pending funds
-    // remain cancellable from the swap screen
-    if (swapAvailable || swaps.length > 0) {
+    if (swapAvailable) {
       setSwapFromAssetId(row.assetId)
       navigate(Pages.WalletSwap)
     } else {

--- a/src/screens/Wallet/HomeQuickActions.tsx
+++ b/src/screens/Wallet/HomeQuickActions.tsx
@@ -20,7 +20,7 @@ interface HomeAction {
 export default function HomeQuickActions() {
   const { navigate } = useContext(NavigationContext)
   const { setRecvInfo, setSendInfo } = useContext(FlowContext)
-  const { swapAvailable, swaps } = useContext(AssetSwapsContext)
+  const { swapAvailable } = useContext(AssetSwapsContext)
   const [swapSheetOpen, setSwapSheetOpen] = useState(false)
 
   const actions: HomeAction[] = [
@@ -46,9 +46,7 @@ export default function HomeQuickActions() {
       icon: <SwapIcon />,
       label: 'Swap',
       onClick: () => {
-        // existing swaps stay reachable during outages so pending funds
-        // remain cancellable from the swap screen
-        if (swapAvailable || swaps.length > 0) navigate(Pages.WalletSwap)
+        if (swapAvailable) navigate(Pages.WalletSwap)
         else setSwapSheetOpen(true)
       },
       testId: 'home-action-swap',

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -18,17 +18,11 @@ import SwapIcon from '../../../icons/Swap'
 import { EASE_IN_OUT_QUINT_TUPLE, EASE_OUT_QUINT_TUPLE } from '../../../lib/animations'
 import { centsToUnits } from '../../../lib/assets'
 import { extractError } from '../../../lib/error'
-import {
-  formatFiatAmountParts,
-  normalizeBitcoinUnit,
-  prettyCurrencyAssetAmount,
-  prettyFiatAmount,
-  prettyNumber,
-} from '../../../lib/format'
+import { formatFiatAmountParts, normalizeBitcoinUnit, prettyFiatAmount, prettyNumber } from '../../../lib/format'
 import { hapticLight, hapticSubtle, hapticTap } from '../../../lib/haptics'
 import { swapRouteTicker } from '../../../lib/swapDisplay'
 import { BTC_ASSET_ID, findMarket, makeCachedFeedFetch, QUOTE_OPTIONS, validatePlan } from '../../../lib/swap/markets'
-import { type AssetSwap, type AssetSwapQuoteSnapshot, type AssetSwapStatus } from '../../../lib/swap/store'
+import { type AssetSwapQuoteSnapshot } from '../../../lib/swap/store'
 import { Currencies, Unit } from '../../../lib/types'
 import { AspContext } from '../../../providers/asp'
 import { AssetSwapsContext } from '../../../providers/assetSwaps'
@@ -81,13 +75,6 @@ interface ExitingAmountCharacter {
 const keypadKeys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '0', 'Back']
 const rateNote = 'Rates are dynamic and may update before you confirm.'
 const rateNoteAutoDismissMs = 2400
-const statusLabels: Record<AssetSwapStatus, string> = {
-  pending: 'Pending',
-  cancelling: 'Cancelling',
-  fulfilled: 'Completed',
-  cancelled: 'Cancelled',
-  recoverable: 'Recoverable',
-}
 const emptySwapAsset: SwapAsset = {
   assetId: 'swap-empty',
   name: 'Asset',
@@ -99,7 +86,7 @@ const emptySwapAsset: SwapAsset = {
 
 export default function WalletSwap() {
   const { aspInfo } = useContext(AspContext)
-  const { cancelSwap, createSwap, markets, swapAvailable, swaps } = useContext(AssetSwapsContext)
+  const { createSwap, markets, swapAvailable } = useContext(AssetSwapsContext)
   const { config } = useContext(ConfigContext)
   const { fiatDecimals, fromFiatAmount, toFiat, toFiatAmount } = useContext(FiatContext)
   const { swapFromAssetId, setSwapFromAssetId } = useContext(FlowContext)
@@ -107,8 +94,6 @@ export default function WalletSwap() {
   const { assetBalances, assetMetadataCache, availableBalance } = useContext(WalletContext)
   const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
-
-  const [cancelling, setCancelling] = useState('')
 
   const btcUnit = normalizeBitcoinUnit(config.unit)
   const swapAssets = useMemo<SwapAsset[]>(() => {
@@ -390,19 +375,6 @@ export default function WalletSwap() {
     }
   }
 
-  const handleCancelSwap = async (swap: AssetSwap) => {
-    if (cancelling) return
-    hapticLight()
-    setCancelling(swap.id)
-    try {
-      await cancelSwap(swap.id)
-    } catch (error) {
-      setConfirmError(extractError(error))
-    } finally {
-      setCancelling('')
-    }
-  }
-
   const receiveAssets = swapAssets.filter((asset) =>
     Boolean(findMarket(markets, fromAsset.assetId, asset.assetId)?.market),
   )
@@ -435,15 +407,6 @@ export default function WalletSwap() {
                   ) : (
                     <SwapUnavailableState />
                   )}
-                  {swaps.length ? (
-                    <PendingSwaps
-                      swaps={swaps}
-                      assets={swapAssets}
-                      cancelling={cancelling}
-                      error={confirmError}
-                      onCancel={handleCancelSwap}
-                    />
-                  ) : null}
                 </motion.section>
               ) : (
                 <motion.section
@@ -522,66 +485,6 @@ function SwapUnavailableState() {
         <p>Swaps are unavailable</p>
         <span>Add another supported asset to swap between balances.</span>
       </div>
-    </div>
-  )
-}
-
-function PendingSwaps({
-  swaps,
-  assets,
-  cancelling,
-  error,
-  onCancel,
-}: {
-  swaps: AssetSwap[]
-  assets: SwapAsset[]
-  cancelling: string
-  error: string
-  onCancel: (swap: AssetSwap) => void
-}) {
-  const assetById = (assetId: string) => assets.find((asset) => asset.assetId === assetId)
-  const formatAmount = (assetId: string, atomic: string) => {
-    const asset = assetById(assetId)
-    return asset ? `${prettyCurrencyAssetAmount(BigInt(atomic), asset.decimals, asset.ticker)} ${asset.ticker}` : atomic
-  }
-
-  return (
-    <div className='swap-asset-list-panel'>
-      <div className='swap-step-heading'>
-        <p>Your swaps</p>
-      </div>
-      <div className='swap-token-list'>
-        {swaps.map((swap) => {
-          const from = assetById(swap.fromAsset)
-          const to = assetById(swap.toAsset)
-          const cancellable = swap.status === 'pending' || swap.status === 'cancelling'
-          return (
-            <div key={swap.id} className='swap-token-row'>
-              <span className='swap-token-row__copy'>
-                <span>
-                  {swapRouteTicker(swap.fromAsset, swap.quote?.fromTicker ?? from?.ticker) ?? '?'} to{' '}
-                  {swapRouteTicker(swap.toAsset, swap.quote?.toTicker ?? to?.ticker) ?? '?'}
-                </span>
-                <small>
-                  {formatAmount(swap.fromAsset, swap.fromAmount)} for ≥ {formatAmount(swap.toAsset, swap.toAmount)}
-                </small>
-              </span>
-              {cancellable ? (
-                <button
-                  type='button'
-                  className='swap-cancel-button'
-                  disabled={Boolean(cancelling)}
-                  onClick={() => onCancel(swap)}
-                >
-                  {cancelling === swap.id ? 'Cancelling…' : swap.status === 'cancelling' ? 'Retry cancel' : 'Cancel'}
-                </button>
-              ) : null}
-              <strong>{statusLabels[swap.status]}</strong>
-            </div>
-          )
-        })}
-      </div>
-      {error ? <p className='swap-confirm-error'>{error}</p> : null}
     </div>
   )
 }

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -25,20 +25,64 @@ import Reminder from '../../components/Reminder'
 import { LimitsContext } from '../../providers/limits'
 import { getInputsToSettle } from '../../lib/asp'
 import SwapTransactionSummary from '../../components/SwapTransactionSummary'
-import { formatSwapAssetAmount, swapFeeAmount, swapPriceRateLabel, swapStatusLabel } from '../../lib/swapDisplay'
+import {
+  formatSwapAssetAmount,
+  swapFeeAmount,
+  swapPriceRateLabel,
+  swapStatusLabel,
+  type SwapStatus,
+} from '../../lib/swapDisplay'
 import { FiatContext } from '../../providers/fiat'
 import { designatedAccountCurrency, fiatAccountAssetSatoshis } from '../../lib/accountAssets'
 import UnverifiedBadge from '../../components/UnverifiedBadge'
+import { AssetSwapsContext } from '../../providers/assetSwaps'
+import { hapticTap } from '../../lib/haptics'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../../components/ui/alert-dialog'
 
 export default function Transaction() {
   const { utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { txInfo } = useContext(FlowContext)
+  const { cancelSwap, swaps } = useContext(AssetSwapsContext)
   const { fromFiatAmount } = useContext(FiatContext)
   const { aspInfo, calcBestMarketHour } = useContext(AspContext)
   const { assetMetadataCache, isVerifiedAsset, settlePreconfirmed, vtxos, vtxoManager, wallet, svcWallet } =
     useContext(WalletContext)
 
-  const tx = txInfo
+  const liveSwap = txInfo?.assetSwap?.fundingTxid
+    ? swaps.find((swap) => swap.fundingTxid === txInfo.assetSwap?.fundingTxid)
+    : undefined
+  const liveSwapStatus: SwapStatus | undefined = liveSwap
+    ? liveSwap.status === 'fulfilled'
+      ? 'completed'
+      : liveSwap.status === 'cancelled'
+        ? 'cancelled'
+        : liveSwap.status === 'recoverable'
+          ? 'recoverable'
+          : 'pending'
+    : undefined
+  const tx =
+    txInfo && txInfo.assetSwap && liveSwap && liveSwapStatus
+      ? {
+          ...txInfo,
+          preconfirmed: liveSwapStatus === 'pending',
+          settled: liveSwapStatus === 'completed' || liveSwapStatus === 'cancelled',
+          redeemTxid: liveSwap.spentTxid ?? txInfo.redeemTxid,
+          assetSwap: {
+            ...txInfo.assetSwap,
+            status: liveSwapStatus,
+            fillTxid: liveSwap.spentTxid,
+          },
+        }
+      : txInfo
   const swapTx = tx?.type === 'swap'
   const issuanceTx = tx ? isIssuance(tx) : false
   const burnTx = tx ? isBurn(tx) : false
@@ -58,6 +102,9 @@ export default function Transaction() {
   const [settleSuccess, setSettleSuccess] = useState(false)
   const [settling, setSettling] = useState(false)
   const [startTime, setStartTime] = useState(0)
+  const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false)
+  const [cancelFailed, setCancelFailed] = useState(false)
+  const [cancellingSwap, setCancellingSwap] = useState(false)
 
   useEffect(() => {
     setButtonLabel(settling ? 'Settling...' : defaultButtonLabel)
@@ -95,6 +142,23 @@ export default function Transaction() {
       setError(extractError(err))
     }
     setSettling(false)
+  }
+
+  const handleCancelSwap = async () => {
+    if (!liveSwap || cancellingSwap) return
+    hapticTap()
+    setCancelConfirmOpen(false)
+    setCancelFailed(false)
+    setError('')
+    setCancellingSwap(true)
+    try {
+      await cancelSwap(liveSwap.id)
+    } catch (err) {
+      setError(extractError(err))
+      setCancelFailed(true)
+    } finally {
+      setCancellingSwap(false)
+    }
   }
 
   if (!tx) return <></>
@@ -169,12 +233,14 @@ export default function Transaction() {
   const swapToIcon = tx.assetSwap?.toAssetId
     ? assetMetadataCache.get(tx.assetSwap.toAssetId)?.metadata?.icon
     : undefined
+  const showCancelSwap = swapTx && liveSwap && (liveSwap.status === 'pending' || liveSwap.status === 'cancelling')
+  const visibleError = cancelFailed && !showCancelSwap ? '' : error
 
   const Body = () => (
     <Content>
       <Padded>
         <FlexCol>
-          <ErrorMessage error={Boolean(error)} text={error} />
+          <ErrorMessage error={Boolean(visibleError)} text={visibleError} />
           {expiredBoardingTx ? (
             <Info color='red' icon={<VtxosIcon />} title='Expired'>
               <Text wrap>Boarding transaction expired.</Text>
@@ -253,7 +319,40 @@ export default function Transaction() {
     !settling
 
   const Buttons = () =>
-    showSettleButtons ? (
+    showCancelSwap ? (
+      <>
+        <ButtonsOnBottom>
+          <Button
+            variant='destructive'
+            label={
+              cancellingSwap
+                ? 'Cancelling…'
+                : cancelFailed || liveSwap.status === 'cancelling'
+                  ? 'Retry cancel'
+                  : 'Cancel swap'
+            }
+            disabled={cancellingSwap}
+            onClick={() => setCancelConfirmOpen(true)}
+          />
+        </ButtonsOnBottom>
+        <AlertDialog open={cancelConfirmOpen} onOpenChange={setCancelConfirmOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Cancel swap?</AlertDialogTitle>
+              <AlertDialogDescription>
+                If the swap is still pending, this will return its locked funds to your wallet.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className='min-h-11'>Keep swap</AlertDialogCancel>
+              <AlertDialogAction className='min-h-11' variant='destructive' onClick={handleCancelSwap}>
+                Cancel swap
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </>
+    ) : showSettleButtons ? (
       <>
         <ButtonsOnBottom>
           <Button onClick={handleSettle} label={buttonLabel} disabled={settling} />

--- a/src/test/components/transactions-list.test.tsx
+++ b/src/test/components/transactions-list.test.tsx
@@ -20,6 +20,28 @@ import {
 } from '../screens/mocks'
 
 describe('TransactionsList', () => {
+  it('filters the list by transaction type', () => {
+    const swapTx = { ...mockWalletContextValue.txs[0], roundTxid: 'swap-tx', type: 'swap' }
+    const sentTx = { ...mockWalletContextValue.txs[0], roundTxid: 'sent-tx', type: 'sent' }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <ConfigContext.Provider value={mockConfigContextValue}>
+          <FiatContext.Provider value={mockFiatContextValue}>
+            <FlowContext.Provider value={mockFlowContextValue}>
+              <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [swapTx, sentTx] } as any}>
+                <TransactionsList mode='static' typeFilter='swap' />
+              </WalletContext.Provider>
+            </FlowContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByText(/Swap/)).toBeInTheDocument()
+    expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+  })
+
   it('formats designated account activity with the underlying asset decimals', () => {
     const tx: Tx = {
       amount: 330,

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -5,10 +5,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AspContext } from '../../providers/asp'
 import { AssetSwapsContext, AssetSwapsProvider } from '../../providers/assetSwaps'
 import { WalletContext } from '../../providers/wallet'
-import { addAssetSwap, getAssetSwaps, type AssetSwap } from '../../lib/swap/store'
+import { addAssetSwap, getAssetSwaps, type AssetSwap, updateAssetSwap } from '../../lib/swap/store'
 import { mockAspContextValue, mockWalletContextValue } from '../screens/mocks'
 
 const cancelOffer = vi.hoisted(() => vi.fn())
+const getVtxos = vi.hoisted(() => vi.fn())
+
+vi.mock('@arkade-os/sdk', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@arkade-os/sdk')>()),
+  RestIndexerProvider: class {
+    getVtxos = getVtxos
+  },
+}))
 
 vi.mock('../../lib/swap/offer', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../lib/swap/offer')>()),
@@ -31,36 +39,57 @@ const pendingSwap: AssetSwap = {
 
 function CancelHarness() {
   const { cancelSwap } = useContext(AssetSwapsContext)
-  return <button onClick={() => cancelSwap(pendingSwap.id)}>Cancel</button>
+  return <button onClick={() => cancelSwap(pendingSwap.id).catch(() => {})}>Cancel</button>
+}
+
+function renderProvider(reloadWallet = vi.fn().mockResolvedValue(undefined)) {
+  render(
+    <AspContext.Provider
+      value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: '', url: '' } } as any}
+    >
+      <WalletContext.Provider value={{ ...mockWalletContextValue, reloadWallet, svcWallet: { identity: {} } } as any}>
+        <AssetSwapsProvider>
+          <CancelHarness />
+        </AssetSwapsProvider>
+      </WalletContext.Provider>
+    </AspContext.Provider>,
+  )
+  return reloadWallet
 }
 
 describe('AssetSwapsProvider cancellation', () => {
   beforeEach(() => {
     localStorage.clear()
     cancelOffer.mockReset().mockResolvedValue('cancel-txid')
+    getVtxos.mockReset()
     addAssetSwap(pendingSwap)
   })
 
   afterEach(() => localStorage.clear())
 
   it('persists the cancellation transaction ID with the terminal status', async () => {
-    const reloadWallet = vi.fn().mockResolvedValue(undefined)
-    render(
-      <AspContext.Provider
-        value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: '', url: '' } } as any}
-      >
-        <WalletContext.Provider value={{ ...mockWalletContextValue, reloadWallet, svcWallet: { identity: {} } } as any}>
-          <AssetSwapsProvider>
-            <CancelHarness />
-          </AssetSwapsProvider>
-        </WalletContext.Provider>
-      </AspContext.Provider>,
-    )
+    const reloadWallet = renderProvider()
 
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
     await waitFor(() => expect(getAssetSwaps()[0]).toMatchObject({ status: 'cancelled', spentTxid: 'cancel-txid' }))
     expect(cancelOffer).toHaveBeenCalledOnce()
     expect(reloadWallet).toHaveBeenCalledOnce()
+  })
+
+  it('does not restore a stale status after another path resolves the cancellation', async () => {
+    cancelOffer.mockRejectedValue(new Error('cancel failed'))
+    let resolveVtxos!: (value: { vtxos: { txid: string; virtualStatus: { state: string } }[] }) => void
+    getVtxos.mockReturnValue(new Promise((resolve) => (resolveVtxos = resolve)))
+
+    renderProvider()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(getAssetSwaps()[0].status).toBe('cancelling'))
+
+    updateAssetSwap(pendingSwap.id, { status: 'fulfilled' })
+    resolveVtxos({ vtxos: [{ txid: pendingSwap.fundingTxid, virtualStatus: { state: 'settled' } }] })
+
+    await waitFor(() => expect(getAssetSwaps()[0].status).toBe('fulfilled'))
   })
 })

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -1,0 +1,66 @@
+import { useContext } from 'react'
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AspContext } from '../../providers/asp'
+import { AssetSwapsContext, AssetSwapsProvider } from '../../providers/assetSwaps'
+import { WalletContext } from '../../providers/wallet'
+import { addAssetSwap, getAssetSwaps, type AssetSwap } from '../../lib/swap/store'
+import { mockAspContextValue, mockWalletContextValue } from '../screens/mocks'
+
+const cancelOffer = vi.hoisted(() => vi.fn())
+
+vi.mock('../../lib/swap/offer', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/swap/offer')>()),
+  cancelOffer,
+}))
+
+const pendingSwap: AssetSwap = {
+  id: 'funding-txid',
+  fromAsset: 'btc',
+  toAsset: 'asset-beta',
+  fromAmount: '10000',
+  toAmount: '500',
+  swapAddress: 'tark1q...',
+  swapPkScript: `5120${'ab'.repeat(32)}`,
+  offerHex: '0100',
+  fundingTxid: 'funding-txid',
+  status: 'pending',
+  createdAt: 1,
+}
+
+function CancelHarness() {
+  const { cancelSwap } = useContext(AssetSwapsContext)
+  return <button onClick={() => cancelSwap(pendingSwap.id)}>Cancel</button>
+}
+
+describe('AssetSwapsProvider cancellation', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    cancelOffer.mockReset().mockResolvedValue('cancel-txid')
+    addAssetSwap(pendingSwap)
+  })
+
+  afterEach(() => localStorage.clear())
+
+  it('persists the cancellation transaction ID with the terminal status', async () => {
+    const reloadWallet = vi.fn().mockResolvedValue(undefined)
+    render(
+      <AspContext.Provider
+        value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: '', url: '' } } as any}
+      >
+        <WalletContext.Provider value={{ ...mockWalletContextValue, reloadWallet, svcWallet: { identity: {} } } as any}>
+          <AssetSwapsProvider>
+            <CancelHarness />
+          </AssetSwapsProvider>
+        </WalletContext.Provider>
+      </AspContext.Provider>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(getAssetSwaps()[0]).toMatchObject({ status: 'cancelled', spentTxid: 'cancel-txid' }))
+    expect(cancelOffer).toHaveBeenCalledOnce()
+    expect(reloadWallet).toHaveBeenCalledOnce()
+  })
+})

--- a/src/test/screens/wallet/activity.test.tsx
+++ b/src/test/screens/wallet/activity.test.tsx
@@ -1,0 +1,42 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import Activity from '../../../screens/Wallet/Activity'
+import { WalletContext } from '../../../providers/wallet'
+import { mockWalletContextValue } from '../mocks'
+
+vi.mock('../../../components/TransactionsList', () => ({
+  default: ({ typeFilter }: { typeFilter?: string }) => <div data-testid='activity-results'>{typeFilter ?? 'all'}</div>,
+}))
+
+const ordinaryTx = { ...mockWalletContextValue.txs[0], type: 'received' }
+const swapTx = { ...ordinaryTx, roundTxid: 'swap-tx', type: 'swap' }
+
+describe('Activity screen', () => {
+  it('defaults to All and filters to every swap status through the shared swap type', async () => {
+    render(
+      <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [ordinaryTx, swapTx] } as any}>
+        <Activity />
+      </WalletContext.Provider>,
+    )
+
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('activity-results')).toHaveTextContent('all')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Swaps' }))
+
+    expect(screen.getByRole('button', { name: 'Swaps' })).toHaveAttribute('aria-pressed', 'true')
+    await waitFor(() => expect(screen.getByTestId('activity-results')).toHaveTextContent('swap'))
+  })
+
+  it('hides the filter when there is no swap activity', () => {
+    render(
+      <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [ordinaryTx] } as any}>
+        <Activity />
+      </WalletContext.Provider>,
+    )
+
+    expect(screen.queryByRole('group', { name: 'Filter activity' })).not.toBeInTheDocument()
+    expect(screen.getByTestId('activity-results')).toHaveTextContent('all')
+  })
+})

--- a/src/test/screens/wallet/activity.test.tsx
+++ b/src/test/screens/wallet/activity.test.tsx
@@ -7,6 +7,7 @@ import { mockWalletContextValue } from '../mocks'
 
 vi.mock('../../../components/TransactionsList', () => ({
   default: ({ typeFilter }: { typeFilter?: string }) => <div data-testid='activity-results'>{typeFilter ?? 'all'}</div>,
+  shouldHideDevAssetTx: (tx: { roundTxid?: string }) => tx.roundTxid === 'hidden-swap',
 }))
 
 const ordinaryTx = { ...mockWalletContextValue.txs[0], type: 'received' }
@@ -38,5 +39,26 @@ describe('Activity screen', () => {
 
     expect(screen.queryByRole('group', { name: 'Filter activity' })).not.toBeInTheDocument()
     expect(screen.getByTestId('activity-results')).toHaveTextContent('all')
+  })
+
+  it('resets to All when the remaining swap is hidden from the transaction list', async () => {
+    const { rerender } = render(
+      <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [ordinaryTx, swapTx] } as any}>
+        <Activity />
+      </WalletContext.Provider>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Swaps' }))
+
+    rerender(
+      <WalletContext.Provider
+        value={{ ...mockWalletContextValue, txs: [ordinaryTx, { ...swapTx, roundTxid: 'hidden-swap' }] } as any}
+      >
+        <Activity />
+      </WalletContext.Provider>,
+    )
+
+    expect(screen.queryByRole('group', { name: 'Filter activity' })).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByTestId('activity-results')).toHaveTextContent('all'))
   })
 })

--- a/src/test/screens/wallet/bitcoin-detail.test.tsx
+++ b/src/test/screens/wallet/bitcoin-detail.test.tsx
@@ -20,6 +20,46 @@ vi.mock('liveline', () => ({
 }))
 
 describe('Bitcoin detail screen', () => {
+  it('filters the asset activity list to swaps involving bitcoin', async () => {
+    vi.stubGlobal('ResizeObserver', undefined)
+    const ordinaryTx = { ...mockWalletContextValue.txs[0], roundTxid: 'ordinary-tx', type: 'received' }
+    const swapTx = {
+      ...ordinaryTx,
+      roundTxid: 'swap-tx',
+      type: 'swap',
+      assetSwap: {
+        fromAssetId: 'btc',
+        fromTicker: 'BTC',
+        toAssetId: 'asset-id',
+        toTicker: 'USDT',
+        status: 'completed',
+      },
+    }
+
+    const { container } = render(
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <FlowContext.Provider value={mockFlowContextValue}>
+            <NavigationContext.Provider value={mockNavigationContextValue}>
+              <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [ordinaryTx, swapTx] } as any}>
+                <BitcoinDetail />
+              </WalletContext.Provider>
+            </NavigationContext.Provider>
+          </FlowContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>,
+    )
+
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true')
+    expect(container.querySelectorAll('.activity-row')).toHaveLength(2)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Swaps' }))
+
+    expect(screen.getByRole('button', { name: 'Swaps' })).toHaveAttribute('aria-pressed', 'true')
+    await waitFor(() => expect(container.querySelectorAll('.activity-row')).toHaveLength(1))
+    expect(container.querySelector('.activity-row__kind')).toHaveTextContent('Swap')
+  })
+
   it('pauses the liveline chart while the pointer is hovering it', async () => {
     const ResizeObserverMock = vi.fn(() => ({
       observe: vi.fn(),

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -41,6 +41,23 @@ describe('Wallet screen', () => {
     expect(screen.queryByText('Borrow against your bitcoin')).not.toBeInTheDocument()
   })
 
+  it('does not use swap history to enter an unavailable swap composer', async () => {
+    const navigate = vi.fn()
+
+    render(
+      <NavigationContext.Provider value={{ ...mockNavigationContextValue, navigate }}>
+        <AssetSwapsContext.Provider value={{ swapAvailable: false, swaps: [{ id: 'pending-swap' }] } as any}>
+          <Wallet />
+        </AssetSwapsContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    await userEvent.click(screen.getByTestId('home-action-swap'))
+
+    expect(navigate).not.toHaveBeenCalledWith(Pages.WalletSwap)
+    expect(screen.getByText(/Swaps are coming soon/i)).toBeInTheDocument()
+  })
+
   it('opens the bitcoin detail page from the bitcoin asset row', async () => {
     const user = userEvent.setup()
     const navigate = vi.fn()

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -506,13 +506,10 @@ describe('Wallet swap flow', () => {
     errorSpy.mockRestore()
   })
 
-  it('keeps PR 784 pending-swap cancellation available', async () => {
-    renderSwap({
-      config: { unit: Unit.BIP177 },
-      swap: { swaps: [{ ...pendingSwap, quote: { ...pendingSwap.quote!, fromTicker: 'sats' } }] },
-    })
-    expect(screen.getByText('BTC to USD')).toBeInTheDocument()
-    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
-    await waitFor(() => expect(cancelSwap).toHaveBeenCalledWith('funding-txid'))
+  it('keeps swap history out of the swap composer', () => {
+    renderSwap({ swap: { swaps: [pendingSwap] } })
+    expect(screen.queryByText('Your swaps')).not.toBeInTheDocument()
+    expect(screen.queryByText('BTC to USD')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
   })
 })

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import userEvent from '@testing-library/user-event'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import Transaction from '../../../screens/Wallet/Transaction'
 import { FlowContext } from '../../../providers/flow'
 import { LimitsContext } from '../../../providers/limits'
@@ -23,8 +25,135 @@ import { FiatContext } from '../../../providers/fiat'
 import { Currencies } from '../../../lib/types'
 import { AssetsContext } from '../../../providers/assets'
 import { MUTINYNET_USDT_ASSET_ID } from '../../../lib/accountAssets'
+import { AssetSwapsContext } from '../../../providers/assetSwaps'
+import type { AssetSwap } from '../../../lib/swap/store'
+
+const pendingSwapTx = {
+  ...mockTxInfo,
+  amount: 0,
+  boardingTxid: '',
+  assetSwap: {
+    fromAmount: BigInt(10_000),
+    fromAssetId: 'btc',
+    fromDecimals: 0,
+    fromTicker: 'sats',
+    toAmount: BigInt(500),
+    toAssetId: 'asset-beta',
+    toDecimals: 2,
+    toTicker: 'BET',
+    status: 'pending' as const,
+    fundingTxid: 'funding-txid',
+  },
+  preconfirmed: true,
+  redeemTxid: 'funding-txid',
+  roundTxid: '',
+  settled: false,
+  type: 'swap',
+}
+
+const pendingSwap: AssetSwap = {
+  id: 'funding-txid',
+  fromAsset: 'btc',
+  toAsset: 'asset-beta',
+  fromAmount: '10000',
+  toAmount: '500',
+  swapAddress: 'tark1q...',
+  swapPkScript: `5120${'ab'.repeat(32)}`,
+  offerHex: '0100',
+  fundingTxid: 'funding-txid',
+  status: 'pending',
+  createdAt: 1,
+}
+
+function CancellationHarness({
+  cancel,
+  reconciled = false,
+}: {
+  cancel: (id: string) => Promise<void>
+  reconciled?: boolean
+}) {
+  const [swaps, setSwaps] = useState([pendingSwap])
+  const cancelledSwap = { ...pendingSwap, status: 'cancelled' as const, spentTxid: 'cancel-txid' }
+  const cancelSwap = async (id: string) => {
+    await cancel(id)
+    setSwaps([cancelledSwap])
+  }
+
+  return (
+    <NavigationContext.Provider value={mockNavigationContextValue}>
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <AspContext.Provider value={mockAspContextValue}>
+            <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo: pendingSwapTx }}>
+              <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [pendingSwapTx] } as any}>
+                <AssetSwapsContext.Provider value={{ swaps: reconciled ? [cancelledSwap] : swaps, cancelSwap } as any}>
+                  <LimitsContext.Provider value={mockLimitsContextValue}>
+                    <Transaction />
+                  </LimitsContext.Provider>
+                </AssetSwapsContext.Provider>
+              </WalletContext.Provider>
+            </FlowContext.Provider>
+          </AspContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>
+    </NavigationContext.Provider>
+  )
+}
 
 describe('Transaction screen', () => {
+  it('confirms a pending swap cancellation and stays on the updated receipt', async () => {
+    let finishCancel: () => void = () => {}
+    const cancel = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCancel = resolve
+        }),
+    )
+    render(<CancellationHarness cancel={cancel} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel swap' }))
+    const dialog = screen.getByRole('alertdialog')
+    expect(within(dialog).getByRole('heading', { name: 'Cancel swap?' })).toBeInTheDocument()
+    expect(within(dialog).getByText(/return its locked funds to your wallet/)).toBeInTheDocument()
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel swap' }))
+    expect(cancel).toHaveBeenCalledWith('funding-txid')
+    expect(screen.getByRole('button', { name: 'Cancelling…' })).toBeDisabled()
+
+    await act(async () => finishCancel())
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: /cancel swap/i })).not.toBeInTheDocument())
+    expect(screen.getByRole('heading', { name: 'Swap' })).toBeInTheDocument()
+    expect(screen.getByTestId('Status')).toHaveTextContent('Cancelled')
+    expect(screen.getByTestId('Cancelled')).toHaveTextContent('cancel-txid')
+  })
+
+  it('surfaces a failed cancellation and offers a retry', async () => {
+    const cancel = vi.fn().mockRejectedValue(new Error('Cancellation unavailable'))
+    render(<CancellationHarness cancel={cancel} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel swap' }))
+    await userEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Cancel swap' }))
+
+    expect(await screen.findByText('Cancellation unavailable')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry cancel' })).toBeInTheDocument()
+  })
+
+  it('clears a cancellation error when reconciliation reaches a terminal state', async () => {
+    const cancel = vi.fn().mockRejectedValue(new Error('Cancellation status unknown'))
+    const view = render(<CancellationHarness cancel={cancel} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel swap' }))
+    await userEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Cancel swap' }))
+    expect(await screen.findByText('Cancellation status unknown')).toBeInTheDocument()
+
+    view.rerender(<CancellationHarness cancel={cancel} reconciled />)
+
+    expect(screen.queryByText('Cancellation status unknown')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /cancel swap/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId('Status')).toHaveTextContent('Cancelled')
+  })
+
   it('renders the settled transaction screen correctly', async () => {
     render(
       <NavigationContext.Provider value={mockNavigationContextValue}>


### PR DESCRIPTION
## Summary

- Remove historical and pending swaps from the swap composer so it stays focused on creating a new swap.
- Keep every swap status in Recent activity and the full Activity screen.
- Add an explicit All/Swaps Activity filter that appears only when visible swap activity exists.
- Reuse the same filter on individual asset pages, scoped to swaps involving the selected asset.
- Move pending-swap cancellation to the transaction receipt with confirmation, cancelling/retry states, and an in-place cancelled receipt.
- Persist the cancellation transaction ID and classify cancellation-versus-solver spend races before updating the stored terminal status.

This is a focused follow-up to #784 for #796 and #806. Those issues are intentionally referenced without closing keywords because they should close only after this work is merged into the parent branch. This asset-page follow-up closes #830 when the PR merges.

## User-visible behavior

- The Swap screen no longer contains a “Your swaps” history section or inline cancellation controls.
- Recent activity continues to show swap rows on the wallet home screen.
- Activity defaults to All and can switch to Swaps; the filter resets when the screen is left.
- Individual asset pages show the same All/Swaps chips when that asset has swap history, and Swaps keeps only transactions involving that asset.
- The filter is hidden when there are no visible swap transactions.
- Swaps includes pending, completed, cancelled, and failed swap activity.
- Opening a pending swap shows a bottom “Cancel swap” action.
- Cancellation requires confirmation, displays progress and retry states, and leaves the user on the updated receipt after success.
- The cancelled receipt includes the cancellation transaction ID.
- Broader recoverable-swap behavior remains unchanged.

## Visual proof

<table>
  <tr>
    <td><strong>Pending receipt with cancellation</strong><br><img width="280" alt="Pending swap receipt with Cancel swap action" src="https://github.com/user-attachments/assets/0ebc81b8-fa02-4068-a05d-ce9822d47fd6" /></td>
    <td><strong>Clean swap composer</strong><br><img width="280" alt="Swap composer without historical swap activity" src="https://github.com/user-attachments/assets/1c98c41e-f692-40b6-8a97-650daa2f9aa4" /></td>
  </tr>
  <tr>
    <td><strong>Swaps activity filter</strong><br><img width="280" alt="Activity page filtered to swap transactions" src="https://github.com/user-attachments/assets/497ccb16-071b-4a30-b105-4a9e4612d8d8" /></td>
    <td><strong>Cancelled receipt</strong><br><img width="280" alt="Cancelled swap transaction receipt" src="https://github.com/user-attachments/assets/7c5d1876-fcc1-41e2-bfbd-edf1b0e22e24" /></td>
  </tr>
  <tr>
    <td colspan="2"><strong>bitcoin asset swaps filter</strong><br><img width="560" alt="bitcoin asset page filtered to swap transactions" src="https://github.com/user-attachments/assets/d9295600-d8ec-42bc-99a6-82755f9526f0" /></td>
  </tr>
</table>

Mutinynet preview: https://wt-swap-activity-controls-20.arkade-wallet.pages.dev

## Verification

- `bun run test` — 61 files passed, 441 tests passed, 3 skipped.
- `bun run lint`
- `bun run format:check`
- `bunx tsc --noEmit`
- Production service-worker and Vite builds.
- `git diff --check`
- Focused Mutinynet UI verification covering pending activity, receipt cancellation, full Activity filtering, asset-page filtering, composer cleanup, and the cancelled receipt.
- Public Mutinynet and bitcoin Cloudflare deployments passed.
- Public Mutinynet deployment loaded and rendered the wallet in the Codex in-app browser.
- The original PR scope received Codex review approval. The asset-page follow-up passed manual cruft, simplify, and Ponytail full reviews; an external re-review was blocked by the current environment.
- Resolved both valid CodeRabbit review threads in `56e8daea`: hidden swap visibility/filter reset and stale cancellation status protection.
- Haptics were not hardware-verified on physical iOS and Android devices.

## Complete file scope

- `src/components/ActivityFilter.tsx` — share the existing accessible, animated, haptic All/Swaps chip control across activity surfaces.
- `src/components/TransactionsList.tsx` — add optional transaction-type filtering after the existing visibility filters and expose the existing asset and visibility matchers for consistent swap detection.
- `src/index.css` — add token-based Activity filter styling and remove obsolete composer cancellation styles.
- `src/lib/swap/restore.ts` — expose cancellation-spend classification for live reconciliation.
- `src/lib/swap/store.ts` — update the outdated consumer comment.
- `src/providers/assetSwaps.tsx` — persist cancellation transaction IDs, reconcile terminal cancellation states, and prevent stale recovery results from overwriting newer terminal states.
- `src/screens/Wallet/Activity.tsx` — use the shared conditional All/Swaps filter while preserving selection feedback, animation, and reduced-motion handling; gate it with the list visibility rule and reset stale selection when visible swaps disappear.
- `src/screens/Wallet/BitcoinDetail.tsx` — make composer entry depend on live swap availability and add asset-scoped All/Swaps filtering to Recent activity with the same visibility gating and stale-selection reset.
- `src/screens/Wallet/HomeQuickActions.tsx` — apply the same composer availability behavior.
- `src/screens/Wallet/Swap/Index.tsx` — remove swap history and inline cancellation from the composer.
- `src/screens/Wallet/Transaction.tsx` — add receipt cancellation confirmation, progress, retry, error, success, and live reconciliation states.
- `src/test/components/transactions-list.test.tsx` — cover transaction-type filtering.
- `src/test/providers/assetSwaps.test.tsx` — cover cancellation persistence, reload behavior, and protection against stale cancellation recovery writes.
- `src/test/screens/wallet/activity.test.tsx` — cover the default filter, swap-only results, conditional visibility, and reset behavior when the last visible swap disappears.
- `src/test/screens/wallet/bitcoin-detail.test.tsx` — verify All shows mixed bitcoin activity and Swaps keeps only bitcoin-involving swaps.
- `src/test/screens/wallet/index.test.tsx` — verify historical swaps do not enter an unavailable composer.
- `src/test/screens/wallet/swap.test.tsx` — verify the composer excludes history and cancellation controls.
- `src/test/screens/wallet/transaction.test.tsx` — cover confirmation, progress, success, retry, and stale-error reconciliation.

No dependencies or unrelated product behavior are changed. Local environment data, test-wallet credentials, screenshots, and review transcripts are not committed to the product branch.

## Base

This PR intentionally targets `claude/swap-ui-mutinynet-yktp51`, the current head branch of #784, rather than `master`.
