### PR TITLE
fix: infinite loop calling delegator/info in Delegate view

### DIFF
--- a/src/screens/Settings/Delegates.tsx
+++ b/src/screens/Settings/Delegates.tsx
@@ -36,8 +36,10 @@ const formatUrl = (host: string, path: string): string => {
   return `${prefix}${host}/${path}`
 }
 
+type DelegateConnectionInfo = Pick<AspInfo, 'deprecatedSigners' | 'network' | 'signerPubkey'>
+
 // test connection to delegate by fetching delegate info and validating the response
-const testConnection = (aspInfo: AspInfo): Promise<Delegate | undefined> => {
+const testConnection = (aspInfo: DelegateConnectionInfo): Promise<Delegate | undefined> => {
   return new Promise((resolve, reject) => {
     // ensure expected pubkeys are in xonly format
     const now = Math.floor(Date.now() / 1000)
@@ -136,26 +138,39 @@ function DelegateCard() {
   const [active, setActive] = useState(false)
   const [delegate, setDelegate] = useState<Delegate>()
 
-  // populate delegate info
-  useEffect(() => {
-    if (!config.delegate || !aspInfo.network) return
-    setDelegate(getDelegateForNetwork(aspInfo.network as Network))
-  }, [config.delegate, aspInfo.network])
+  const { deprecatedSigners, network, signerPubkey } = aspInfo
 
-  // test connection to delegate and update status
+  // populate delegate info, then test the connection once for the current network/ASP signer
   useEffect(() => {
-    if (!delegate?.url || !aspInfo.signerPubkey) return
-    testConnection(aspInfo)
-      .then((delegate) => {
-        if (!delegate) return
-        setDelegate(delegate)
+    if (!config.delegate || !network) {
+      setDelegate(undefined)
+      setActive(false)
+      return
+    }
+
+    const networkDelegate = getDelegateForNetwork(network as Network)
+    setDelegate(networkDelegate)
+    setActive(false)
+
+    if (!networkDelegate?.url || !signerPubkey) return
+
+    let cancelled = false
+    testConnection({ deprecatedSigners, network, signerPubkey })
+      .then((testedDelegate) => {
+        if (cancelled || !testedDelegate) return
+        setDelegate(testedDelegate)
         setActive(true)
       })
       .catch((error) => {
+        if (cancelled) return
         consoleError(error, 'Error testing delegate connection:')
         setActive(false)
       })
-  }, [delegate, aspInfo.signerPubkey])
+
+    return () => {
+      cancelled = true
+    }
+  }, [config.delegate, deprecatedSigners, network, signerPubkey])
 
   if (!config.delegate) return null
 

--- a/src/test/screens/settings/delegates.test.tsx
+++ b/src/test/screens/settings/delegates.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import Delegates from '../../../screens/Settings/Delegates'
 import { ConfigContext } from '../../../providers/config'
 import { mockAspContextValue, mockConfigContextValue } from '../mocks'
@@ -23,7 +23,7 @@ describe('Delegates screen', () => {
 
     fetchMocker = createFetchMock(vi)
     fetchMocker.enableMocks()
-    fetchMocker.mockResponseOnce(
+    fetchMocker.mockResponse(
       JSON.stringify({
         fee: '0',
         name: 'Arkade Default',
@@ -58,7 +58,7 @@ describe('Delegates screen', () => {
     expect(() => screen.getByTestId('delegate-card')).toThrow()
   })
 
-  it('renders the delegate card when toggle is on', () => {
+  it('renders the delegate card when toggle is on', async () => {
     render(
       <AspContext.Provider value={mockDelegatesAspContextValue as any}>
         <ConfigContext.Provider value={getMockConfigWithDelegate(true) as any}>
@@ -78,6 +78,9 @@ describe('Delegates screen', () => {
     expect(screen.getByText('fee: 0 sats')).toBeInTheDocument()
     expect(screen.getByText('address:')).toBeInTheDocument()
     expect(screen.getByText('pubkey:')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('Active')).toBeInTheDocument())
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fetchMocker).toHaveBeenCalledTimes(1)
   })
 
   it('renders warning when delegate is not found for the network', () => {


### PR DESCRIPTION
To reproduce: enter `Settings -> Advanced -> Delegate`.
Observe the network tab: there are unbounded calls to `v1/delegator/info`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delegate connection validation and state handling when network or delegate details are unavailable.
  * Prevented outdated connection results from affecting the interface after settings change or navigation.
  * Made delegate status updates more reliable and consistent.

* **Tests**
  * Improved coverage for asynchronous delegate activation and connection status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->