### PR TITLE
Replace deprecated virtualStatus with canonical fields and predicates

### DIFF
--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -108,6 +108,10 @@ export const collaborativeExit = async (wallet: IWallet, amount: number, address
   }
 }
 
+// Compare by batch expiry ascending; VTXOs without an expiry sort last.
+export const byExpiryAsc = (a: { expiresAt?: Date | null }, b: { expiresAt?: Date | null }): number =>
+  (a.expiresAt?.getTime() ?? Number.POSITIVE_INFINITY) - (b.expiresAt?.getTime() ?? Number.POSITIVE_INFINITY)
+
 export const collaborativeExitWithFees = async (
   wallet: IWallet,
   inputAmount: number,
@@ -118,8 +122,8 @@ export const collaborativeExitWithFees = async (
   const selectedVtxos = []
   let selectedAmount = 0
 
-  // sort vtxos by batch expiry ascending
-  const vtxosSorted = vtxos.sort((a, b) => (a.expiresAt?.getTime() ?? 0) - (b.expiresAt?.getTime() ?? 0))
+  // sort vtxos by batch expiry ascending; missing expiry sorts last
+  const vtxosSorted = vtxos.sort(byExpiryAsc)
 
   for (const vtxo of vtxosSorted) {
     if (selectedAmount >= inputAmount) break

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -119,7 +119,7 @@ export const collaborativeExitWithFees = async (
   let selectedAmount = 0
 
   // sort vtxos by batch expiry ascending
-  const vtxosSorted = vtxos.sort((a, b) => (a.virtualStatus.batchExpiry ?? 0) - (b.virtualStatus.batchExpiry ?? 0))
+  const vtxosSorted = vtxos.sort((a, b) => (a.expiresAt?.getTime() ?? 0) - (b.expiresAt?.getTime() ?? 0))
 
   for (const vtxo of vtxosSorted) {
     if (selectedAmount >= inputAmount) break

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -28,20 +28,21 @@ export const calcNextRollover = async (vtxos: Vtxo[], wallet: IWallet, aspInfo: 
     return minBlockTime + expiration
   }
   return vtxos.reduce((acc: number, cur) => {
-    if (!cur.virtualStatus.batchExpiry) return acc
-    const unixtimestamp = Math.floor(cur.virtualStatus.batchExpiry / 1000)
+    const expiryMs = cur.expiresAt?.getTime()
+    if (!expiryMs) return acc
+    const unixtimestamp = Math.floor(expiryMs / 1000)
     return unixtimestamp < acc || acc === 0 ? unixtimestamp : acc
   }, 0)
 }
 
 export const calcBatchLifetimeMs = async (vtxos: Vtxo[], indexer: Indexer): Promise<number> => {
-  const sampleVtxo = vtxos.find((vtxo) => vtxo.virtualStatus.batchExpiry && vtxo.virtualStatus.commitmentTxIds)
-  if (!sampleVtxo || !sampleVtxo.virtualStatus.batchExpiry || !sampleVtxo.virtualStatus.commitmentTxIds?.[0]) return 0
+  const sampleVtxo = vtxos.find((vtxo) => vtxo.expiresAt && vtxo.commitmentTxIds?.length)
+  if (!sampleVtxo?.expiresAt || !sampleVtxo.commitmentTxIds?.[0]) return 0
 
-  const batchStart = await indexer.getAndUpdateCommitmentTxCreatedAt(sampleVtxo.virtualStatus.commitmentTxIds[0])
+  const batchStart = await indexer.getAndUpdateCommitmentTxCreatedAt(sampleVtxo.commitmentTxIds[0])
   if (!batchStart) return 0
   const batchStartMs = batchStart * 1000
 
-  const batchExpiryMs = sampleVtxo.virtualStatus.batchExpiry
+  const batchExpiryMs = sampleVtxo.expiresAt.getTime()
   return batchExpiryMs - batchStartMs
 }

--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -22,7 +22,7 @@ import LoadingLogo from '../../components/LoadingLogo'
 import { LimitsContext } from '../../providers/limits'
 import { EmptyCoinsList } from '../../components/Empty'
 import WarningBox from '../../components/Warning'
-import { ExtendedCoin, ExtendedVirtualCoin, isVtxoExpiringSoon } from '@arkade-os/sdk'
+import { ExtendedCoin, ExtendedVirtualCoin, isVtxoExpiringSoon, canRecoverOnchain, TimeHeight } from '@arkade-os/sdk'
 import { consoleError } from '../../lib/logs'
 import * as Sentry from '@sentry/react'
 import Grid from '../../components/Grid'
@@ -272,8 +272,8 @@ export default function Vtxos() {
   }
 
   const VtxoLine = ({ vtxo }: { vtxo: Vtxo }) => {
-    const now = Date.now()
-    const expired = vtxo.virtualStatus?.batchExpiry ? now > vtxo.virtualStatus.batchExpiry : false
+    const now: TimeHeight = { timestamp: new Date() }
+    const expiryMs = vtxo.expiresAt?.getTime()
     const satsAmount = config.showBalance ? prettyNumber(vtxo.value) : prettyHide(vtxo.value)
     const assetsAmounts = vtxo.assets?.length
       ? vtxo.assets.map((a) => {
@@ -284,16 +284,16 @@ export default function Vtxos() {
           return { text: `${prettyAssetAmount(a.amount, decimals)} ${label}`, assetId: a.assetId }
         })
       : []
-    const expiry = vtxo.virtualStatus?.batchExpiry ? prettyAgo(vtxo.virtualStatus.batchExpiry) : 'Unknown'
+    const expiry = expiryMs ? prettyAgo(expiryMs) : 'Unknown'
     const tags = (
       <FlexRow centered>
         {vtxo.value < aspInfo.dust
           ? Tags.subdust
-          : vtxo.virtualStatus?.state === 'swept' || expired
+          : canRecoverOnchain(vtxo, now)
             ? Tags.swept
             : wallet.thresholdMs && isVtxoExpiringSoon(vtxo, wallet.thresholdMs)
               ? Tags.expiring
-              : vtxo.virtualStatus?.state === 'settled'
+              : !vtxo.isSpent && !vtxo.isSwept && !vtxo.isPreconfirmed
                 ? Tags.settled
                 : null}
       </FlexRow>

--- a/src/test/lib/asp.test.ts
+++ b/src/test/lib/asp.test.ts
@@ -25,7 +25,22 @@ vi.mock('@arkade-os/sdk', async (importOriginal) => {
   }
 })
 
-import { getAspInfo, aspErrorText, emptyAspInfo } from '../../lib/asp'
+import { getAspInfo, aspErrorText, emptyAspInfo, byExpiryAsc } from '../../lib/asp'
+
+describe('byExpiryAsc', () => {
+  it('sorts known expiries ascending and places missing expiry last', () => {
+    const items = [
+      { id: 'no-expiry', expiresAt: undefined },
+      { id: 'later', expiresAt: new Date(2000) },
+      { id: 'null-expiry', expiresAt: null },
+      { id: 'earlier', expiresAt: new Date(1000) },
+    ]
+
+    const sorted = [...items].sort(byExpiryAsc).map((i) => i.id)
+
+    expect(sorted).toEqual(['earlier', 'later', 'no-expiry', 'null-expiry'])
+  })
+})
 
 describe('aspErrorText', () => {
   it('returns the caller fallback when not outdated', () => {


### PR DESCRIPTION
`virtualStatus` being deprecated here https://github.com/arkade-os/ts-sdk/pull/619

Replaces all `virtualStatus` usages with canonical `VirtualCoin` fields (`expiresAt`, `commitmentTxIds`, `isSpent`/`isSwept`/`isPreconfirmed`) and the SDK capability predicates (`isPastExpiry`, `canRecoverOnchain`).

- `src/lib/asp.ts` — sort VTXOs by `expiresAt`.
- `src/lib/wallet.ts` — `calcNextRollover` / `calcBatchLifetimeMs` read canonical fields.
- `src/screens/Settings/Vtxos.tsx` — expiry display and coin-control tags via canonical fields + predicates.