### PR TITLE
fix(swaps): preserve BRL branding at zero balance

### DIFF
--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -39,6 +39,7 @@ import { NavigationContext, Pages } from '../../../providers/navigation'
 import { WalletContext } from '../../../providers/wallet'
 import { usePortfolioFiat, type PortfolioRow } from '../../../hooks/usePortfolioFiat'
 import { useReducedMotion } from '../../../hooks/useReducedMotion'
+import { verifiedDesignatedCurrency } from '../../../lib/accountAssets'
 
 type AssetTarget = 'from' | 'to'
 type DrawerState = 'to' | 'review' | null
@@ -104,7 +105,7 @@ export default function WalletSwap() {
   const { fiatDecimals, fromFiatAmount, toFiat, toFiatAmount } = useContext(FiatContext)
   const { swapFromAssetId, setSwapFromAssetId } = useContext(FlowContext)
   const { goBack, navigate } = useContext(NavigationContext)
-  const { assetBalances, assetMetadataCache, availableBalance } = useContext(WalletContext)
+  const { assetBalances, assetMetadataCache, availableBalance, isVerifiedAsset } = useContext(WalletContext)
   const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
 
@@ -143,10 +144,11 @@ export default function WalletSwap() {
 
       const row = rows.find((candidate) => candidate.assetId === asset.id)
       const owned = assetBalances.find((balance) => balance.assetId === asset.id)
+      const designatedCurrency = verifiedDesignatedCurrency(aspInfo.network, asset.id, isVerifiedAsset)
       return {
         assetId: asset.id,
-        name: row?.name ?? asset.name,
-        ticker: row?.ticker ?? asset.ticker,
+        name: row?.name ?? designatedCurrency ?? asset.name,
+        ticker: row?.ticker ?? designatedCurrency ?? asset.ticker,
         decimals: asset.decimals,
         balance: BigInt(owned?.amount ?? 0),
         fiatText: row?.hasFiatPrice
@@ -159,11 +161,13 @@ export default function WalletSwap() {
   }, [
     assetBalances,
     assetMetadataCache,
+    aspInfo.network,
     availableBalance,
     btcUnit,
     config.currency,
     config.unit,
     fromFiatAmount,
+    isVerifiedAsset,
     markets,
     rows,
     toFiat,

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -56,10 +56,12 @@ function renderSwap({
   flow = {},
   swap = {},
   config = {},
+  wallet = {},
 }: {
   flow?: Record<string, unknown>
   swap?: Record<string, unknown>
   config?: Record<string, unknown>
+  wallet?: Record<string, unknown>
 } = {}) {
   const navigate = vi.fn()
   const goBack = vi.fn()
@@ -100,6 +102,7 @@ function renderSwap({
                       ],
                       assetMetadataCache,
                       availableBalance: 100_000,
+                      ...wallet,
                     } as any
                   }
                 >
@@ -149,6 +152,19 @@ describe('Wallet swap flow', () => {
     expect(screen.getByText('BRL')).toBeInTheDocument()
     expect(screen.queryByText('USDT')).not.toBeInTheDocument()
     expect(screen.queryByText('DEPIX')).not.toBeInTheDocument()
+  })
+
+  it('keeps the BRL identity and flag after spending the full DePix balance', () => {
+    renderSwap({
+      flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() },
+      wallet: { assetBalances: [{ assetId: USDT_ID, amount: BigInt(15_000) }] },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
+
+    expect(screen.getByText('BRL')).toBeInTheDocument()
+    expect(screen.queryByText(/DePix|DEPIX/)).not.toBeInTheDocument()
+    expect(document.querySelector('#br-flag-circle')).not.toBeNull()
   })
 
   it('finds Bitcoin when searching "btc", even though its swap-entry ticker is sats', async () => {


### PR DESCRIPTION

## Summary

- Preserve the verified BRL identity for Mutinynet DePix in the swap asset list even when its wallet balance is zero and no portfolio row exists.
- Keep the Brazilian flag and BRL ticker consistent in the BTC → BRL picker and in swap display snapshots created from that selection.
- Add a regression test for the exact post-“send max” condition reported in #821.

Addresses #821.

## User-visible behavior

After spending the full BRL balance, BTC → BRL still appears as BRL with the Brazilian flag. The picker no longer falls back to Decentralized Pix / DePix branding, and subsequent swap history uses the BRL ticker consistently.

## Affected files

- `src/screens/Wallet/Swap/Index.tsx` — falls back to the existing verification-gated asset designation when a zero balance removes the portfolio row.
- `src/test/screens/wallet/swap.test.tsx` — allows wallet-state overrides and verifies zero-balance BRL naming plus Brazilian flag rendering.

No files were added, moved, or deleted. No unrelated files or behavior changed.

## Verification

- `bun run test:unit` — 59 files passed; 431 tests passed, 3 skipped.
- `bunx tsc --noEmit` — passed.
- `bun run lint` — passed.
- `bun run format:check` — passed.
- Mobile visual verification at 375 × 667 in the running Mutinynet app with a newly generated empty test wallet — confirmed `0.00000000 BRL`, the Brazilian flag, and no DePix label in the BTC → receive picker.
- Independent GPT-5.6 code review — approved with no substantive issues.

## Visual proof

Empty Mutinynet wallet, BTC → receive picker at 375 × 667:

<img width="375" height="667" alt="issue-821-brl-zero-balance" src="https://github.com/user-attachments/assets/0c500d2b-918c-4db3-9038-bf746fd1c145" />
