### PR TITLE
Enable dev mode via ?dev query param

### DIFF
--- a/src/providers/devMode.tsx
+++ b/src/providers/devMode.tsx
@@ -12,8 +12,20 @@ export const DevModeContext = createContext<DevModeContextProps>({
   handleTap: () => {},
 })
 
+// Enable/disable dev mode via ?dev=true / ?dev=false. Persisted to localStorage,
+// so it stays sticky until explicitly cleared (?dev=false or toggling off).
+function readInitialDevMode(): boolean {
+  const param = new URLSearchParams(window.location.search).get('dev')
+  if (param === 'true' || param === 'false') {
+    const enabled = param === 'true'
+    localStorage.setItem(DEV_MODE_KEY, String(enabled))
+    return enabled
+  }
+  return localStorage.getItem(DEV_MODE_KEY) === 'true'
+}
+
 export function DevModeProvider({ children }: { children: ReactNode }) {
-  const [devMode, setDevMode] = useState(() => localStorage.getItem(DEV_MODE_KEY) === 'true')
+  const [devMode, setDevMode] = useState(readInitialDevMode)
   const tapCountRef = useRef(0)
   const tapTimerRef = useRef<ReturnType<typeof setTimeout>>()
 

--- a/src/providers/devMode.tsx
+++ b/src/providers/devMode.tsx
@@ -19,6 +19,10 @@ function readInitialDevMode(): boolean {
   if (param === 'true' || param === 'false') {
     const enabled = param === 'true'
     localStorage.setItem(DEV_MODE_KEY, String(enabled))
+    // Remove the param from the URL (without reloading) so it isn't re-read on refresh.
+    const url = new URL(window.location.href)
+    url.searchParams.delete('dev')
+    window.history.replaceState(null, '', url)
     return enabled
   }
   return localStorage.getItem(DEV_MODE_KEY) === 'true'

--- a/src/test/providers/devMode.test.tsx
+++ b/src/test/providers/devMode.test.tsx
@@ -16,7 +16,10 @@ function Harness() {
 
 describe('DevModeProvider', () => {
   beforeEach(() => localStorage.clear())
-  afterEach(() => localStorage.clear())
+  afterEach(() => {
+    localStorage.clear()
+    window.history.replaceState({}, '', '/')
+  })
 
   it('starts with dev mode off', () => {
     render(
@@ -29,6 +32,40 @@ describe('DevModeProvider', () => {
 
   it('reads initial state from localStorage', () => {
     localStorage.setItem('dev_mode', 'true')
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    expect(screen.getByTestId('status').textContent).toBe('on')
+  })
+
+  it('enables dev mode from ?dev=true and persists it', () => {
+    window.history.replaceState({}, '', '/?dev=true')
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    expect(screen.getByTestId('status').textContent).toBe('on')
+    expect(localStorage.getItem('dev_mode')).toBe('true')
+  })
+
+  it('disables dev mode from ?dev=false even if previously enabled', () => {
+    localStorage.setItem('dev_mode', 'true')
+    window.history.replaceState({}, '', '/?dev=false')
+    render(
+      <DevModeProvider>
+        <Harness />
+      </DevModeProvider>,
+    )
+    expect(screen.getByTestId('status').textContent).toBe('off')
+    expect(localStorage.getItem('dev_mode')).toBe('false')
+  })
+
+  it('ignores an unrelated dev value and falls back to localStorage', () => {
+    localStorage.setItem('dev_mode', 'true')
+    window.history.replaceState({}, '', '/?dev=maybe')
     render(
       <DevModeProvider>
         <Harness />


### PR DESCRIPTION
Adds `?dev=true` / `?dev=false` to toggle dev mode without the triple-tap. Value is persisted to localStorage and stays sticky until explicitly cleared. Any other `dev` value falls back to the stored setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL-based controls for developer mode using `?dev=true` or `?dev=false`.
  * The resolved developer mode setting is persisted for future visits.
  * Invalid or unrecognized `?dev` values fall back to the previously saved setting.
* **Bug Fixes**
  * Improved developer mode initialization and ensured state resets correctly between tests/sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->