### PR TITLE
fix(swaps): soften cancelled activity values

### DIFF
--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -259,9 +259,11 @@ function SwapAmountInfo({
   const statusClassName =
     status === 'pending'
       ? ' activity-row__amount--pending'
-      : status === 'failed' || status === 'cancelled'
+      : status === 'failed'
         ? ' activity-row__amount--failed'
-        : ''
+        : status === 'cancelled'
+          ? ' activity-row__amount--cancelled'
+          : ''
 
   return (
     <span className={`activity-row__amount${statusClassName}`}>

--- a/src/index.css
+++ b/src/index.css
@@ -1086,6 +1086,14 @@ iframe {
   color: color-mix(in srgb, var(--red-700) 76%, var(--fg));
 }
 
+.activity-row__amount--cancelled {
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+}
+
+.activity-row__amount--cancelled .privacy-amount__value {
+  text-decoration: line-through;
+}
+
 .palette-dark .home-section-action {
   color: color-mix(in srgb, var(--purple-200) 86%, var(--fg));
 }
@@ -1120,6 +1128,10 @@ iframe {
 
 .palette-dark .activity-row__amount--failed {
   color: color-mix(in srgb, var(--red-400) 78%, var(--fg));
+}
+
+.palette-dark .activity-row__amount--cancelled {
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
 }
 
 .transaction-asset-logo {

--- a/src/test/components/transactions-list.test.tsx
+++ b/src/test/components/transactions-list.test.tsx
@@ -258,6 +258,52 @@ describe('TransactionsList', () => {
     expect(screen.queryByText('Completed')).not.toBeInTheDocument()
   })
 
+  it('separates a cancelled swap value from the failed treatment', () => {
+    const swapTx: Tx = {
+      amount: 0,
+      boardingTxid: '',
+      createdAt: 1_700_000_000,
+      explorable: undefined,
+      preconfirmed: false,
+      assetSwap: {
+        fiatAmount: 100,
+        fromAmount: BigInt(10_000),
+        fromAssetId: 'btc',
+        fromDecimals: 8,
+        fromTicker: 'BTC',
+        status: 'cancelled',
+        toAmount: BigInt(500),
+        toAssetId: MUTINYNET_DEPIX_ASSET_ID,
+        toDecimals: 2,
+        toTicker: 'BRL',
+      },
+      redeemTxid: '',
+      roundTxid: 'cancel-txid',
+      settled: true,
+      type: 'swap',
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <ConfigContext.Provider
+          value={{ ...mockConfigContextValue, config: { ...mockConfigContextValue.config, currency: Currencies.USD } }}
+        >
+          <FiatContext.Provider value={mockFiatContextValue}>
+            <FlowContext.Provider value={mockFlowContextValue}>
+              <WalletContext.Provider value={{ ...mockWalletContextValue, isVerifiedAsset: () => true, txs: [swapTx] }}>
+                <TransactionsList mode='static' />
+              </WalletContext.Provider>
+            </FlowContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    const amount = screen.getByText('$100.00').closest('.activity-row__amount')
+    expect(amount).toHaveClass('activity-row__amount--cancelled')
+    expect(amount).not.toHaveClass('activity-row__amount--failed')
+  })
+
   it('hides the data-carrier value when any asset lacks account pricing', () => {
     const tx: Tx = {
       amount: 330,


### PR DESCRIPTION
## Summary

- Give cancelled swap values a muted neutral treatment with a light line-through, so a returned swap does not read like a dangerous failure.
- Keep actual failed swaps on the existing red danger treatment.
- Add focused regression coverage for the cancelled status class.

This PR is intentionally stacked on [PR #784](https://github.com/arkade-os/wallet/pull/784).

Related issue: [#829](https://github.com/arkade-os/wallet/issues/829). Keep the issue open until this PR merges into #784.

## Scope

- `src/components/TransactionsList.tsx` — separates cancelled amounts from the failed status class at the shared swap activity renderer.
- `src/index.css` — adds token-based neutral colors for light and dark themes and applies a native line-through to the displayed value.
- `src/test/components/transactions-list.test.tsx` — verifies that a cancelled value receives the cancelled class and not the failed class.

## User-visible behavior

Cancelled swap activity values are now neutral and crossed out. The row still says “Swap cancelled,” route/date context remains visible, and failed swaps remain red.

## Verification

- `bunx vitest run src/test/components/transactions-list.test.tsx` — 7 tests passed.
- `bunx tsc --noEmit` — passed.
- `bunx eslint src/components/TransactionsList.tsx src/test/components/transactions-list.test.tsx` — passed.
- Prettier and `git diff --check` — passed.
- Created and cancelled a real Mutinynet test swap in the Codex in-app browser; verified the resulting activity row in light and dark themes with no browser errors.
- Verified 4.61:1 light-theme text contrast and the computed `line-through` decoration.
- Verified 375×667, 768×1024, 1440×900, and 1920×1080 layouts with no horizontal overflow.
- Independent Codex code review — approved with no substantive issues.

## Visual proof

Post-change dark activity view after creating and cancelling a real Mutinynet test swap:

<img width="1280" height="720" alt="Cancelled swap amount shown in a muted neutral color with a line-through" src="https://github.com/user-attachments/assets/b0b475c0-bccd-4160-a595-0d576bb2b00a" />

No unrelated files or behavior were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled swap transactions now display a distinct visual state from failed transactions.
  * Cancelled amounts use muted styling and a strikethrough for clearer status identification, including in dark mode.

* **Tests**
  * Added coverage to verify cancelled transactions receive the correct styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->