### PR TITLE
Improve transaction details across bitcoin and asset activity

### DIFF
--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -30,6 +30,8 @@ export interface DetailsProps {
   address?: string
   arknote?: string
   assetId?: string
+  assetIds?: { assetId: string; label: string }[]
+  assetTotals?: (SwapDisplayAmount & { label: string })[]
   amountDisplay?: TransactionAmountDisplay
   date?: string
   destination?: string
@@ -65,6 +67,8 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     address,
     arknote,
     assetId,
+    assetIds,
+    assetTotals,
     amountDisplay,
     date,
     direction,
@@ -151,16 +155,24 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
   const offchainTxOnClick = (id?: string) =>
     wallet && id && getOffchainTxURL(id, wallet) ? () => openOffchainTxInNewTab(id, wallet) : undefined
 
-  const assetIdOnClick =
-    wallet && assetId && getAssetURL(assetId, wallet)
+  const assetIdOnClick = (id: string) =>
+    wallet && getAssetURL(id, wallet)
       ? () => {
-          openAssetInNewTab(assetId, wallet)
+          openAssetInNewTab(id, wallet)
         }
       : undefined
+  const assetIdRows: TableData = (assetIds ?? (assetId ? [{ assetId, label: 'Asset ID' }] : [])).map(
+    ({ assetId: id, label }) => [label, id, <InfoIcon key={`${label}-${id}`} />, assetIdOnClick(id)],
+  )
+  const assetTotalRows: TableData = (assetTotals ?? []).map(({ label, ...amount }) => [
+    label,
+    formatSensitiveDetail(amount),
+    <TotalIcon key={`${label}-${amount.value}`} />,
+  ])
 
   const data: TableData = [
-    ['From', formatSensitiveDetail(swapFrom), <ArrowUpDownIcon key='swap-from-icon' />],
-    ['To', formatSensitiveDetail(swapTo), <ArrowUpDownIcon key='swap-to-icon' />],
+    ['Swap from', formatSensitiveDetail(swapFrom), <ArrowUpDownIcon key='swap-from-icon' />],
+    ['Swap to', formatSensitiveDetail(swapTo), <ArrowUpDownIcon key='swap-to-icon' />],
     ['Address', address, <TypeIcon key='address-icon' />],
     ['Arknote', arknote, <NotesIcon key='notes-icon' small />],
     ['Invoice', invoice, <TypeIcon key='invoice-icon' />],
@@ -169,7 +181,7 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     ['Funded', fundedTxid, <HashIcon key='funded-icon' />, offchainTxOnClick(fundedTxid)],
     [spendLabel ?? 'Completed', spendTxid, <HashIcon key='spend-icon' />, offchainTxOnClick(spendTxid)],
     ['Transaction ID', txid, <HashIcon key='txid-icon' />, showTxidLink ? txidOnClick : undefined],
-    ['Asset ID', assetId, <InfoIcon key='asset-id-icon' />, assetIdOnClick],
+    ...assetIdRows,
     ['Direction', direction, <DirectionIcon key='direction-icon' />],
     ['Type', type, <TypeIcon key='type-icon' />],
     ['Status', status, <StatusIcon key='status-icon' />],
@@ -180,6 +192,7 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     ['Price rate', priceRate, <ArrowUpDownIcon key='price-rate-icon' />],
     ['Network fees', fees === undefined ? undefined : formatAmount(fees), <FeesIcon key='fees-icon' />],
     ['Swap fees', formatSensitiveDetail(swapFees), <FeesIcon key='swap-fees-icon' />],
+    ...assetTotalRows,
     ['Total', formatAmount(total), <TotalIcon key='total-icon' />],
   ]
 

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -20,6 +20,7 @@ import { getConfirmedAndNotExpiredUtxos } from './utxo'
 import * as Sentry from '@sentry/react'
 import { hex } from '@scure/base'
 import { toXOnlyHex } from './keys'
+import { readTransactionActivityMetadata } from './storage'
 
 const emptyFees: FeeInfo = {
   intentFee: { offchainInput: '', offchainOutput: '', onchainInput: '', onchainOutput: '' },
@@ -198,14 +199,18 @@ export const getTxHistory = async (wallet: IWallet): Promise<Tx[]> => {
       const { key, settled, type, amount } = tx
       const explorable = key.boardingTxid ? key.boardingTxid : key.commitmentTxid ? key.commitmentTxid : undefined
       const assets = tx.assets?.map((a) => ({ assetId: a.assetId, amount: a.amount }))
+      const activityMetadata = readTransactionActivityMetadata([key.arkTxid, key.boardingTxid, key.commitmentTxid])
       txs.push({
         amount: Math.abs(amount),
+        assetAction: activityMetadata?.assetAction,
         assets,
         boardingTxid: key.boardingTxid,
+        destination: type === 'SENT' ? activityMetadata?.destination : undefined,
         redeemTxid: key.arkTxid,
         roundTxid: key.commitmentTxid,
         createdAt: unix,
         explorable,
+        networkFee: activityMetadata?.networkFee,
         preconfirmed: !settled,
         settled: type === 'SENT' ? true : settled, // show all sent tx as settled
         type: type.toLowerCase(),

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -52,6 +52,51 @@ export const readWalletFromStorage = (): Wallet | undefined => {
   return getStorageItem('wallet', undefined, (val) => JSON.parse(val))
 }
 
+export type TransactionActivityMetadata = {
+  assetAction?: 'issued' | 'reissued' | 'burned'
+  destination?: string
+  networkFee?: number
+  savedAt: number
+}
+
+const TRANSACTION_ACTIVITY_METADATA_KEY = 'transactionActivityMetadata'
+const TRANSACTION_ACTIVITY_METADATA_LIMIT = 250
+
+export const saveTransactionActivityMetadata = (
+  txid: string,
+  metadata: Omit<TransactionActivityMetadata, 'savedAt'>,
+): void => {
+  if (!txid) return
+  const stored = getStorageItem<Record<string, TransactionActivityMetadata>>(
+    TRANSACTION_ACTIVITY_METADATA_KEY,
+    {},
+    (value) => JSON.parse(value),
+  )
+  stored[txid] = { ...stored[txid], ...metadata, savedAt: Date.now() }
+  const entries = Object.entries(stored)
+    .sort(([, a], [, b]) => a.savedAt - b.savedAt)
+    .slice(-TRANSACTION_ACTIVITY_METADATA_LIMIT)
+  setStorageItemSafely(
+    TRANSACTION_ACTIVITY_METADATA_KEY,
+    JSON.stringify(Object.fromEntries(entries)),
+    'Failed to save transaction activity metadata',
+  )
+}
+
+export const readTransactionActivityMetadata = (
+  txids: (string | undefined)[],
+): TransactionActivityMetadata | undefined => {
+  const stored = getStorageItem<Record<string, TransactionActivityMetadata>>(
+    TRANSACTION_ACTIVITY_METADATA_KEY,
+    {},
+    (value) => JSON.parse(value),
+  )
+  return txids
+    .filter(Boolean)
+    .map((txid) => stored[txid!])
+    .find(Boolean)
+}
+
 // local storage caches the asset details for 24 hours
 export const ASSET_METADATA_TTL_MS = 24 * 60 * 60 * 1000
 

--- a/src/lib/swapDisplay.ts
+++ b/src/lib/swapDisplay.ts
@@ -68,22 +68,40 @@ export function formatSwapAssetAmount(tx: Tx, side: 'from' | 'to'): SwapDisplayA
   return swapAssetDisplayAmount(amount, decimals, ticker)
 }
 
+function swapFeeAtomic(tx: Tx): bigint | undefined {
+  const swap = tx.assetSwap
+  if (!swap) return undefined
+  const { toAmount, feeBps } = swap
+  if (toAmount === undefined || feeBps === undefined) return undefined
+  if (toAmount <= BigInt(0) || feeBps < 0 || feeBps >= 10_000) return undefined
+  if (feeBps === 0) return BigInt(0)
+  return BigInt(
+    new Decimal(toAmount.toString())
+      .mul(feeBps)
+      .div(10_000 - feeBps)
+      .toFixed(0),
+  )
+}
+
 /** The market fee, in the receive asset — same unit as the live composer's
  * Fees row. The stored toAmount is net of the fee, so the fee is the
  * gross-minus-net gap: toAmount × feeBps / (10000 − feeBps). */
 export function swapFeeAmount(tx: Tx): SwapDisplayAmount | undefined {
   const swap = tx.assetSwap
   if (!swap) return undefined
-  const { toAmount, toDecimals, toTicker, feeBps } = swap
-  if (toAmount === undefined || toDecimals === undefined || !toTicker || feeBps === undefined) return undefined
-  if (toAmount <= BigInt(0) || feeBps <= 0 || feeBps >= 10_000) return undefined
-  const feeAtomic = BigInt(
-    new Decimal(toAmount.toString())
-      .mul(feeBps)
-      .div(10_000 - feeBps)
-      .toFixed(0),
-  )
-  return swapAssetDisplayAmount(feeAtomic, toDecimals, toTicker)
+  const { toDecimals, toTicker } = swap
+  const fee = swapFeeAtomic(tx)
+  if (fee === undefined || toDecimals === undefined || !toTicker) return undefined
+  return swapAssetDisplayAmount(fee, toDecimals, toTicker)
+}
+
+export function swapAmountBeforeFee(tx: Tx): SwapDisplayAmount | undefined {
+  const swap = tx.assetSwap
+  if (!swap) return undefined
+  const { toAmount, toDecimals, toTicker } = swap
+  const fee = swapFeeAtomic(tx)
+  if (toAmount === undefined || fee === undefined || toDecimals === undefined || !toTicker) return undefined
+  return swapAssetDisplayAmount(toAmount + fee, toDecimals, toTicker)
 }
 
 /** Rate the covenant enforced: receive-asset units bought by one unit of the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -93,10 +93,13 @@ export enum Themes {
 
 export type Tx = {
   amount: number
+  assetAction?: 'issued' | 'reissued' | 'burned'
   assets?: Asset[]
   boardingTxid: string
   createdAt: number
+  destination?: string
   explorable: string | undefined
+  networkFee?: number
   preconfirmed: boolean
   redeemTxid: string
   roundTxid: string

--- a/src/screens/Apps/Assets/Burn.tsx
+++ b/src/screens/Apps/Assets/Burn.tsx
@@ -18,6 +18,7 @@ import { extractError } from '../../../lib/error'
 import Input from '../../../components/Input'
 import AssetCard from '../../../components/AssetCard'
 import { centsToUnits, prettyAssetAmount, unitsToCents } from '../../../lib/assets'
+import { saveTransactionActivityMetadata } from '../../../lib/storage'
 
 export default function AppAssetBurn() {
   const { replace } = useContext(NavigationContext)
@@ -63,7 +64,8 @@ export default function AppAssetBurn() {
     setError('')
 
     try {
-      await svcWallet.assetManager.burn({ assetId: assetInfo.assetId, amount })
+      const txid = await svcWallet.assetManager.burn({ assetId: assetInfo.assetId, amount })
+      saveTransactionActivityMetadata(txid, { assetAction: 'burned' })
       await reloadWallet()
       pendingNav.current = () => replace(Pages.AppAssetDetail, Pages.AppAssets)
       setOpDone(true)

--- a/src/screens/Apps/Assets/Mint.tsx
+++ b/src/screens/Apps/Assets/Mint.tsx
@@ -18,6 +18,7 @@ import { FlowContext } from '../../../providers/flow'
 import { WalletContext } from '../../../providers/wallet'
 import { consoleError } from '../../../lib/logs'
 import { extractError } from '../../../lib/error'
+import { saveTransactionActivityMetadata } from '../../../lib/storage'
 import type { AssetDetails, IssuanceParams, KnownMetadata } from '@arkade-os/sdk'
 import Input from '../../../components/Input'
 import AssetCard from '../../../components/AssetCard'
@@ -141,6 +142,7 @@ export default function AppAssetMint() {
           amount: ctrlRawAmount,
           metadata: ctrlMeta,
         })
+        saveTransactionActivityMetadata(ctrlResult.arkTxId, { assetAction: 'issued' })
         resolvedControlAssetId = ctrlResult.assetId
         iconApprovalManager.approve(resolvedControlAssetId)
 
@@ -162,6 +164,7 @@ export default function AppAssetMint() {
       if (resolvedControlAssetId) params.controlAssetId = resolvedControlAssetId
 
       const result = await svcWallet.assetManager.issue(params)
+      saveTransactionActivityMetadata(result.arkTxId, { assetAction: 'issued' })
       const newAssetId = result.assetId
       iconApprovalManager.approve(newAssetId)
 

--- a/src/screens/Apps/Assets/Reissue.tsx
+++ b/src/screens/Apps/Assets/Reissue.tsx
@@ -19,6 +19,7 @@ import { consoleError } from '../../../lib/logs'
 import { extractError } from '../../../lib/error'
 import Input from '../../../components/Input'
 import { prettyAssetAmount, unitsToCents } from '../../../lib/assets'
+import { saveTransactionActivityMetadata } from '../../../lib/storage'
 
 export default function AppAssetReissue() {
   const { replace } = useContext(NavigationContext)
@@ -64,7 +65,8 @@ export default function AppAssetReissue() {
     setError('')
 
     try {
-      await svcWallet.assetManager.reissue({ assetId: assetInfo.assetId, amount })
+      const txid = await svcWallet.assetManager.reissue({ assetId: assetInfo.assetId, amount })
+      saveTransactionActivityMetadata(txid, { assetAction: 'reissued' })
       await reloadWallet()
       pendingNav.current = () => replace(Pages.AppAssetDetail, Pages.AppAssets)
       setOpDone(true)

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -23,6 +23,7 @@ import { FeesContext } from '../../../providers/fees'
 import { buildTransactionAmountDisplay } from '../../../lib/transactionAmountDisplay'
 import { useAmountDisplayContext } from '../../../hooks/useTransactionAmountDisplay'
 import TransactionAmountSummary from '../../../components/TransactionAmountSummary'
+import { saveTransactionActivityMetadata } from '../../../lib/storage'
 
 export default function SendDetails() {
   const displayContext = useAmountDisplayContext()
@@ -124,6 +125,10 @@ export default function SendDetails() {
 
   const handleTxid = (txid: string) => {
     if (!txid) return handleError('Error sending transaction')
+    saveTransactionActivityMetadata(txid, {
+      destination: details?.destination,
+      networkFee: details?.fees,
+    })
     setSendInfo({ ...sendInfo, total: details?.total, txid })
     setSendDone(true)
   }

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -4,7 +4,7 @@ import ButtonsOnBottom from '../../components/ButtonsOnBottom'
 import Padded from '../../components/Padded'
 import { WalletContext } from '../../providers/wallet'
 import { FlowContext } from '../../providers/flow'
-import { isBurn, isIssuance, prettyAgo, prettyDate } from '../../lib/format'
+import { isBurn, isIssuance, prettyDate } from '../../lib/format'
 import { defaultFee } from '../../lib/constants'
 import ErrorMessage from '../../components/Error'
 import { extractError } from '../../lib/error'
@@ -25,6 +25,7 @@ import { getInputsToSettle } from '../../lib/asp'
 import SwapTransactionSummary from '../../components/SwapTransactionSummary'
 import {
   formatSwapAssetAmount,
+  swapAmountBeforeFee,
   swapFeeAmount,
   swapPriceRateLabel,
   swapStatusLabel,
@@ -50,7 +51,8 @@ export default function Transaction() {
   const { txInfo } = useContext(FlowContext)
   const { cancelSwap, swaps } = useContext(AssetSwapsContext)
   const { aspInfo, calcBestMarketHour } = useContext(AspContext)
-  const { assetMetadataCache, settlePreconfirmed, vtxos, vtxoManager, wallet, svcWallet } = useContext(WalletContext)
+  const { assetMetadataCache, isVerifiedAsset, settlePreconfirmed, vtxos, vtxoManager, wallet, svcWallet } =
+    useContext(WalletContext)
 
   const liveSwap = txInfo?.assetSwap?.fundingTxid
     ? swaps.find((swap) => swap.fundingTxid === txInfo.assetSwap?.fundingTxid)
@@ -80,8 +82,10 @@ export default function Transaction() {
       : txInfo
   const swapTx = tx?.type === 'swap'
   const amountDisplay = useTransactionAmountDisplay(tx)
-  const issuanceTx = tx ? isIssuance(tx) : false
-  const burnTx = tx ? isBurn(tx) : false
+  const issuanceTx = tx
+    ? tx.assetAction === 'issued' || tx.assetAction === 'reissued' || (!tx.assetAction && isIssuance(tx))
+    : false
+  const burnTx = tx ? tx.assetAction === 'burned' || (!tx.assetAction && isBurn(tx)) : false
   const boardingTx = Boolean(tx?.boardingTxid)
   const defaultButtonLabel = 'Settle transaction'
   const boardingExitDelay = Number(aspInfo?.boardingExitDelay || 0)
@@ -169,24 +173,57 @@ export default function Transaction() {
           ? 'Settled'
           : 'Preconfirmed'
 
-  const fees = tx.type === 'sent' ? defaultFee : 0
+  const fees = tx.networkFee ?? (tx.type === 'sent' ? defaultFee : 0)
   // On asset transfers tx.amount is only the data carrier, not the asset value.
   // The asset-aware rows below replace the legacy Amount/Total rows.
   const assetTransfer = Boolean(tx.assets?.length)
   const transferSatoshis = tx.type === 'sent' ? tx.amount - defaultFee : tx.amount
-  const summaryLabel = issuanceTx
-    ? 'Amount issued'
-    : burnTx
-      ? 'Amount burned'
-      : tx.type === 'sent'
-        ? 'Amount sent'
-        : 'Amount received'
-  const when = tx.createdAt ? prettyAgo(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed'
+  const summaryLabel =
+    tx.assetAction === 'reissued'
+      ? 'Amount reissued'
+      : issuanceTx
+        ? 'Amount issued'
+        : burnTx
+          ? 'Amount burned'
+          : tx.type === 'sent'
+            ? 'Amount sent'
+            : 'Amount received'
   const date = tx.createdAt ? prettyDate(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed'
   const txid = tx.boardingTxid || tx.redeemTxid || tx.roundTxid || ''
+  const displayedAssets = amountDisplay?.raw.filter((amount) => amount.assetId) ?? []
+  const assetIds = displayedAssets.map((amount) => ({
+    assetId: amount.assetId!,
+    label:
+      displayedAssets.length === 1
+        ? `Asset ID${amount.unverified ? ' (unverified)' : ''}`
+        : `Asset ID (${amount.ticker}${amount.unverified ? ', unverified' : ''})`,
+  }))
+  const assetTotals = assetTransfer
+    ? amountDisplay?.raw.map((amount) => ({
+        ...amount,
+        label: amountDisplay.raw.length === 1 ? 'Total' : `Total (${amount.ticker})`,
+      }))
+    : undefined
+  const swapAssetIds = [
+    tx.assetSwap?.fromAssetId && tx.assetSwap.fromAssetId !== 'btc'
+      ? {
+          assetId: tx.assetSwap.fromAssetId,
+          label: `From asset ID${isVerifiedAsset(tx.assetSwap.fromAssetId) ? '' : ' (unverified)'}`,
+        }
+      : undefined,
+    tx.assetSwap?.toAssetId && tx.assetSwap.toAssetId !== 'btc'
+      ? {
+          assetId: tx.assetSwap.toAssetId,
+          label: `To asset ID${isVerifiedAsset(tx.assetSwap.toAssetId) ? '' : ' (unverified)'}`,
+        }
+      : undefined,
+  ].filter((entry): entry is { assetId: string; label: string } => Boolean(entry))
+  const swapReceived = swapTx ? formatSwapAssetAmount(tx, 'to') : undefined
 
   const details: DetailsProps = swapTx
     ? {
+        assetIds: swapAssetIds,
+        assetTotals: swapReceived ? [{ ...swapReceived, label: 'Total received' }] : undefined,
         date,
         fees: 0,
         fundedTxid: tx.assetSwap?.fundingTxid,
@@ -196,25 +233,23 @@ export default function Transaction() {
         status: swapStatusLabel(tx),
         swapFees: swapFeeAmount(tx),
         swapFrom: formatSwapAssetAmount(tx, 'from'),
-        swapTo: formatSwapAssetAmount(tx, 'to'),
-        type: 'Swap',
+        swapTo: swapAmountBeforeFee(tx),
         wallet,
-        when,
       }
     : {
         amountDisplay,
-        assetId: tx.assets?.[0]?.assetId,
+        assetIds,
+        assetTotals,
         date,
-        direction: issuanceTx ? 'Issuance' : burnTx ? 'Burn' : tx.type === 'sent' ? 'Sent' : 'Received',
+        destination: tx.type === 'sent' && !boardingTx && !issuanceTx && !burnTx ? tx.destination : undefined,
         fees,
         isOffchainTx: !tx.boardingTxid && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
         satoshis: assetTransfer ? undefined : transferSatoshis,
         status,
         total: assetTransfer ? undefined : tx.amount,
         txid,
-        type: boardingTx ? 'Boarding' : 'Offchain',
+        type: boardingTx ? 'Boarding' : undefined,
         wallet,
-        when,
       }
 
   const swapFromIcon = tx.assetSwap?.fromAssetId

--- a/src/test/e2e/swaps.test.ts
+++ b/src/test/e2e/swaps.test.ts
@@ -46,9 +46,6 @@ test('swap BTC <-> RGT using BTC as currency', async ({ page }) => {
   page.locator('.swap-receive-card').first().click()
   await page.getByTestId('swap-asset-row-sats').click()
 
-  // change to amount in RGT
-  await page.getByTestId('swap-amount-toggle').click()
-
   // insert 1000 RGT to swap
   await page.locator('[aria-label="1"]').click()
   await expect(page.getByText('Amount too small')).toBeVisible()
@@ -108,9 +105,6 @@ test('swap BTC <-> RGT using USD as currency', async ({ page }) => {
   // select BTC as asset to swap to
   await page.locator('.swap-receive-card').first().click()
   await page.getByTestId('swap-asset-row-sats').click()
-
-  // change to amount in RGT
-  await page.getByTestId('swap-amount-toggle').click()
 
   // insert 1000 RGT to swap
   await page.locator('[aria-label="1"]').click()

--- a/src/test/lib/asp.test.ts
+++ b/src/test/lib/asp.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 
 // Keep the real SDK (so ArkError stays a real class for the instanceof check in
 // getAspInfo) and only override RestArkProvider to control what getInfo throws.
@@ -25,7 +25,12 @@ vi.mock('@arkade-os/sdk', async (importOriginal) => {
   }
 })
 
-import { getAspInfo, aspErrorText, emptyAspInfo, byExpiryAsc } from '../../lib/asp'
+import { getAspInfo, aspErrorText, emptyAspInfo, byExpiryAsc, getTxHistory } from '../../lib/asp'
+import { saveTransactionActivityMetadata } from '../../lib/storage'
+
+beforeEach(() => {
+  localStorage.clear()
+})
 
 describe('byExpiryAsc', () => {
   it('sorts known expiries ascending and places missing expiry last', () => {
@@ -74,5 +79,35 @@ describe('getAspInfo', () => {
     const info = await getAspInfo('down.example.com')
     expect(info.unreachable).toBe(true)
     expect(info.outdated).toBeFalsy()
+  })
+})
+
+describe('getTxHistory', () => {
+  it('restores locally persisted receipt details for a sent transaction', async () => {
+    saveTransactionActivityMetadata('ark-txid', {
+      assetAction: 'reissued',
+      destination: 'tark1destination',
+      networkFee: 0,
+    })
+    const wallet = {
+      getTransactionHistory: async () => [
+        {
+          amount: 0,
+          assets: [{ assetId: 'asset-id', amount: BigInt(100) }],
+          createdAt: Date.now(),
+          key: { arkTxid: 'ark-txid', boardingTxid: '', commitmentTxid: '' },
+          settled: true,
+          type: 'SENT',
+        },
+      ],
+    }
+
+    const [tx] = await getTxHistory(wallet as any)
+
+    expect(tx).toMatchObject({
+      assetAction: 'reissued',
+      destination: 'tark1destination',
+      networkFee: 0,
+    })
   })
 })

--- a/src/test/lib/storage.test.ts
+++ b/src/test/lib/storage.test.ts
@@ -5,6 +5,8 @@ import {
   CachedAssetDetails,
   ASSET_METADATA_TTL_MS,
   clearStorage,
+  readTransactionActivityMetadata,
+  saveTransactionActivityMetadata,
 } from '../../lib/storage'
 
 describe('asset metadata storage', () => {
@@ -71,6 +73,26 @@ describe('asset metadata storage', () => {
     expect(loaded!.size).toBe(1)
     expect(loaded!.has('a')).toBe(false)
     expect(loaded!.get('b')?.metadata?.name).toBe('Second')
+  })
+})
+
+describe('transaction activity metadata storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('roundtrips destination, network fee, and asset action by transaction ID', () => {
+    saveTransactionActivityMetadata('ark-txid', {
+      assetAction: 'reissued',
+      destination: 'tark1destination',
+      networkFee: 0,
+    })
+
+    expect(readTransactionActivityMetadata(['missing', 'ark-txid'])).toMatchObject({
+      assetAction: 'reissued',
+      destination: 'tark1destination',
+      networkFee: 0,
+    })
   })
 })
 

--- a/src/test/lib/swapDisplay.test.ts
+++ b/src/test/lib/swapDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { swapRouteLabel, swapUnitOfAccountAmount } from '../../lib/swapDisplay'
+import { swapAmountBeforeFee, swapFeeAmount, swapRouteLabel, swapUnitOfAccountAmount } from '../../lib/swapDisplay'
 import { Currencies, Tx, Unit } from '../../lib/types'
 
 const PRICE = 63_750 // USD per whole BTC
@@ -52,6 +52,24 @@ describe('swapRouteLabel', () => {
       toTicker: 'sats',
     }
     expect(swapRouteLabel(reverse)).toBe('USD to BTC')
+  })
+})
+
+describe('swap receipt amounts', () => {
+  it('shows a zero fee and keeps the total received equal to the before-fee amount', () => {
+    const tx = btcCurrencySwap()
+
+    expect(swapFeeAmount(tx)?.value).toBe('0.00 USD')
+    expect(swapAmountBeforeFee(tx)?.value).toBe('1.02 USD')
+  })
+
+  it('reconciles the before-fee amount, fee, and received total', () => {
+    const tx = btcCurrencySwap()
+    tx.assetSwap!.feeBps = 200
+    tx.assetSwap!.toAmount = BigInt(645_000_000)
+
+    expect(swapFeeAmount(tx)?.value).toBe('0.13 USD')
+    expect(swapAmountBeforeFee(tx)?.value).toBe('6.58 USD')
   })
 })
 

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -171,13 +171,13 @@ describe('Transaction screen', () => {
     // left side of the table
     expect(screen.getByText('Network fees')).toBeInTheDocument()
     expect(screen.getByText('Transaction')).toBeInTheDocument()
-    expect(screen.getByText('Direction')).toBeInTheDocument()
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
     expect(screen.getByText('Asset amount')).toBeInTheDocument()
     expect(screen.getByText('Total')).toBeInTheDocument()
     expect(screen.getByText('Date')).toBeInTheDocument()
-    expect(screen.getByText('When')).toBeInTheDocument()
+    expect(screen.queryByText('When')).not.toBeInTheDocument()
     // right side of the table
-    expect(await screen.findByText('Received')).toBeInTheDocument()
+    expect(await screen.findByText('Amount received')).toBeInTheDocument()
     expect(await screen.findByText('0 BTC')).toBeInTheDocument()
   })
 
@@ -211,13 +211,13 @@ describe('Transaction screen', () => {
     // left side of the table
     expect(screen.getByText('Network fees')).toBeInTheDocument()
     expect(screen.getByText('Transaction')).toBeInTheDocument()
-    expect(screen.getByText('Direction')).toBeInTheDocument()
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
     expect(screen.getByText('Asset amount')).toBeInTheDocument()
     expect(screen.getByText('Total')).toBeInTheDocument()
     expect(screen.getByText('Date')).toBeInTheDocument()
-    expect(screen.getByText('When')).toBeInTheDocument()
+    expect(screen.queryByText('When')).not.toBeInTheDocument()
     // right side of the table
-    expect(screen.getByText('Received')).toBeInTheDocument()
+    expect(screen.getByText('Amount received')).toBeInTheDocument()
     expect(screen.getByText('0 BTC')).toBeInTheDocument()
     // buttons
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
@@ -248,13 +248,13 @@ describe('Transaction screen', () => {
     // left side of the table
     expect(screen.getByText('Network fees')).toBeInTheDocument()
     expect(screen.getByText('Transaction')).toBeInTheDocument()
-    expect(screen.getByText('Direction')).toBeInTheDocument()
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
     expect(screen.getByText('Asset amount')).toBeInTheDocument()
     expect(screen.getByText('Total')).toBeInTheDocument()
     expect(screen.getByText('Date')).toBeInTheDocument()
-    expect(screen.getByText('When')).toBeInTheDocument()
+    expect(screen.queryByText('When')).not.toBeInTheDocument()
     // right side of the table
-    expect(screen.getByText('Received')).toBeInTheDocument()
+    expect(screen.getByText('Amount received')).toBeInTheDocument()
     expect(screen.getByText('0 BTC')).toBeInTheDocument()
     // buttons should not be present
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
@@ -285,13 +285,13 @@ describe('Transaction screen', () => {
     // left side of the table
     expect(screen.getByText('Network fees')).toBeInTheDocument()
     expect(screen.getByText('Transaction')).toBeInTheDocument()
-    expect(screen.getByText('Direction')).toBeInTheDocument()
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
     expect(screen.getByText('Asset amount')).toBeInTheDocument()
     expect(screen.getByText('Total')).toBeInTheDocument()
     expect(screen.getByText('Date')).toBeInTheDocument()
-    expect(screen.getByText('When')).toBeInTheDocument()
+    expect(screen.queryByText('When')).not.toBeInTheDocument()
     // right side of the table
-    expect(screen.getByText('Received')).toBeInTheDocument()
+    expect(screen.getByText('Amount received')).toBeInTheDocument()
     expect(screen.getByText('0 BTC')).toBeInTheDocument()
     // buttons should be present
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
@@ -322,11 +322,11 @@ describe('Transaction screen', () => {
     // left side of the table
     expect(screen.getByText('Network fees')).toBeInTheDocument()
     expect(screen.getByText('Transaction')).toBeInTheDocument()
-    expect(screen.getByText('Direction')).toBeInTheDocument()
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
     expect(screen.getByText('Asset amount')).toBeInTheDocument()
     expect(screen.getByText('Total')).toBeInTheDocument()
     expect(screen.getByText('Date')).toBeInTheDocument()
-    expect(screen.getByText('When')).toBeInTheDocument()
+    expect(screen.queryByText('When')).not.toBeInTheDocument()
     // right side of the table
     // expect(screen.getByText('Received')).toBeInTheDocument()
     expect(screen.getByText('0 BTC')).toBeInTheDocument()
@@ -361,20 +361,20 @@ describe('Transaction screen', () => {
     // left side of the table
     expect(screen.getByText('Network fees')).toBeInTheDocument()
     expect(screen.getByText('Transaction')).toBeInTheDocument()
-    expect(screen.getByText('Direction')).toBeInTheDocument()
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
     expect(screen.getByText('Asset amount')).toBeInTheDocument()
     expect(screen.getByText('Total')).toBeInTheDocument()
     expect(screen.getByText('Date')).toBeInTheDocument()
-    expect(screen.getByText('When')).toBeInTheDocument()
+    expect(screen.queryByText('When')).not.toBeInTheDocument()
     // right side of the table
-    expect(screen.getByText('Received')).toBeInTheDocument()
+    expect(screen.getByText('Amount received')).toBeInTheDocument()
     expect(screen.getByText('0 BTC')).toBeInTheDocument()
     // buttons should not be present
     expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
     expect(screen.queryByText('Add reminder')).not.toBeInTheDocument()
   })
 
-  it('renders issuance transaction with correct direction and amounts', async () => {
+  it('labels an issuance with the exact action and hides the direction row', async () => {
     const localFlowContextValue = { ...mockFlowContextValue, txInfo: mockIssuanceTxInfo }
     const localWalletContextValue = { ...mockWalletContextValue, txs: [mockIssuanceTxInfo] }
 
@@ -394,12 +394,12 @@ describe('Transaction screen', () => {
       </NavigationContext.Provider>,
     )
 
-    // Should show "Issuance" instead of "Sent"
-    expect(screen.getByText('Issuance')).toBeInTheDocument()
-    expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+    expect(screen.getByText('Amount issued')).toBeInTheDocument()
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
+    expect(screen.getByTestId('Total')).toHaveTextContent('0.0001')
   })
 
-  it('renders burn transaction with correct direction', async () => {
+  it('labels a burn with the exact action and hides the direction row', async () => {
     const mockBurnTxInfo = {
       ...mockIssuanceTxInfo,
       assets: [
@@ -425,9 +425,28 @@ describe('Transaction screen', () => {
       </NavigationContext.Provider>,
     )
 
-    // Should show "Burn" instead of "Sent"
-    expect(screen.getByText('Burn')).toBeInTheDocument()
-    expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+    expect(screen.getByText('Amount burned')).toBeInTheDocument()
+    expect(screen.queryByText('Direction')).not.toBeInTheDocument()
+  })
+
+  it('labels a persisted reissue with the exact action', () => {
+    const txInfo = { ...mockIssuanceTxInfo, assetAction: 'reissued' as const }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <AspContext.Provider value={mockAspContextValue}>
+          <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo }}>
+            <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [txInfo] }}>
+              <LimitsContext.Provider value={mockLimitsContextValue}>
+                <Transaction />
+              </LimitsContext.Provider>
+            </WalletContext.Provider>
+          </FlowContext.Provider>
+        </AspContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByText('Amount reissued')).toBeInTheDocument()
   })
 
   it('renders a swap as an asset-pair receipt without send-only fields', () => {
@@ -487,12 +506,14 @@ describe('Transaction screen', () => {
     expect(screen.getByRole('heading', { name: 'Swap' })).toBeInTheDocument()
     expect(screen.getByText('ALP to BET')).toBeInTheDocument()
     expect(screen.getByText('$100.00')).toBeInTheDocument()
-    expect(screen.getByTestId('From')).toHaveTextContent('123.45 ALP')
-    expect(screen.getByTestId('To')).toHaveTextContent('67.89 BET')
+    expect(screen.getByTestId('Swap from')).toHaveTextContent('123.45 ALP')
+    expect(screen.getByTestId('Swap to')).toHaveTextContent('68.094 BET')
     expect(screen.getByTestId('Status')).toHaveTextContent('Completed')
-    expect(screen.getByTestId('Type')).toHaveTextContent('Swap')
+    expect(screen.queryByTestId('Type')).not.toBeInTheDocument()
     expect(screen.getByTestId('Funded')).toHaveTextContent('funding-txid')
     expect(screen.getByTestId('Completed')).toHaveTextContent('fill-txid')
+    expect(screen.getByTestId('From asset ID (unverified)')).toHaveTextContent('asset-alpha')
+    expect(screen.getByTestId('To asset ID (unverified)')).toHaveTextContent('asset-beta')
     expect(screen.queryByTestId('Transaction ID')).not.toBeInTheDocument()
     expect(screen.queryByText('Direction')).not.toBeInTheDocument()
     expect(screen.queryByText('Amount')).not.toBeInTheDocument()
@@ -501,7 +522,48 @@ describe('Transaction screen', () => {
     // the fee is shown in the receive asset (like the live composer), not a
     // bare percentage — 67.89 BET received net of a 0.30% fee is a 0.204 BET fee
     expect(screen.getByTestId('Swap fees')).toHaveTextContent('0.204 BET')
-    expect(screen.queryByText('Total')).not.toBeInTheDocument()
+    expect(screen.getByTestId('Total received')).toHaveTextContent('67.89 BET')
+  })
+
+  it('shows a zero swap fee and reconciles it with the total received', () => {
+    const swapTxInfo = {
+      ...mockTxInfo,
+      amount: 0,
+      boardingTxid: '',
+      assetSwap: {
+        fromAmount: BigInt(12_345),
+        fromAssetId: 'asset-alpha',
+        fromDecimals: 2,
+        fromTicker: 'ALP',
+        toAmount: BigInt(67_890),
+        toAssetId: 'asset-beta',
+        toDecimals: 3,
+        toTicker: 'BET',
+        feeBps: 0,
+        status: 'completed' as const,
+      },
+      roundTxid: 'fill-txid',
+      settled: true,
+      type: 'swap',
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <AspContext.Provider value={mockAspContextValue}>
+          <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo: swapTxInfo }}>
+            <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [swapTxInfo] }}>
+              <LimitsContext.Provider value={mockLimitsContextValue}>
+                <Transaction />
+              </LimitsContext.Provider>
+            </WalletContext.Provider>
+          </FlowContext.Provider>
+        </AspContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByTestId('Swap to')).toHaveTextContent('67.89 BET')
+    expect(screen.getByTestId('Swap fees')).toHaveTextContent('0 BET')
+    expect(screen.getByTestId('Total received')).toHaveTextContent('67.89 BET')
   })
 
   it('masks swap asset amounts when balances are hidden', () => {
@@ -549,9 +611,10 @@ describe('Transaction screen', () => {
       </NavigationContext.Provider>,
     )
 
-    expect(screen.getByTestId('From')).toHaveTextContent('········ ALP')
-    expect(screen.getByTestId('To')).toHaveTextContent('········ BET')
+    expect(screen.getByTestId('Swap from')).toHaveTextContent('········ ALP')
+    expect(screen.getByTestId('Swap to')).toHaveTextContent('········ BET')
     expect(screen.getByTestId('Swap fees')).toHaveTextContent('········ BET')
+    expect(screen.getByTestId('Total received')).toHaveTextContent('········ BET')
     expect(screen.queryByText('123.45 ALP')).not.toBeInTheDocument()
     expect(screen.queryByText('67.89 BET')).not.toBeInTheDocument()
     expect(screen.queryByText('0.204 BET')).not.toBeInTheDocument()
@@ -607,6 +670,8 @@ describe('Transaction screen', () => {
         ...mockTxInfo,
         amount: 330,
         assets: [{ assetId, amount: assetAmount }],
+        boardingTxid: '',
+        destination: type === 'sent' ? 'tark1destination' : undefined,
         type,
       }
       const walletContextValue = {
@@ -671,16 +736,25 @@ describe('Transaction screen', () => {
         </ConfigContext.Provider>,
       )
 
-      expect(screen.getByText(direction)).toBeInTheDocument()
+      expect(screen.getByText(`Amount ${direction.toLowerCase()}`)).toBeInTheDocument()
       expect(screen.getByTestId('primary-amount')).toHaveTextContent('$100.00')
       expect(screen.getByTestId('Asset amount')).toHaveTextContent(assetLabel)
       expect(screen.getByTestId('Value')).toHaveTextContent('$100.00')
-      expect(screen.queryByTestId('Total')).not.toBeInTheDocument()
+      expect(screen.getByTestId('Total')).toHaveTextContent(assetLabel)
+      expect(screen.getByTestId('Asset ID')).toHaveTextContent(/^f121ac9b765.*cb9791a0000$/)
+      expect(screen.queryByTestId('Direction')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('Type')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('When')).not.toBeInTheDocument()
+      if (type === 'sent') {
+        expect(screen.getByTestId('Destination')).toHaveTextContent('tark1destination')
+      } else {
+        expect(screen.queryByTestId('Destination')).not.toBeInTheDocument()
+      }
       expect(screen.queryByText('Tether USD')).not.toBeInTheDocument()
     },
   )
 
-  it('hides Amount and Total when a mixed asset cannot be valued as an account', () => {
+  it('shows each raw total and asset ID when a mixed asset cannot be valued as an account', () => {
     const txInfo = {
       ...mockTxInfo,
       amount: 330,
@@ -734,10 +808,13 @@ describe('Transaction screen', () => {
       </ConfigContext.Provider>,
     )
 
-    // master semantics: an asset transfer's dust must not read as a price,
-    // so Amount/Total are hidden when the asset can't be valued as an account
+    // The carrier dust must not read as a price, but each actual asset amount
+    // remains visible and independently identified.
     expect(screen.queryByTestId('Amount')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('Total')).not.toBeInTheDocument()
+    expect(screen.getByTestId('Total (USDT)')).toHaveTextContent('100 USDT')
+    expect(screen.getByTestId('Total (unknown-…)')).toHaveTextContent('0.0000005 unknown-…')
+    expect(screen.getByTestId('Asset ID (USDT, unverified)')).toHaveTextContent('usdt-asset')
+    expect(screen.getByTestId('Asset ID (unknown-…, unverified)')).toHaveTextContent('unknown-asset')
     expect(screen.queryByText('€100.00')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Stacked on

- Base PR: #784 — Add asset swap covenant-based atomic swaps
- Base branch: `claude/swap-ui-mutinynet-yktp51`
- This branch was verified to start exactly at PR #784 head commit `23b7d7aa`.

## Summary

Makes transaction receipts useful across bitcoin transfers, boarding, verified currencies, other verified assets, unverified assets, mixed-asset activity, asset issuance/reissue/burn, and swaps.

The receipt now keeps only relevant fields, always exposes network and swap fees including explicit zero values, shows totals in the actual asset units, labels unverified assets precisely, and preserves exact send/lifecycle metadata for future history entries.

Addresses #794.

## User-visible behavior

- Removes redundant `Direction` and relative `When` rows.
- Shows `Type` only when it provides real information, currently `Boarding`.
- Shows absolute transaction dates.
- Shows `Destination` for newly recorded sends.
- Shows network fees even when the value is zero.
- Shows totals for bitcoin and every transferred asset.
- Shows every non-bitcoin asset ID and marks only the exact unverified asset.
- Uses exact lifecycle headings: `Amount issued`, `Amount reissued`, and `Amount burned`.
- Shows swaps as `Swap from`, `Swap to`, funded/completed transaction IDs, price rate, network fees, swap fees, and total received.
- Shows swap fees even when they are `0`.

## Scope

- `src/components/Details.tsx` — supports multiple asset IDs/totals and clear swap row labels in the shared receipt table.
- `src/lib/asp.ts` — restores locally persisted receipt metadata into wallet history.
- `src/lib/storage.ts` — adds bounded transaction activity metadata persistence keyed by transaction ID.
- `src/lib/swapDisplay.ts` — calculates explicit zero swap fees and gross swap destination amounts while preserving net total received.
- `src/lib/types.ts` — adds destination, network-fee, and asset-action receipt metadata to `Tx`.
- `src/screens/Apps/Assets/Burn.tsx` — records the exact burn action.
- `src/screens/Apps/Assets/Mint.tsx` — records issued assets, including control-asset issuance.
- `src/screens/Apps/Assets/Reissue.tsx` — records the exact reissue action.
- `src/screens/Wallet/Send/Details.tsx` — records destination and actual network fee after a successful send.
- `src/screens/Wallet/Transaction.tsx` — applies the approved receipt field matrix across bitcoin, asset, lifecycle, mixed, and swap activity.
- `src/test/lib/asp.test.ts` — covers history metadata restoration.
- `src/test/lib/storage.test.ts` — covers metadata persistence and explicit zero network fees.
- `src/test/lib/swapDisplay.test.ts` — covers zero/nonzero swap-fee reconciliation.
- `src/test/screens/wallet/transaction.test.tsx` — covers all receipt categories, privacy masking, totals, IDs, and labels.

No files were added, moved, or deleted. No unrelated product behavior was changed.

## Verification

- Full unit suite: **506 passed, 3 skipped** across 64 test files.
- Focused transaction receipt suite: **19 passed**.
- ESLint: passed for every changed file.
- Prettier: passed for every changed file.
- Production build: passed.
- Browser verification: all receipt categories rendered from the real transaction component without application console warnings or errors.
- Build emitted only existing Node engine, dynamic-import, and large-chunk warnings.

## Compatibility note

Transactions created before this metadata existed cannot retroactively recover a destination or distinguish old issue/reissue/burn actions when the wallet history itself does not expose those facts.

## Visual proof

The screenshots below cover bitcoin sent/received/boarding, verified currency, other verified asset, unverified asset, mixed assets, issue/reissue/burn, and swaps with zero and nonzero fees.

<img width="1280" height="784" alt="proof-bitcoin-sent" src="https://github.com/user-attachments/assets/3ef6c368-916e-42d2-8d88-185a80c4c9a9" />
<img width="1280" height="784" alt="proof-bitcoin-received" src="https://github.com/user-attachments/assets/e8ead303-c737-4fd3-b4cd-0c867daa4935" />
<img width="1280" height="784" alt="proof-bitcoin-boarding" src="https://github.com/user-attachments/assets/4680d10d-207b-4252-aed7-c60301c0395c" />
<img width="1280" height="784" alt="proof-verified-currency" src="https://github.com/user-attachments/assets/a074c664-3cde-4912-a536-28b18b3e7c7c" />
<img width="1280" height="784" alt="proof-verified-asset" src="https://github.com/user-attachments/assets/24f2a133-3ce4-4239-b99e-ef0e8d270e37" />
<img width="1280" height="784" alt="proof-unverified-asset" src="https://github.com/user-attachments/assets/96a309ce-2406-4c2a-8187-0c7c9e2a1e63" />
<img width="1280" height="784" alt="proof-mixed" src="https://github.com/user-attachments/assets/8d83e904-9b59-4d64-b5b8-42eafc034ed0" />
<img width="1280" height="784" alt="proof-issued" src="https://github.com/user-attachments/assets/d9118e1a-860a-47c8-86b2-e5d74edb5918" />
<img width="1280" height="784" alt="proof-reissued" src="https://github.com/user-attachments/assets/a40dcf49-cb58-41ec-bbe8-e9455903c436" />
<img width="1280" height="784" alt="proof-burned" src="https://github.com/user-attachments/assets/0280f4be-a0b7-4453-9f1e-457492fd4178" />
<img width="1280" height="720" alt="proof-swap-zero-fee-final" src="https://github.com/user-attachments/assets/73372a00-951d-4c53-8518-d04a5d68631d" />
<img width="1280" height="720" alt="proof-swap-with-fee-final" src="https://github.com/user-attachments/assets/463d438e-c293-4564-bcef-34c5e7736120" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction receipts now show asset IDs, per-asset totals, destinations, network fees, and clearer swap details.
  * Asset issuance, reissuance, and burn activity is reflected in transaction history.
  * Transaction metadata is preserved for later receipt display.

* **Bug Fixes**
  * Corrected swap fee and pre-fee amount calculations, including zero-fee swaps.
  * Improved receipt labeling for sent, received, issued, reissued, and burned assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->