### PR TITLE
show wallet mode in about

### DIFF
--- a/src/screens/Settings/About.tsx
+++ b/src/screens/Settings/About.tsx
@@ -9,9 +9,11 @@ import { gitCommit } from '../../_gitCommit'
 import { prettyDelta } from '../../lib/format'
 import FlexCol from '../../components/FlexCol'
 import ErrorMessage from '../../components/Error'
+import { ConfigContext } from '@/providers/config'
 
 export default function About() {
   const { aspInfo } = useContext(AspContext)
+  const { config } = useContext(ConfigContext)
 
   const [error, setError] = useState(false)
 
@@ -28,6 +30,7 @@ export default function About() {
     ['Session duration', prettyDelta(Number(aspInfo.sessionDuration), true)],
     ['Boarding exit delay', prettyDelta(Number(aspInfo.boardingExitDelay), true)],
     ['Unilateral exit delay', prettyDelta(Number(aspInfo.unilateralExitDelay), true)],
+    ['Wallet mode', config.walletMode],
     ['Git commit hash', gitCommit],
   ]
 


### PR DESCRIPTION
<img width="652" height="644" alt="Screenshot 2026-07-27 at 14 16 11" src="https://github.com/user-attachments/assets/9d49b11a-5d80-4057-8240-e9cf6b735a36" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the current wallet mode to the Settings > About screen alongside server and network details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->