### PR TITLE
Add manual solver registration in Settings (card.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
-    "@arkade-os/solver-discovery": "0.1.4",
+    "@arkade-os/solver-discovery": "0.1.5",
     "@arkade-os/boltz-swap": "0.3.57",
     "@arkade-os/sdk": "0.4.52",
     "@base-ui/react": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: 0.4.52
         version: 0.4.52
       '@arkade-os/solver-discovery':
-        specifier: 0.1.4
-        version: 0.1.4
+        specifier: 0.1.5
+        version: 0.1.5
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.26)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -285,8 +285,8 @@ packages:
       expo-task-manager:
         optional: true
 
-  '@arkade-os/solver-discovery@0.1.4':
-    resolution: {integrity: sha512-xksH+DerDgmsLhXtWka6j9/Y3Giy/70THEPkRaVOhrHxSHg2OjutzcLFHHTuqKFZvVsOVIDqU6eQKk9ZMrebPg==}
+  '@arkade-os/solver-discovery@0.1.5':
+    resolution: {integrity: sha512-GMcwsuzSPXXAfhThRVe/ab/iKS2DTIVjpMtnrrGGvp0kS98Unkr8C+EVSjjBLv8zcTIsKvh8huhT7oGTSjh8Ig==}
     engines: {node: '>=18'}
 
   '@asamuzakjp/css-color@3.2.0':
@@ -4384,7 +4384,7 @@ snapshots:
       - ecpair
       - utf-8-validate
 
-  '@arkade-os/solver-discovery@0.1.4': {}
+  '@arkade-os/solver-discovery@0.1.5': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:

--- a/src/lib/logs.ts
+++ b/src/lib/logs.ts
@@ -24,19 +24,25 @@ export const getInfoLogs = (): LogLine[] => getLogs().filter((l) => l.level === 
 export const clearLogs = () => localStorage.removeItem(itemName)
 
 const addLog = (level: LogLevel, args: string[]) => {
-  const logs = getLogs()
-  logs.push({
-    level,
-    msg: args.join(' '),
-    time: new Date().toString(),
-  })
+  try {
+    const logs = getLogs()
+    logs.push({
+      level,
+      msg: args.join(' '),
+      time: new Date().toString(),
+    })
 
-  // Remove oldest logs if we exceed the limit
-  if (logs.length > MAX_LOGS) {
-    logs.splice(0, logs.length - MAX_LOGS)
+    // Remove oldest logs if we exceed the limit
+    if (logs.length > MAX_LOGS) {
+      logs.splice(0, logs.length - MAX_LOGS)
+    }
+
+    localStorage.setItem(itemName, JSON.stringify(logs))
+  } catch {
+    // persisting is best effort: a full or corrupt log store must never make
+    // the logger itself throw and mask the very error being reported — the
+    // console output in the callers below still lands
   }
-
-  localStorage.setItem(itemName, JSON.stringify(logs))
 }
 
 export const consoleLog = (...args: any[]) => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -27,12 +27,15 @@ const setStorageItem = (key: string, value: string): void => {
 }
 
 /** For non-critical persistence where a failed write (quota, private mode)
- * should degrade silently rather than fail the caller. */
-export const setStorageItemSafely = (key: string, value: string, context: string): void => {
+ * should degrade gracefully rather than throw at the caller. Returns whether
+ * the write landed, for callers that must not report a phantom success. */
+export const setStorageItemSafely = (key: string, value: string, context: string): boolean => {
   try {
     setStorageItem(key, value)
+    return true
   } catch (err) {
     consoleError(err, context)
+    return false
   }
 }
 

--- a/src/lib/swap/markets.ts
+++ b/src/lib/swap/markets.ts
@@ -4,13 +4,14 @@ import {
   isNetwork,
   stableStringify,
   type DiscoveredMarket,
+  type Network as SolverNetwork,
   type OfferPlan,
   type Side,
 } from '@arkade-os/solver-discovery'
 import { getSolverRegistryUrl } from '../constants'
 import { consoleLog } from '../logs'
 import { getStorageItem } from '../storage'
-import { getPinnedSolverCards } from './solverCards'
+import { getPinnedSolverCards, type PinnedSolverCard } from './solverCards'
 import { Network } from '@arkade-os/boltz-swap'
 
 export const BTC_ASSET_ID = 'btc'
@@ -87,13 +88,18 @@ const writeMarketsCache = (network: Network, registry: string, markets: Discover
 /** Markets from the user's pinned solver cards (Settings > Solvers). Purely
  * local — with no registries, discover() only schema-validates the cards, so
  * a card that turned invalid in storage is skipped with a warning instead of
- * breaking discovery. */
-const discoverLocalMarkets = async (network: Network): Promise<DiscoveredMarket[]> => {
-  if (!isNetwork(network)) return []
-  const localCards = getPinnedSolverCards(network).map(({ card }) => ({ card, network }))
-  if (localCards.length === 0) return []
+ * breaking discovery. Memoized on the pinned list's identity (stable while
+ * storage is unchanged), so calls between pins — every mount, tab return and
+ * refresh — skip re-validating cards that did not change. */
+let localMarketsCache: { pinned: PinnedSolverCard[]; markets: DiscoveredMarket[] } | undefined
+const discoverLocalMarkets = async (network: SolverNetwork): Promise<DiscoveredMarket[]> => {
+  const pinned = getPinnedSolverCards(network)
+  if (pinned.length === 0) return []
+  if (localMarketsCache?.pinned === pinned) return localMarketsCache.markets
+  const localCards = pinned.map(({ card }) => ({ card, network }))
   const { markets, warnings } = await discover({ registries: [], localCards, network })
   if (warnings.length) consoleLog('solver discovery (pinned cards):', ...warnings)
+  localMarketsCache = { pinned, markets }
   return markets
 }
 
@@ -123,10 +129,14 @@ const mergeMarkets = (registryMarkets: DiscoveredMarket[], localMarkets: Discove
     seen.add(key)
     merged.push(market)
   }
-  const withKey = merged.map((market) => ({ market, key: `${market.base_asset.id}/${market.quote_asset.id}` }))
+  const pairKey = (market: DiscoveredMarket) => `${market.base_asset.id}/${market.quote_asset.id}`
   // stable sort, so equal (pair, fee) keys keep registry-first input order
-  withKey.sort((a, b) => (a.key !== b.key ? (a.key < b.key ? -1 : 1) : a.market.fee_bps - b.market.fee_bps))
-  return withKey.map(({ market }) => market)
+  merged.sort((a, b) => {
+    const keyA = pairKey(a)
+    const keyB = pairKey(b)
+    return keyA !== keyB ? (keyA < keyB ? -1 : 1) : a.fee_bps - b.fee_bps
+  })
+  return merged
 }
 
 /**

--- a/src/lib/swap/markets.ts
+++ b/src/lib/swap/markets.ts
@@ -9,6 +9,7 @@ import {
 import { getSolverRegistryUrl } from '../constants'
 import { consoleLog } from '../logs'
 import { getStorageItem } from '../storage'
+import { getPinnedSolverCards } from './solverCards'
 import { Network } from '@arkade-os/boltz-swap'
 
 export const BTC_ASSET_ID = 'btc'
@@ -82,24 +83,81 @@ const writeMarketsCache = (network: Network, registry: string, markets: Discover
   }
 }
 
+/** Markets from the user's pinned solver cards (Settings > Solvers). Purely
+ * local — with no registries, discover() only schema-validates the cards, so
+ * a card that turned invalid in storage is skipped with a warning instead of
+ * breaking discovery. */
+const discoverLocalMarkets = async (network: Network): Promise<DiscoveredMarket[]> => {
+  if (!isNetwork(network)) return []
+  const localCards = getPinnedSolverCards(network).map(({ card }) => ({ card, network }))
+  if (localCards.length === 0) return []
+  const { markets, warnings } = await discover({ registries: [], localCards, network })
+  if (warnings.length) consoleLog('solver discovery (pinned cards):', ...warnings)
+  return markets
+}
+
+/** Canonical JSON (sorted keys, no whitespace) — the identity discover() uses
+ * to dedupe across sources; the SDK does not export its stableStringify. */
+const sortedStringify = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(sortedStringify).join(',')}]`
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([k, v]) => `${JSON.stringify(k)}:${sortedStringify(v)}`)
+  return `{${entries.join(',')}}`
+}
+
+// dedupe on the market fields alone: provenance differs by construction
+// (registry URL vs local:<name>), the listing is what must not double up —
+// undefined-valued keys are dropped by sortedStringify
+const marketIdentity = (market: DiscoveredMarket): string =>
+  sortedStringify({ ...market, source: undefined, sourceType: undefined })
+
+/** Merge registry and pinned-card markets the way a single discover() call
+ * would: byte-identical entries collapse (a pinned solver that is also listed
+ * publicly), then rank per id pair by fee_bps with input order — registry
+ * first — as the tiebreak. Needed because registry markets may come from the
+ * cache while pinned cards are always read live. */
+const mergeMarkets = (registryMarkets: DiscoveredMarket[], localMarkets: DiscoveredMarket[]): DiscoveredMarket[] => {
+  if (localMarkets.length === 0) return registryMarkets
+  const seen = new Set(registryMarkets.map(marketIdentity))
+  const merged = [...registryMarkets]
+  for (const market of localMarkets) {
+    const key = marketIdentity(market)
+    if (seen.has(key)) continue
+    seen.add(key)
+    merged.push(market)
+  }
+  const withKey = merged.map((market) => ({ market, key: `${market.base_asset.id}/${market.quote_asset.id}` }))
+  // stable sort, so equal (pair, fee) keys keep registry-first input order
+  withKey.sort((a, b) => (a.key !== b.key ? (a.key < b.key ? -1 : 1) : a.market.fee_bps - b.market.fee_bps))
+  return withKey.map(({ market }) => market)
+}
+
 /**
- * Markets from the network's solver registry; [] when none is configured.
- * Registry content changes rarely, so results are cached for an hour and a
- * stale cache backstops an unreachable registry (quotes stay live either way).
+ * Markets from the network's solver registry plus the user's pinned solver
+ * cards; [] when neither is configured. Registry content changes rarely, so
+ * registry results are cached for an hour and a stale cache backstops an
+ * unreachable registry (quotes stay live either way). Pinned cards live in
+ * local storage and are merged fresh on every call, so pinning or removing a
+ * solver takes effect without waiting out the registry cache.
  */
 export const discoverMarkets = async (network: Network): Promise<DiscoveredMarket[]> => {
+  if (!isNetwork(network)) return []
   const registry = getSolverRegistryUrl(network)
-  if (!registry || !isNetwork(network)) return []
+  const localMarkets = await discoverLocalMarkets(network)
+  if (!registry) return localMarkets
   const cached = readMarketsCache(network, registry)
-  if (cached && Date.now() - cached.fetchedAt < MARKETS_CACHE_TTL_MS) return cached.markets
+  if (cached && Date.now() - cached.fetchedAt < MARKETS_CACHE_TTL_MS) return mergeMarkets(cached.markets, localMarkets)
   const { markets, sources, warnings } = await discover({ registries: [registry], network })
   if (warnings.length) consoleLog('solver discovery:', ...warnings)
   // an unreachable registry (fetch/validation failure) falls back to the stale
   // cache; a reachable registry is authoritative even when it emptied out
   const reachable = sources.some((source) => source.ok)
-  if (!reachable && cached) return cached.markets
+  if (!reachable && cached) return mergeMarkets(cached.markets, localMarkets)
   if (reachable) writeMarketsCache(network, registry, markets)
-  return markets
+  return mergeMarkets(markets, localMarkets)
 }
 
 /** Best market for a from/to pair, in either orientation. `give` is the side

--- a/src/lib/swap/markets.ts
+++ b/src/lib/swap/markets.ts
@@ -2,6 +2,7 @@ import {
   bestMarket,
   discover,
   isNetwork,
+  stableStringify,
   type DiscoveredMarket,
   type OfferPlan,
   type Side,
@@ -97,22 +98,15 @@ const discoverLocalMarkets = async (network: Network): Promise<DiscoveredMarket[
 }
 
 /** Canonical JSON (sorted keys, no whitespace) — the identity discover() uses
- * to dedupe across sources; the SDK does not export its stableStringify. */
-const sortedStringify = (value: unknown): string => {
-  if (value === null || typeof value !== 'object') return JSON.stringify(value)
-  if (Array.isArray(value)) return `[${value.map(sortedStringify).join(',')}]`
-  const entries = Object.entries(value as Record<string, unknown>)
-    .filter(([, v]) => v !== undefined)
-    .sort(([a], [b]) => (a < b ? -1 : 1))
-    .map(([k, v]) => `${JSON.stringify(k)}:${sortedStringify(v)}`)
-  return `{${entries.join(',')}}`
+ * to dedupe across sources: provenance differs by construction (registry URL
+ * vs local:<name>), the listing is what must not double up. Keys are really
+ * deleted so the string matches what discover() hashes pre-provenance. */
+const marketIdentity = (market: DiscoveredMarket): string => {
+  const listing = { ...market } as Partial<DiscoveredMarket>
+  delete listing.source
+  delete listing.sourceType
+  return stableStringify(listing)
 }
-
-// dedupe on the market fields alone: provenance differs by construction
-// (registry URL vs local:<name>), the listing is what must not double up —
-// undefined-valued keys are dropped by sortedStringify
-const marketIdentity = (market: DiscoveredMarket): string =>
-  sortedStringify({ ...market, source: undefined, sourceType: undefined })
 
 /** Merge registry and pinned-card markets the way a single discover() call
  * would: byte-identical entries collapse (a pinned solver that is also listed

--- a/src/lib/swap/markets.ts
+++ b/src/lib/swap/markets.ts
@@ -10,7 +10,8 @@ import {
 } from '@arkade-os/solver-discovery'
 import { getSolverRegistryUrl } from '../constants'
 import { consoleLog } from '../logs'
-import { getStorageItem } from '../storage'
+import { getStorageItem, setStorageItemSafely } from '../storage'
+import { isValidUrl } from '../validators'
 import { getPinnedSolverCards, type PinnedSolverCard } from './solverCards'
 import { Network } from '@arkade-os/boltz-swap'
 
@@ -52,9 +53,54 @@ interface MarketsCacheEntry {
   fetchedAt: number
 }
 
-// keyed by network AND registry so a redeployed registry override never
-// serves markets cached from a different registry
+// keyed by network AND the followed registry set, so a redeployed registry
+// override — or a user adding/removing a registry — never serves markets
+// cached from a different set
 const cacheKey = (network: Network, registry: string) => `${MARKETS_CACHE_KEY}-${network}-${registry}`
+
+/** Drop every cached market set for `network`; the next discovery refetches
+ * from the followed registries. */
+export const clearMarketsCache = (network: Network): void => {
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith(`${MARKETS_CACHE_KEY}-${network}-`)) localStorage.removeItem(key)
+  }
+}
+
+const USER_REGISTRIES_KEY = 'solverRegistries'
+
+const readUserRegistries = (): Record<string, string[]> =>
+  getStorageItem<Record<string, string[]>>(USER_REGISTRIES_KEY, {}, (blob) => {
+    const parsed = JSON.parse(blob)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('malformed registries')
+    return parsed
+  })
+
+const writeUserRegistries = (all: Record<string, string[]>): boolean =>
+  setStorageItemSafely(USER_REGISTRIES_KEY, JSON.stringify(all), 'Failed to save solver registries')
+
+/** Extra registry indexes the user follows (Settings > Solvers), per network. */
+export const getUserRegistries = (network: Network): string[] =>
+  (readUserRegistries()[network] ?? []).filter((url) => typeof url === 'string')
+
+/** Follow another registry index for `network` — its markets join discovery,
+ * deduped and ranked against the default registry's by the SDK. Returns an
+ * error message, or undefined on success. */
+export const addUserRegistry = (network: Network, url: string): string | undefined => {
+  if (!url || !isValidUrl(url)) return 'not a valid registry URL'
+  const normalized = /^https?:\/\//.test(url) ? url : `https://${url}`
+  if (normalized === getSolverRegistryUrl(network)) return 'that is the default registry'
+  const all = readUserRegistries()
+  const list = all[network] ?? []
+  if (list.includes(normalized)) return 'registry already followed'
+  if (!writeUserRegistries({ ...all, [network]: [...list, normalized] })) {
+    return 'could not save the registry — storage is full or unavailable'
+  }
+}
+
+export const removeUserRegistry = (network: Network, url: string): void => {
+  const all = readUserRegistries()
+  writeUserRegistries({ ...all, [network]: (all[network] ?? []).filter((stored) => stored !== url) })
+}
 
 const isMarketShaped = (m: unknown): boolean => {
   const market = m as DiscoveredMarket | null
@@ -140,27 +186,34 @@ const mergeMarkets = (registryMarkets: DiscoveredMarket[], localMarkets: Discove
 }
 
 /**
- * Markets from the network's solver registry plus the user's pinned solver
- * cards; [] when neither is configured. Registry content changes rarely, so
- * registry results are cached for an hour and a stale cache backstops an
- * unreachable registry (quotes stay live either way). Pinned cards live in
- * local storage and are merged fresh on every call, so pinning or removing a
- * solver takes effect without waiting out the registry cache.
+ * Markets from the network's default solver registry, any registries the user
+ * follows, and the user's pinned solver cards; [] when none is configured.
+ * Registry content changes rarely, so registry results are cached for an hour
+ * and a stale cache backstops an unreachable registry (quotes stay live
+ * either way). Pinned cards live in local storage and are merged fresh on
+ * every call, so pinning or removing a solver takes effect without waiting
+ * out the registry cache.
  */
 export const discoverMarkets = async (network: Network): Promise<DiscoveredMarket[]> => {
   if (!isNetwork(network)) return []
-  const registry = getSolverRegistryUrl(network)
+  const builtin = getSolverRegistryUrl(network)
+  const registries = [...(builtin ? [builtin] : []), ...getUserRegistries(network)]
   const localMarkets = await discoverLocalMarkets(network)
-  if (!registry) return localMarkets
-  const cached = readMarketsCache(network, registry)
+  if (registries.length === 0) return localMarkets
+  const registrySet = registries.join(' ')
+  const cached = readMarketsCache(network, registrySet)
   if (cached && Date.now() - cached.fetchedAt < MARKETS_CACHE_TTL_MS) return mergeMarkets(cached.markets, localMarkets)
-  const { markets, sources, warnings } = await discover({ registries: [registry], network })
+  const { markets, sources, warnings } = await discover({ registries, network })
   if (warnings.length) consoleLog('solver discovery:', ...warnings)
-  // an unreachable registry (fetch/validation failure) falls back to the stale
-  // cache; a reachable registry is authoritative even when it emptied out
+  // an unreachable registry set (every source failing) falls back to the
+  // stale cache; any reachable registry is authoritative even when it
+  // emptied out.
+  // ponytail: reachability is per set, so markets from a temporarily
+  // unreachable secondary registry drop out until it recovers; add
+  // per-registry stale-merge if that ever bites
   const reachable = sources.some((source) => source.ok)
   if (!reachable && cached) return mergeMarkets(cached.markets, localMarkets)
-  if (reachable) writeMarketsCache(network, registry, markets)
+  if (reachable) writeMarketsCache(network, registrySet, markets)
   return mergeMarkets(markets, localMarkets)
 }
 

--- a/src/lib/swap/solverCards.ts
+++ b/src/lib/swap/solverCards.ts
@@ -1,6 +1,5 @@
 import { isNetwork, validateCard, type Card, type Network } from '@arkade-os/solver-discovery'
-import { consoleError } from '../logs'
-import { getStorageItem } from '../storage'
+import { getStorageItem, setStorageItemSafely } from '../storage'
 
 /** A solver card the user pinned by hand: solver operators who prefer not to
  * list in the public registry hand their card.json to users directly, and the
@@ -36,31 +35,38 @@ const isPinnedShaped = (entry: unknown): entry is PinnedSolverCard => {
 // unshaped entries are dropped rather than failing the read: one hand-edited
 // blob must not take every pinned solver down with it. Full schema validation
 // happens again at discovery time, where a bad card is skipped with a warning.
-const readAll = (): PinnedSolverCard[] =>
-  getStorageItem<PinnedSolverCard[]>(PINNED_CARDS_KEY, [], (blob) => {
-    const entries = JSON.parse(blob)
-    if (!Array.isArray(entries)) throw new Error('malformed pinned cards')
-    return entries.filter(isPinnedShaped)
-  })
-
-// a failed write (quota, private mode) must reach the caller: reporting a pin
-// as saved while storage rejected it would leave a phantom solver in the UI
-const writeAll = (entries: PinnedSolverCard[]): boolean => {
+const parseEntries = (blob: string | null): PinnedSolverCard[] => {
+  if (blob === null) return []
   try {
-    localStorage.setItem(PINNED_CARDS_KEY, JSON.stringify(entries))
-    return true
-  } catch (err) {
-    try {
-      consoleError(err, 'Failed to save pinned solver cards')
-    } catch {
-      // the log writer persists to the same full localStorage
-    }
-    return false
+    const entries = JSON.parse(blob)
+    return Array.isArray(entries) ? entries.filter(isPinnedShaped) : []
+  } catch {
+    return []
   }
 }
 
-export const getPinnedSolverCards = (network: Network): PinnedSolverCard[] =>
-  readAll().filter((pinned) => pinned.network === network)
+const readBlob = (): string | null => getStorageItem<string | null>(PINNED_CARDS_KEY, null, (blob) => blob)
+
+const readAll = (): PinnedSolverCard[] => parseEntries(readBlob())
+
+// a failed write (quota, private mode) must reach the caller: reporting a pin
+// as saved while storage rejected it would leave a phantom solver in the UI
+const writeAll = (entries: PinnedSolverCard[]): boolean =>
+  setStorageItemSafely(PINNED_CARDS_KEY, JSON.stringify(entries), 'Failed to save pinned solver cards')
+
+// single-entry memo: discovery re-reads the pinned list on every call (mount,
+// tab return, refresh), so an unchanged blob should cost a string compare, not
+// a re-parse — and the stable array identity lets discovery skip re-validating
+// cards that did not change
+let readCache: { blob: string | null; network: Network; cards: PinnedSolverCard[] } | undefined
+
+export const getPinnedSolverCards = (network: Network): PinnedSolverCard[] => {
+  const blob = readBlob()
+  if (readCache && readCache.blob === blob && readCache.network === network) return readCache.cards
+  const cards = parseEntries(blob).filter((pinned) => pinned.network === network)
+  readCache = { blob, network, cards }
+  return cards
+}
 
 export type PinSolverCardResult = { ok: true; card: Card } | { ok: false; errors: string[] }
 

--- a/src/lib/swap/solverCards.ts
+++ b/src/lib/swap/solverCards.ts
@@ -1,0 +1,62 @@
+import { validateCard, type Card } from '@arkade-os/solver-discovery'
+import { Network } from '@arkade-os/boltz-swap'
+import { getStorageItem, setStorageItemSafely } from '../storage'
+
+/** A solver card the user pinned by hand: solver operators who prefer not to
+ * list in the public registry hand their card.json to users directly, and the
+ * user pastes it in Settings > Solvers (#828). */
+export interface PinnedSolverCard {
+  /** Network the user pinned the card for — cards do not carry one themselves. */
+  network: Network
+  /** The schema-validated card, exactly as the solver published it. */
+  card: Card
+  /** Pin time, for display and stable list ordering. */
+  addedAt: number
+}
+
+const PINNED_CARDS_KEY = 'pinnedSolverCards'
+
+const isPinnedShaped = (entry: unknown): entry is PinnedSolverCard => {
+  const pinned = entry as PinnedSolverCard | null
+  return Boolean(
+    pinned &&
+      typeof pinned.network === 'string' &&
+      typeof pinned.addedAt === 'number' &&
+      pinned.card &&
+      typeof pinned.card.name === 'string' &&
+      Array.isArray(pinned.card.markets),
+  )
+}
+
+// unshaped entries are dropped rather than failing the read: one hand-edited
+// blob must not take every pinned solver down with it. Full schema validation
+// happens again at discovery time, where a bad card is skipped with a warning.
+const readAll = (): PinnedSolverCard[] =>
+  getStorageItem<PinnedSolverCard[]>(PINNED_CARDS_KEY, [], (blob) => {
+    const entries = JSON.parse(blob)
+    if (!Array.isArray(entries)) throw new Error('malformed pinned cards')
+    return entries.filter(isPinnedShaped)
+  })
+
+const writeAll = (entries: PinnedSolverCard[]): void =>
+  setStorageItemSafely(PINNED_CARDS_KEY, JSON.stringify(entries), 'Failed to save pinned solver cards')
+
+export const getPinnedSolverCards = (network: Network): PinnedSolverCard[] =>
+  readAll().filter((pinned) => pinned.network === network)
+
+export type PinSolverCardResult = { ok: true; card: Card } | { ok: false; errors: string[] }
+
+/** Validate and pin a pasted card.json for `network`. Card name is the solver
+ * identity, so re-pinning the same name replaces the previous version (the
+ * normal way to take a solver's updated card). */
+export const pinSolverCard = (network: Network, input: unknown): PinSolverCardResult => {
+  const result = validateCard(input)
+  if (!result.ok || !result.value) return { ok: false, errors: result.errors }
+  const card = result.value
+  const others = readAll().filter((pinned) => !(pinned.network === network && pinned.card.name === card.name))
+  writeAll([...others, { network, card, addedAt: Date.now() }])
+  return { ok: true, card }
+}
+
+export const unpinSolverCard = (network: Network, name: string): void =>
+  writeAll(readAll().filter((pinned) => !(pinned.network === network && pinned.card.name === name)))

--- a/src/lib/swap/solverCards.ts
+++ b/src/lib/swap/solverCards.ts
@@ -96,3 +96,7 @@ export const pinSolverCard = (network: Network, input: unknown): PinSolverCardRe
 export const unpinSolverCard = (network: Network, name: string): void => {
   writeAll(readAll().filter((pinned) => !(pinned.network === network && pinned.card.name === name)))
 }
+
+export const unpinAllSolverCards = (network: Network): void => {
+  writeAll(readAll().filter((pinned) => pinned.network !== network))
+}

--- a/src/lib/swap/solverCards.ts
+++ b/src/lib/swap/solverCards.ts
@@ -1,6 +1,6 @@
-import { validateCard, type Card } from '@arkade-os/solver-discovery'
-import { Network } from '@arkade-os/boltz-swap'
-import { getStorageItem, setStorageItemSafely } from '../storage'
+import { isNetwork, validateCard, type Card, type Network } from '@arkade-os/solver-discovery'
+import { consoleError } from '../logs'
+import { getStorageItem } from '../storage'
 
 /** A solver card the user pinned by hand: solver operators who prefer not to
  * list in the public registry hand their card.json to users directly, and the
@@ -15,6 +15,11 @@ export interface PinnedSolverCard {
 }
 
 const PINNED_CARDS_KEY = 'pinnedSolverCards'
+
+/** Caps so pasted cards cannot crowd out the wallet's own persistence in the
+ * ~5 MB localStorage budget: real cards are a few KB with a handful of markets. */
+export const MAX_PINNED_CARDS_PER_NETWORK = 10
+export const MAX_CARD_JSON_BYTES = 64 * 1024
 
 const isPinnedShaped = (entry: unknown): entry is PinnedSolverCard => {
   const pinned = entry as PinnedSolverCard | null
@@ -38,8 +43,21 @@ const readAll = (): PinnedSolverCard[] =>
     return entries.filter(isPinnedShaped)
   })
 
-const writeAll = (entries: PinnedSolverCard[]): void =>
-  setStorageItemSafely(PINNED_CARDS_KEY, JSON.stringify(entries), 'Failed to save pinned solver cards')
+// a failed write (quota, private mode) must reach the caller: reporting a pin
+// as saved while storage rejected it would leave a phantom solver in the UI
+const writeAll = (entries: PinnedSolverCard[]): boolean => {
+  try {
+    localStorage.setItem(PINNED_CARDS_KEY, JSON.stringify(entries))
+    return true
+  } catch (err) {
+    try {
+      consoleError(err, 'Failed to save pinned solver cards')
+    } catch {
+      // the log writer persists to the same full localStorage
+    }
+    return false
+  }
+}
 
 export const getPinnedSolverCards = (network: Network): PinnedSolverCard[] =>
   readAll().filter((pinned) => pinned.network === network)
@@ -50,13 +68,25 @@ export type PinSolverCardResult = { ok: true; card: Card } | { ok: false; errors
  * identity, so re-pinning the same name replaces the previous version (the
  * normal way to take a solver's updated card). */
 export const pinSolverCard = (network: Network, input: unknown): PinSolverCardResult => {
+  // defense in depth for untyped callers: discovery ignores cards pinned
+  // under a network the SDK does not know, so refuse to persist them at all
+  if (!isNetwork(network)) return { ok: false, errors: [`solver cards are not supported on network "${network}"`] }
   const result = validateCard(input)
   if (!result.ok || !result.value) return { ok: false, errors: result.errors }
   const card = result.value
+  if (JSON.stringify(card).length > MAX_CARD_JSON_BYTES) {
+    return { ok: false, errors: [`card is too large (max ${MAX_CARD_JSON_BYTES / 1024} KB)`] }
+  }
   const others = readAll().filter((pinned) => !(pinned.network === network && pinned.card.name === card.name))
-  writeAll([...others, { network, card, addedAt: Date.now() }])
+  if (others.filter((pinned) => pinned.network === network).length >= MAX_PINNED_CARDS_PER_NETWORK) {
+    return { ok: false, errors: [`at most ${MAX_PINNED_CARDS_PER_NETWORK} solvers can be pinned — remove one first`] }
+  }
+  if (!writeAll([...others, { network, card, addedAt: Date.now() }])) {
+    return { ok: false, errors: ['could not save the card — storage is full or unavailable'] }
+  }
   return { ok: true, card }
 }
 
-export const unpinSolverCard = (network: Network, name: string): void =>
+export const unpinSolverCard = (network: Network, name: string): void => {
   writeAll(readAll().filter((pinned) => !(pinned.network === network && pinned.card.name === name)))
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,6 +80,7 @@ export enum SettingsOptions {
   Password = 'change password',
   Reset = 'reset wallet',
   Server = 'server',
+  Solvers = 'solvers',
   Support = 'support',
   Theme = 'theme',
   Vtxos = 'coin control',

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -19,8 +19,10 @@ const STREAM_RETRY_MS = 5_000
 const SAFETY_RECONCILE_MS = 60_000
 
 interface AssetSwapsContextProps {
-  /** Markets from the network's solver registry. */
+  /** Markets from the network's solver registry and the user's pinned cards. */
   markets: DiscoveredMarket[]
+  /** Re-runs discovery now — call after pinning/removing a solver card. */
+  refreshMarkets: () => void
   /** True when there are markets and the covenant co-signer is reachable. */
   swapAvailable: boolean
   swaps: AssetSwap[]
@@ -30,6 +32,7 @@ interface AssetSwapsContextProps {
 
 export const AssetSwapsContext = createContext<AssetSwapsContextProps>({
   markets: [],
+  refreshMarkets: () => {},
   swapAvailable: false,
   swaps: [],
   createSwap: async () => {
@@ -45,13 +48,18 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   const { dataReady, svcWallet, reloadWallet, txs } = useContext(WalletContext)
 
   const [markets, setMarkets] = useState<DiscoveredMarket[]>([])
+  const [marketsNonce, setMarketsNonce] = useState(0)
   const [emulatorUrl, setEmulatorUrl] = useState<string>()
   const [swaps, setSwaps] = useState<AssetSwap[]>(getAssetSwaps)
 
-  // discover markets and probe the emulator once the network is known, and
-  // again on every tab return (discoverMarkets' TTL cache is the rate
-  // limiter); stale results from a previous network must never land after a
-  // switch
+  // pinned solver cards bypass the registry cache, so re-running discovery is
+  // enough for a pin/remove in Settings to land immediately
+  const refreshMarkets = () => setMarketsNonce((nonce) => nonce + 1)
+
+  // discover markets and probe the emulator once the network is known, again
+  // on every tab return (discoverMarkets' TTL cache is the rate limiter), and
+  // on demand via refreshMarkets; stale results from a previous network must
+  // never land after a switch
   useEffect(() => {
     setMarkets([])
     setEmulatorUrl(undefined)
@@ -83,7 +91,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
       cancelled = true
       document.removeEventListener('visibilitychange', onVisible)
     }
-  }, [aspInfo.network])
+  }, [aspInfo.network, marketsNonce])
 
   // After a restore the swap store is empty while the funding/fill txs are
   // back in history, so swaps would show as bare sent/received rows. Scan the
@@ -361,7 +369,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
 
   const swapAvailable = markets.length > 0 && Boolean(emulatorUrl)
   const value = useMemo(
-    () => ({ markets, swapAvailable, swaps, createSwap, cancelSwap }),
+    () => ({ markets, refreshMarkets, swapAvailable, swaps, createSwap, cancelSwap }),
     // createSwap/cancelSwap close over these
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [markets, swapAvailable, swaps, svcWallet, emulatorUrl, aspInfo.url],

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -56,13 +56,19 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   // enough for a pin/remove in Settings to land immediately
   const refreshMarkets = () => setMarketsNonce((nonce) => nonce + 1)
 
-  // discover markets and probe the emulator once the network is known, again
-  // on every tab return (discoverMarkets' TTL cache is the rate limiter), and
-  // on demand via refreshMarkets; stale results from a previous network must
-  // never land after a switch
+  // stale results from a previous network must never land after a switch;
+  // keyed on the network alone so a nonce-driven refresh keeps the last good
+  // markets and verified emulator (a pin/remove invalidates neither, and one
+  // failed re-probe must not flip swapAvailable off mid-session)
   useEffect(() => {
     setMarkets([])
     setEmulatorUrl(undefined)
+  }, [aspInfo.network])
+
+  // discover markets and probe the emulator once the network is known, again
+  // on every tab return (discoverMarkets' TTL cache is the rate limiter), and
+  // on demand via refreshMarkets
+  useEffect(() => {
     if (!aspInfo.network) return
     let cancelled = false
     const network = aspInfo.network as Network

--- a/src/providers/options.tsx
+++ b/src/providers/options.tsx
@@ -66,6 +66,11 @@ export const options: Option[] = [
     section: SettingsSections.Advanced,
   },
   {
+    icon: <SwapIcon />,
+    option: SettingsOptions.Solvers,
+    section: SettingsSections.Advanced,
+  },
+  {
     icon: <CurrencyIcon />,
     option: SettingsOptions.Currency,
     section: SettingsSections.General,

--- a/src/screens/Settings/Index.tsx
+++ b/src/screens/Settings/Index.tsx
@@ -7,6 +7,7 @@ import About from './About'
 import Vtxos from './Vtxos'
 import NotesForm from '../Wallet/Notes/Form'
 import Server from './Server'
+import Solvers from './Solvers'
 import Support from './Support'
 import { OptionsContext } from '../../providers/options'
 import SettingsMenu from './Menu'
@@ -60,6 +61,8 @@ function settingsContent(option: SettingsOptions, menuBack?: () => void): JSX.El
       return <Reset />
     case SettingsOptions.Server:
       return <Server />
+    case SettingsOptions.Solvers:
+      return <Solvers />
     case SettingsOptions.Support:
       return <Support />
     case SettingsOptions.Theme:

--- a/src/screens/Settings/Solvers.tsx
+++ b/src/screens/Settings/Solvers.tsx
@@ -1,0 +1,155 @@
+import { useContext, useState } from 'react'
+import Header from './Header'
+import Button from '../../components/Button'
+import ButtonsOnBottom from '../../components/ButtonsOnBottom'
+import Content from '../../components/Content'
+import ErrorMessage from '../../components/Error'
+import FlexCol from '../../components/FlexCol'
+import FlexRow from '../../components/FlexRow'
+import Padded from '../../components/Padded'
+import Paste from '../../components/Paste'
+import Shadow from '../../components/Shadow'
+import Text, { TextSecondary } from '../../components/Text'
+import WarningBox from '../../components/Warning'
+import { Textarea } from '@/components/ui/textarea'
+import { AspContext } from '../../providers/asp'
+import { AssetSwapsContext } from '../../providers/assetSwaps'
+import { useToast } from '../../components/Toast'
+import { prettyAgo } from '../../lib/format'
+import { getPinnedSolverCards, pinSolverCard, unpinSolverCard, type PinnedSolverCard } from '../../lib/swap/solverCards'
+import { Network } from '@arkade-os/boltz-swap'
+
+// hero component to explain what manual solver registration is for
+function Hero() {
+  return (
+    <FlexCol gap='0.5rem'>
+      <Text bold>Add a solver manually</Text>
+      <Text small thin wrap>
+        Swap markets normally come from the public solver registry. A solver that prefers to stay unlisted can hand you
+        its card.json instead — paste it below to use its markets on this wallet only.
+      </Text>
+    </FlexCol>
+  )
+}
+
+function PinnedCard({ pinned, onRemove }: { pinned: PinnedSolverCard; onRemove: (name: string) => void }) {
+  const { card } = pinned
+  const pairs = card.markets.map((market) => market.pair).join(', ')
+  return (
+    <Shadow lighter fat testId={`pinned-solver-${card.name}`}>
+      <FlexCol gap='0.5rem'>
+        <FlexRow between>
+          <Text>{card.name}</Text>
+          <Text color='neutral-500' tiny>
+            added {prettyAgo(pinned.addedAt)}
+          </Text>
+        </FlexRow>
+        <hr className='dashed' />
+        <FlexRow between>
+          <TextSecondary>
+            {card.markets.length} {card.markets.length === 1 ? 'market' : 'markets'}: {pairs}
+          </TextSecondary>
+          <button type='button' onClick={() => onRemove(card.name)} aria-label={`Remove solver ${card.name}`}>
+            <Text tiny>Remove</Text>
+          </button>
+        </FlexRow>
+      </FlexCol>
+    </Shadow>
+  )
+}
+
+export default function Solvers() {
+  const { aspInfo } = useContext(AspContext)
+  const { refreshMarkets } = useContext(AssetSwapsContext)
+  const { toast } = useToast()
+
+  const network = aspInfo.network as Network
+
+  const [cardJson, setCardJson] = useState('')
+  const [error, setError] = useState('')
+  const [pinned, setPinned] = useState<PinnedSolverCard[]>(() => (network ? getPinnedSolverCards(network) : []))
+
+  const handleAdd = () => {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(cardJson)
+    } catch {
+      setError('Not valid JSON — paste the solver card.json exactly as published')
+      return
+    }
+    const result = pinSolverCard(network, parsed)
+    if (!result.ok) {
+      setError(`Invalid card: ${result.errors.slice(0, 3).join('; ')}`)
+      return
+    }
+    setError('')
+    setCardJson('')
+    setPinned(getPinnedSolverCards(network))
+    refreshMarkets()
+    toast(`Solver "${result.card.name}" added`)
+  }
+
+  const handleRemove = (name: string) => {
+    unpinSolverCard(network, name)
+    setPinned(getPinnedSolverCards(network))
+    refreshMarkets()
+    toast(`Solver "${name}" removed`)
+  }
+
+  const handlePaste = (data: string) => {
+    setError('')
+    setCardJson(data)
+  }
+
+  if (!network) {
+    return (
+      <>
+        <Header text='Solvers' back />
+        <Content>
+          <Padded>
+            <WarningBox text='Connect to a server first to manage solvers for its network.' />
+          </Padded>
+        </Content>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Header text='Solvers' back />
+      <Content>
+        <Padded>
+          <FlexCol gap='1rem' padding='0 0 24px 0'>
+            <Shadow fat purple>
+              <Hero />
+            </Shadow>
+            {pinned.map((entry) => (
+              <PinnedCard key={entry.card.name} pinned={entry} onRemove={handleRemove} />
+            ))}
+            <FlexCol gap='0.5rem'>
+              <FlexRow between>
+                <Text small>Solver card.json for {network}</Text>
+                <Paste onPaste={handlePaste} />
+              </FlexRow>
+              <Textarea
+                aria-label='Solver card JSON'
+                className='min-h-40 font-mono'
+                onChange={(event) => {
+                  setError('')
+                  setCardJson(event.target.value)
+                }}
+                placeholder='{ "version": 0, "name": "my-solver", "markets": [ … ] }'
+                value={cardJson}
+              />
+              <ErrorMessage error={Boolean(error)} text={error} />
+            </FlexCol>
+            <WarningBox text='Only add cards from solvers you trust: prices come from the feed URL the card advertises.' />
+          </FlexCol>
+        </Padded>
+      </Content>
+      <ButtonsOnBottom>
+        <Button onClick={handleAdd} label='Add solver' disabled={!cardJson.trim()} />
+      </ButtonsOnBottom>
+    </>
+  )
+}

--- a/src/screens/Settings/Solvers.tsx
+++ b/src/screens/Settings/Solvers.tsx
@@ -6,6 +6,7 @@ import Content from '../../components/Content'
 import ErrorMessage from '../../components/Error'
 import FlexCol from '../../components/FlexCol'
 import FlexRow from '../../components/FlexRow'
+import Input from '../../components/Input'
 import Padded from '../../components/Padded'
 import Paste from '../../components/Paste'
 import Shadow from '../../components/Shadow'
@@ -15,8 +16,16 @@ import { Textarea } from '@/components/ui/textarea'
 import { AspContext } from '../../providers/asp'
 import { AssetSwapsContext } from '../../providers/assetSwaps'
 import { useToast } from '../../components/Toast'
+import { getSolverRegistryUrl } from '../../lib/constants'
 import { prettyAgo } from '../../lib/format'
-import { getPinnedSolverCards, pinSolverCard, unpinSolverCard, type PinnedSolverCard } from '../../lib/swap/solverCards'
+import { addUserRegistry, clearMarketsCache, getUserRegistries, removeUserRegistry } from '../../lib/swap/markets'
+import {
+  getPinnedSolverCards,
+  pinSolverCard,
+  unpinAllSolverCards,
+  unpinSolverCard,
+  type PinnedSolverCard,
+} from '../../lib/swap/solverCards'
 import { isNetwork } from '@arkade-os/solver-discovery'
 
 // hero component to explain what manual solver registration is for
@@ -53,6 +62,14 @@ function PinnedCard({ pinned, onRemove }: { pinned: PinnedSolverCard; onRemove: 
             <Text tiny>Remove</Text>
           </button>
         </FlexRow>
+        <details>
+          <summary className='cursor-pointer'>
+            <Text tiny color='neutral-500'>
+              View card.json
+            </Text>
+          </summary>
+          <pre className='max-h-60 overflow-auto font-mono text-xs'>{JSON.stringify(card, null, 2)}</pre>
+        </details>
       </FlexCol>
     </Shadow>
   )
@@ -70,11 +87,15 @@ export default function Solvers() {
 
   const [cardJson, setCardJson] = useState('')
   const [error, setError] = useState('')
+  const [registryUrl, setRegistryUrl] = useState('')
+  const [registryError, setRegistryError] = useState('')
   // derived, not held as state: keyed on the network because aspInfo.network
-  // resolves async on boot (the list must not freeze at the mount-time value),
-  // and on a revision counter the mutation handlers bump after a pin/remove
+  // resolves async on boot (the lists must not freeze at the mount-time value),
+  // and on a revision counter the mutation handlers bump after any change
   const [storageRev, setStorageRev] = useState(0)
   const pinned = useMemo(() => (network ? getPinnedSolverCards(network) : []), [network, storageRev])
+  const userRegistries = useMemo(() => (network ? getUserRegistries(network) : []), [network, storageRev])
+  const defaultRegistry = network ? getSolverRegistryUrl(network) : undefined
 
   const handleAdd = () => {
     if (!network) return
@@ -108,6 +129,38 @@ export default function Solvers() {
   const handleInput = (data: string) => {
     setError('')
     setCardJson(data)
+  }
+
+  const handleRegistryInput = (data: string) => {
+    setRegistryError('')
+    setRegistryUrl(data)
+  }
+
+  const handleAddRegistry = () => {
+    if (!network || !registryUrl.trim()) return
+    const addError = addUserRegistry(network, registryUrl.trim())
+    if (addError) return setRegistryError(addError)
+    setRegistryUrl('')
+    setStorageRev((rev) => rev + 1)
+    refreshMarkets()
+    toast('Registry added')
+  }
+
+  const handleRemoveRegistry = (url: string) => {
+    if (!network) return
+    removeUserRegistry(network, url)
+    setStorageRev((rev) => rev + 1)
+    refreshMarkets()
+    toast('Registry removed')
+  }
+
+  const handleReset = () => {
+    if (!network) return
+    unpinAllSolverCards(network)
+    clearMarketsCache(network)
+    setStorageRev((rev) => rev + 1)
+    refreshMarkets()
+    toast('Solvers reset, markets refreshed from registry')
   }
 
   if (!network) {
@@ -156,11 +209,49 @@ export default function Solvers() {
               <ErrorMessage error={Boolean(error)} text={error} />
             </FlexCol>
             <WarningBox text='Only add cards from solvers you trust: prices come from the feed URL the card advertises.' />
+            <FlexCol gap='0.5rem'>
+              <Text small>Followed registries</Text>
+              {defaultRegistry ? (
+                <FlexRow between>
+                  <Text small thin wrap>
+                    {defaultRegistry}
+                  </Text>
+                  <Text color='neutral-500' tiny>
+                    default
+                  </Text>
+                </FlexRow>
+              ) : null}
+              {userRegistries.map((url) => (
+                <FlexRow between key={url}>
+                  <Text small thin wrap>
+                    {url}
+                  </Text>
+                  <button type='button' onClick={() => handleRemoveRegistry(url)} aria-label={`Remove registry ${url}`}>
+                    <Text tiny>Remove</Text>
+                  </button>
+                </FlexRow>
+              ))}
+              <Input
+                error={registryError}
+                label='Add a registry index URL'
+                onChange={handleRegistryInput}
+                onEnter={handleAddRegistry}
+                placeholder={`https://…/${network}.json`}
+                right={
+                  <button type='button' onClick={handleAddRegistry} aria-label='Add registry'>
+                    <Text tiny>Add</Text>
+                  </button>
+                }
+                testId='registry-url'
+                value={registryUrl}
+              />
+            </FlexCol>
           </FlexCol>
         </Padded>
       </Content>
       <ButtonsOnBottom>
         <Button onClick={handleAdd} label='Add solver' disabled={!cardJson.trim()} />
+        <Button onClick={handleReset} label='Reset from registry' secondary disabled={!pinned.length} />
       </ButtonsOnBottom>
     </>
   )

--- a/src/screens/Settings/Solvers.tsx
+++ b/src/screens/Settings/Solvers.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import Header from './Header'
 import Button from '../../components/Button'
 import ButtonsOnBottom from '../../components/ButtonsOnBottom'
@@ -17,7 +17,7 @@ import { AssetSwapsContext } from '../../providers/assetSwaps'
 import { useToast } from '../../components/Toast'
 import { prettyAgo } from '../../lib/format'
 import { getPinnedSolverCards, pinSolverCard, unpinSolverCard, type PinnedSolverCard } from '../../lib/swap/solverCards'
-import { Network } from '@arkade-os/boltz-swap'
+import { isNetwork } from '@arkade-os/solver-discovery'
 
 // hero component to explain what manual solver registration is for
 function Hero() {
@@ -63,13 +63,23 @@ export default function Solvers() {
   const { refreshMarkets } = useContext(AssetSwapsContext)
   const { toast } = useToast()
 
-  const network = aspInfo.network as Network
+  // discovery only understands the SDK's network names — anything else (e.g.
+  // a testnet ASP) must not offer the form, or pins would persist but never
+  // produce a market
+  const network = isNetwork(aspInfo.network) ? aspInfo.network : undefined
 
   const [cardJson, setCardJson] = useState('')
   const [error, setError] = useState('')
-  const [pinned, setPinned] = useState<PinnedSolverCard[]>(() => (network ? getPinnedSolverCards(network) : []))
+  const [pinned, setPinned] = useState<PinnedSolverCard[]>([])
+
+  // aspInfo.network resolves async on boot, so the list must re-read when it
+  // lands (or changes) rather than freeze whatever value the screen mounted with
+  useEffect(() => {
+    setPinned(network ? getPinnedSolverCards(network) : [])
+  }, [network])
 
   const handleAdd = () => {
+    if (!network) return
     let parsed: unknown
     try {
       parsed = JSON.parse(cardJson)
@@ -90,6 +100,7 @@ export default function Solvers() {
   }
 
   const handleRemove = (name: string) => {
+    if (!network) return
     unpinSolverCard(network, name)
     setPinned(getPinnedSolverCards(network))
     refreshMarkets()
@@ -107,7 +118,13 @@ export default function Solvers() {
         <Header text='Solvers' back />
         <Content>
           <Padded>
-            <WarningBox text='Connect to a server first to manage solvers for its network.' />
+            <WarningBox
+              text={
+                aspInfo.network
+                  ? 'Solver cards are not supported on this network.'
+                  : 'Connect to a server first to manage solvers for its network.'
+              }
+            />
           </Padded>
         </Content>
       </>

--- a/src/screens/Settings/Solvers.tsx
+++ b/src/screens/Settings/Solvers.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import Header from './Header'
 import Button from '../../components/Button'
 import ButtonsOnBottom from '../../components/ButtonsOnBottom'
@@ -70,13 +70,11 @@ export default function Solvers() {
 
   const [cardJson, setCardJson] = useState('')
   const [error, setError] = useState('')
-  const [pinned, setPinned] = useState<PinnedSolverCard[]>([])
-
-  // aspInfo.network resolves async on boot, so the list must re-read when it
-  // lands (or changes) rather than freeze whatever value the screen mounted with
-  useEffect(() => {
-    setPinned(network ? getPinnedSolverCards(network) : [])
-  }, [network])
+  // derived, not held as state: keyed on the network because aspInfo.network
+  // resolves async on boot (the list must not freeze at the mount-time value),
+  // and on a revision counter the mutation handlers bump after a pin/remove
+  const [storageRev, setStorageRev] = useState(0)
+  const pinned = useMemo(() => (network ? getPinnedSolverCards(network) : []), [network, storageRev])
 
   const handleAdd = () => {
     if (!network) return
@@ -94,7 +92,7 @@ export default function Solvers() {
     }
     setError('')
     setCardJson('')
-    setPinned(getPinnedSolverCards(network))
+    setStorageRev((rev) => rev + 1)
     refreshMarkets()
     toast(`Solver "${result.card.name}" added`)
   }
@@ -102,12 +100,12 @@ export default function Solvers() {
   const handleRemove = (name: string) => {
     if (!network) return
     unpinSolverCard(network, name)
-    setPinned(getPinnedSolverCards(network))
+    setStorageRev((rev) => rev + 1)
     refreshMarkets()
     toast(`Solver "${name}" removed`)
   }
 
-  const handlePaste = (data: string) => {
+  const handleInput = (data: string) => {
     setError('')
     setCardJson(data)
   }
@@ -146,15 +144,12 @@ export default function Solvers() {
             <FlexCol gap='0.5rem'>
               <FlexRow between>
                 <Text small>Solver card.json for {network}</Text>
-                <Paste onPaste={handlePaste} />
+                <Paste onPaste={handleInput} />
               </FlexRow>
               <Textarea
                 aria-label='Solver card JSON'
                 className='min-h-40 font-mono'
-                onChange={(event) => {
-                  setError('')
-                  setCardJson(event.target.value)
-                }}
+                onChange={(event) => handleInput(event.target.value)}
                 placeholder='{ "version": 0, "name": "my-solver", "markets": [ … ] }'
                 value={cardJson}
               />

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -241,10 +241,14 @@ export default function WalletSwap() {
     solvable: solvable ?? undefined,
     status,
   })
+  // the market fed to the quote hook: stable per (markets, asset selection),
+  // unlike `pair` itself which findMarket rebuilds every render
+  const pairMarket = pair?.market ?? null
   const quote = useMemo(
     () =>
       buildQuoteFromPlan(
         currentPlan,
+        pairMarket,
         assetAmount,
         preservedAmounts?.entryMode ?? amountMode,
         fromAsset,
@@ -260,6 +264,7 @@ export default function WalletSwap() {
       config.unit,
       currentPlan,
       fromAsset,
+      pairMarket,
       preservedAmounts?.entryMode,
       toAsset,
       unitOfAccountUsd,
@@ -1296,6 +1301,7 @@ function MetricRow({ label, value, loading }: { label: ReactNode; value: string;
 
 function buildQuoteFromPlan(
   plan: OfferPlan | null,
+  market: DiscoveredMarket | null,
   assetAmount: string,
   entryMode: AmountMode,
   fromAsset: SwapAsset,
@@ -1321,9 +1327,6 @@ function buildQuoteFromPlan(
   const toCurrencyAvailable = Boolean(toAsset && hasCurrencyConversion(toAsset, unitOfAccountUsd))
   const receivedCurrencyAmount = toCurrencyAvailable ? (receivedProtocol * toUsd) / unitOfAccountUsd : 0
   const feeFraction = (plan?.market.fee_bps ?? 0) / 10_000
-  // the plan's market is the DiscoveredMarket the quote hook was fed, so the
-  // discovery provenance is there even though OfferPlan types it as Market
-  const planMarket = plan?.market as DiscoveredMarket | undefined
   // received amounts are net of the fee; grossUp recovers the pre-fee total
   const grossUp = feeFraction < 1 ? 1 / (1 - feeFraction) : 0
   // once a live quote exists, price the give side off that SAME quote (via
@@ -1353,10 +1356,11 @@ function buildQuoteFromPlan(
     toCurrency: toCurrencyAvailable ? prettyFiatAmount(receivedCurrencyAmount, currency, formatOptions) : '',
     feeLabel: toAsset ? `${formatAssetQuantity(feeReceived, toAsset.decimals)} ${toAsset.ticker}` : '',
     // who serves the quote — a card the user pinned by hand is flagged so a
-    // manual solver can never pass itself off as a registry-vetted one
-    solverLabel: planMarket
-      ? `${planMarket.solver}${planMarket.sourceType === 'local' ? ' · added manually' : ''}`
-      : '',
+    // manual solver can never pass itself off as a registry-vetted one. The
+    // quote hook never exposes a plan computed for a market other than the
+    // one it was fed this render, so `market` IS the plan's market — with its
+    // discovery provenance typed, where plan.market erases it to Market
+    solverLabel: plan && market ? `${market.solver}${market.sourceType === 'local' ? ' · added manually' : ''}` : '',
     // the rate is always quoted per whole BTC even though amounts display in
     // sats — "1 sats = 0.0000006 USD" is technically correct but unreadable
     rateFromTicker: swapRouteTicker(fromAsset.assetId, fromAsset.ticker) ?? '',

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -1,6 +1,6 @@
 import Decimal from 'decimal.js'
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
-import { fromAtomic, type OfferPlan } from '@arkade-os/solver-discovery'
+import { fromAtomic, type DiscoveredMarket, type OfferPlan } from '@arkade-os/solver-discovery'
 import { useOfferQuote } from '@arkade-os/solver-discovery/react'
 import { type ReactNode, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from 'react'
 import AssetAvatar from '../../../components/AssetAvatar'
@@ -62,6 +62,7 @@ interface SwapQuote {
   toAmount: string
   toCurrency: string
   feeLabel: string
+  solverLabel: string
   rateFromTicker: string
   rateToTicker: string
   rateLabel: string
@@ -1206,6 +1207,7 @@ function QuoteDetails({ quote, loading }: { quote: SwapQuote; loading: boolean }
         value={quote.toAsset ? `1 ${quote.rateFromTicker} = ${quote.rateLabel} ${quote.rateToTicker}` : 'Pending'}
         loading={loading}
       />
+      {quote.solverLabel ? <MetricRow label='Solver' value={quote.solverLabel} loading={loading} /> : null}
     </div>
   )
 }
@@ -1319,6 +1321,9 @@ function buildQuoteFromPlan(
   const toCurrencyAvailable = Boolean(toAsset && hasCurrencyConversion(toAsset, unitOfAccountUsd))
   const receivedCurrencyAmount = toCurrencyAvailable ? (receivedProtocol * toUsd) / unitOfAccountUsd : 0
   const feeFraction = (plan?.market.fee_bps ?? 0) / 10_000
+  // the plan's market is the DiscoveredMarket the quote hook was fed, so the
+  // discovery provenance is there even though OfferPlan types it as Market
+  const planMarket = plan?.market as DiscoveredMarket | undefined
   // received amounts are net of the fee; grossUp recovers the pre-fee total
   const grossUp = feeFraction < 1 ? 1 / (1 - feeFraction) : 0
   // once a live quote exists, price the give side off that SAME quote (via
@@ -1347,6 +1352,11 @@ function buildQuoteFromPlan(
     toAmount: toAsset ? formatAssetQuantity(received, toAsset.decimals) : '0',
     toCurrency: toCurrencyAvailable ? prettyFiatAmount(receivedCurrencyAmount, currency, formatOptions) : '',
     feeLabel: toAsset ? `${formatAssetQuantity(feeReceived, toAsset.decimals)} ${toAsset.ticker}` : '',
+    // who serves the quote — a card the user pinned by hand is flagged so a
+    // manual solver can never pass itself off as a registry-vetted one
+    solverLabel: planMarket
+      ? `${planMarket.solver}${planMarket.sourceType === 'local' ? ' · added manually' : ''}`
+      : '',
     // the rate is always quoted per whole BTC even though amounts display in
     // sats — "1 sats = 0.0000006 USD" is technically correct but unreadable
     rateFromTicker: swapRouteTicker(fromAsset.assetId, fromAsset.ticker) ?? '',

--- a/src/test/lib/swap/fixtures.ts
+++ b/src/test/lib/swap/fixtures.ts
@@ -1,4 +1,4 @@
-import type { DiscoveredMarket } from '@arkade-os/solver-discovery'
+import type { Card, DiscoveredMarket, Market } from '@arkade-os/solver-discovery'
 
 // the two mutinynet registry markets, in the 0.1.3 registry schema
 export const USDT_ID = 'f121ac9b7656797cc68d1e8fecacfbaa2069ec1461edf0bf2f3c37404cb9791a0000'
@@ -51,3 +51,22 @@ export const btcDepix: DiscoveredMarket = {
   max_quote_amount: '100000000000',
   solver: 'jpmorgan',
 }
+
+/** The card-schema shape of a discovered market: cards carry the market
+ * fields alone — `solver` comes from the card name, provenance from discovery.
+ * Keys are really deleted, not undefined: the strict card schema rejects them. */
+export const asCardMarket = (market: DiscoveredMarket): Market => {
+  const cardMarket = { ...market } as Partial<DiscoveredMarket>
+  delete cardMarket.solver
+  delete cardMarket.source
+  delete cardMarket.sourceType
+  return cardMarket as Market
+}
+
+/** A schema-valid card.json as a solver would publish it (strict schema:
+ * version 0, lowercase name, market fields only). */
+export const solverCard = (name = 'privateer', markets: Market[] = [asCardMarket(btcUsdt)]): Card => ({
+  version: 0,
+  name,
+  markets,
+})

--- a/src/test/lib/swap/markets.test.ts
+++ b/src/test/lib/swap/markets.test.ts
@@ -216,6 +216,15 @@ describe('discoverMarkets with pinned solver cards', () => {
     expect(markets[0].sourceType).toBe('local')
   })
 
+  it('breaks a (pair, fee) tie in favor of the registry market', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: Date.now() }))
+    // same pair and fee, different feed URL so dedupe keeps both entries
+    const rival = { ...asCardMarket(btcUsdt), price_feed: 'https://feeds.example.com/btcusd' }
+    pinSolverCard('mutinynet', solverCard('copycat', [rival]))
+    const markets = await discoverMarkets('mutinynet')
+    expect(markets.map((m) => m.sourceType)).toEqual(['registry', 'local'])
+  })
+
   it('skips a pinned card that turned invalid in storage without breaking discovery', async () => {
     localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: Date.now() }))
     localStorage.setItem(

--- a/src/test/lib/swap/markets.test.ts
+++ b/src/test/lib/swap/markets.test.ts
@@ -1,7 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'
 import { planOffer, quoteOffer } from '@arkade-os/solver-discovery'
-import { discoverMarkets, findMarket, QUOTE_OPTIONS, validatePlan } from '../../../lib/swap/markets'
+import {
+  addUserRegistry,
+  clearMarketsCache,
+  discoverMarkets,
+  findMarket,
+  getUserRegistries,
+  QUOTE_OPTIONS,
+  removeUserRegistry,
+  validatePlan,
+} from '../../../lib/swap/markets'
 import { pinSolverCard } from '../../../lib/swap/solverCards'
 import {
   asCardMarket,
@@ -233,6 +242,67 @@ describe('discoverMarkets with pinned solver cards', () => {
     const markets = await discoverMarkets('mutinynet')
     expect(fetchMocker).toHaveBeenCalledTimes(1)
     expect(markets).toHaveLength(2)
+  })
+})
+
+describe('user registries', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    fetchMocker.resetMocks()
+  })
+
+  it('follows a registry, normalizing a bare host to https, and rejects junk', () => {
+    expect(addUserRegistry('mutinynet', 'registry.example.com/mutinynet.json')).toBeUndefined()
+    expect(getUserRegistries('mutinynet')).toEqual(['https://registry.example.com/mutinynet.json'])
+    expect(addUserRegistry('mutinynet', 'not a url')).toMatch(/not a valid/i)
+  })
+
+  it('refuses the default registry and an already-followed one', () => {
+    expect(addUserRegistry('mutinynet', 'https://arkade-os.github.io/solver-registry/mutinynet.json')).toMatch(
+      /default/,
+    )
+    addUserRegistry('mutinynet', 'https://r.example.com/m.json')
+    expect(addUserRegistry('mutinynet', 'https://r.example.com/m.json')).toMatch(/already/)
+    expect(getUserRegistries('mutinynet')).toEqual(['https://r.example.com/m.json'])
+  })
+
+  it('removes a followed registry', () => {
+    addUserRegistry('mutinynet', 'https://r.example.com/m.json')
+    removeUserRegistry('mutinynet', 'https://r.example.com/m.json')
+    expect(getUserRegistries('mutinynet')).toEqual([])
+  })
+
+  it('discovers across the default and followed registries, deduped and ranked', async () => {
+    addUserRegistry('mutinynet', 'https://r.example.com/m.json')
+    // both registries list btcUsdt (collapses to one entry); the followed one
+    // adds a cheaper rival for the same pair, which ranks first
+    const rival = { ...indexMarket, fee_bps: 10 }
+    fetchMocker.mockResponses(
+      JSON.stringify(registryIndex()),
+      JSON.stringify({ ...registryIndex(), markets: [indexMarket, rival] }),
+    )
+    const found = await discoverMarkets('mutinynet')
+    expect(fetchMocker).toHaveBeenCalledTimes(2)
+    expect(found.map((m) => m.fee_bps)).toEqual([10, 30])
+    expect(found.map((m) => m.sourceType)).toEqual(['registry', 'registry'])
+  })
+
+  it('a changed registry set misses the single-registry cache and refetches', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: Date.now() }))
+    addUserRegistry('mutinynet', 'https://r.example.com/m.json')
+    fetchMocker.mockResponses(JSON.stringify(registryIndex()), JSON.stringify(registryIndex()))
+    await discoverMarkets('mutinynet')
+    expect(fetchMocker).toHaveBeenCalledTimes(2)
+  })
+
+  it('clearMarketsCache drops every cached set for the network only', () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: Date.now() }))
+    localStorage.setItem('swapMarkets-mutinynet-other', '{}')
+    localStorage.setItem('swapMarkets-bitcoin-x', '{}')
+    clearMarketsCache('mutinynet')
+    expect(localStorage.getItem(CACHE_KEY)).toBeNull()
+    expect(localStorage.getItem('swapMarkets-mutinynet-other')).toBeNull()
+    expect(localStorage.getItem('swapMarkets-bitcoin-x')).not.toBeNull()
   })
 })
 

--- a/src/test/lib/swap/markets.test.ts
+++ b/src/test/lib/swap/markets.test.ts
@@ -20,6 +20,19 @@ fetchMocker.enableMocks()
 
 const markets = [btcUsdt, btcDepix]
 
+const CACHE_KEY = 'swapMarkets-mutinynet-https://arkade-os.github.io/solver-registry/mutinynet.json'
+// a valid registry index entry: btcUsdt without the fields discover() adds
+const indexMarket: Record<string, unknown> = { ...btcUsdt }
+delete indexMarket.source
+delete indexMarket.sourceType
+const registryIndex = () => ({
+  version: 0,
+  network: 'mutinynet',
+  generated_at: Math.floor(Date.now() / 1000),
+  commit: 'a'.repeat(40),
+  markets: [indexMarket],
+})
+
 describe('findMarket', () => {
   it('maps btc->asset to giving the base side', () => {
     expect(findMarket(markets, 'btc', USDT_ID)).toEqual({ market: btcUsdt, give: 'base' })
@@ -85,19 +98,6 @@ describe('quoteOffer with the wallet quote options', () => {
 })
 
 describe('discoverMarkets caching', () => {
-  const CACHE_KEY = 'swapMarkets-mutinynet-https://arkade-os.github.io/solver-registry/mutinynet.json'
-  // a valid registry index entry: btcUsdt without the fields discover() adds
-  const indexMarket: Record<string, unknown> = { ...btcUsdt }
-  delete indexMarket.source
-  delete indexMarket.sourceType
-  const registryIndex = () => ({
-    version: 0,
-    network: 'mutinynet',
-    generated_at: Math.floor(Date.now() / 1000),
-    commit: 'a'.repeat(40),
-    markets: [indexMarket],
-  })
-
   beforeEach(() => {
     localStorage.clear()
     fetchMocker.resetMocks()
@@ -154,18 +154,6 @@ describe('discoverMarkets caching', () => {
 })
 
 describe('discoverMarkets with pinned solver cards', () => {
-  const CACHE_KEY = 'swapMarkets-mutinynet-https://arkade-os.github.io/solver-registry/mutinynet.json'
-  const indexMarket: Record<string, unknown> = { ...btcUsdt }
-  delete indexMarket.source
-  delete indexMarket.sourceType
-  const registryIndex = () => ({
-    version: 0,
-    network: 'mutinynet',
-    generated_at: Math.floor(Date.now() / 1000),
-    commit: 'a'.repeat(40),
-    markets: [indexMarket],
-  })
-
   beforeEach(() => {
     localStorage.clear()
     fetchMocker.resetMocks()

--- a/src/test/lib/swap/markets.test.ts
+++ b/src/test/lib/swap/markets.test.ts
@@ -2,7 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'
 import { planOffer, quoteOffer } from '@arkade-os/solver-discovery'
 import { discoverMarkets, findMarket, QUOTE_OPTIONS, validatePlan } from '../../../lib/swap/markets'
-import { btcDepix, btcUsdt, DEPIX_ID, MARAT_ID, maratNapo, NAPO_ID, USDT_ID } from './fixtures'
+import { pinSolverCard } from '../../../lib/swap/solverCards'
+import {
+  asCardMarket,
+  btcDepix,
+  btcUsdt,
+  DEPIX_ID,
+  MARAT_ID,
+  maratNapo,
+  NAPO_ID,
+  solverCard,
+  USDT_ID,
+} from './fixtures'
 
 const fetchMocker = createFetchMock(vi)
 fetchMocker.enableMocks()
@@ -139,6 +150,92 @@ describe('discoverMarkets caching', () => {
     expect(markets).toHaveLength(1)
     expect(fetchMocker).toHaveBeenCalledTimes(1)
     expect(JSON.parse(localStorage.getItem(CACHE_KEY)!).markets).toHaveLength(1)
+  })
+})
+
+describe('discoverMarkets with pinned solver cards', () => {
+  const CACHE_KEY = 'swapMarkets-mutinynet-https://arkade-os.github.io/solver-registry/mutinynet.json'
+  const indexMarket: Record<string, unknown> = { ...btcUsdt }
+  delete indexMarket.source
+  delete indexMarket.sourceType
+  const registryIndex = () => ({
+    version: 0,
+    network: 'mutinynet',
+    generated_at: Math.floor(Date.now() / 1000),
+    commit: 'a'.repeat(40),
+    markets: [indexMarket],
+  })
+
+  beforeEach(() => {
+    localStorage.clear()
+    fetchMocker.resetMocks()
+  })
+
+  it('merges pinned-card markets with a fresh registry cache without fetching', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: Date.now() }))
+    pinSolverCard('mutinynet', solverCard('privateer', [asCardMarket(btcDepix)]))
+    const markets = await discoverMarkets('mutinynet')
+    expect(fetchMocker).not.toHaveBeenCalled()
+    expect(markets).toHaveLength(2)
+    const local = markets.find((m) => m.sourceType === 'local')
+    expect(local?.pair).toBe('BTC/DePix')
+    expect(local?.solver).toBe('privateer')
+    expect(local?.source).toBe('local:privateer')
+  })
+
+  it('keeps the registry cache free of pinned-card markets', async () => {
+    fetchMocker.mockResponseOnce(JSON.stringify(registryIndex()))
+    pinSolverCard('mutinynet', solverCard('privateer', [asCardMarket(btcDepix)]))
+    const markets = await discoverMarkets('mutinynet')
+    expect(markets).toHaveLength(2)
+    // otherwise a removed solver would keep serving quotes until the TTL runs out
+    expect(JSON.parse(localStorage.getItem(CACHE_KEY)!).markets).toHaveLength(1)
+  })
+
+  it('serves pinned cards on a network with no registry, with no fetch', async () => {
+    pinSolverCard('signet', solverCard())
+    const markets = await discoverMarkets('signet')
+    expect(fetchMocker).not.toHaveBeenCalled()
+    expect(markets).toHaveLength(1)
+    expect(markets[0].sourceType).toBe('local')
+  })
+
+  it('dedupes a pinned card the registry also lists, registry entry winning', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: Date.now() }))
+    pinSolverCard('mutinynet', solverCard('frenchman'))
+    const markets = await discoverMarkets('mutinynet')
+    expect(markets).toHaveLength(1)
+    expect(markets[0].sourceType).toBe('registry')
+  })
+
+  it('ranks a cheaper pinned market above the registry market for the same pair', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: Date.now() }))
+    pinSolverCard('mutinynet', solverCard('cheapskate', [{ ...asCardMarket(btcUsdt), fee_bps: 10 }]))
+    const markets = await discoverMarkets('mutinynet')
+    expect(markets.map((m) => m.fee_bps)).toEqual([10, 30])
+    expect(markets[0].sourceType).toBe('local')
+  })
+
+  it('skips a pinned card that turned invalid in storage without breaking discovery', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: Date.now() }))
+    localStorage.setItem(
+      'pinnedSolverCards',
+      JSON.stringify([
+        { network: 'mutinynet', addedAt: 1, card: { version: 1, name: 'bad', markets: [asCardMarket(btcDepix)] } },
+      ]),
+    )
+    const markets = await discoverMarkets('mutinynet')
+    expect(markets).toHaveLength(1)
+    expect(markets[0].pair).toBe('BTC/USDT')
+  })
+
+  it('merges pinned cards with the stale cache when the registry is unreachable', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ markets: [btcUsdt], fetchedAt: 0 }))
+    pinSolverCard('mutinynet', solverCard('privateer', [asCardMarket(btcDepix)]))
+    fetchMocker.mockRejectOnce(new Error('network down'))
+    const markets = await discoverMarkets('mutinynet')
+    expect(fetchMocker).toHaveBeenCalledTimes(1)
+    expect(markets).toHaveLength(2)
   })
 })
 

--- a/src/test/lib/swap/solverCards.test.ts
+++ b/src/test/lib/swap/solverCards.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_CARD_JSON_BYTES,
   MAX_PINNED_CARDS_PER_NETWORK,
   pinSolverCard,
+  unpinAllSolverCards,
   unpinSolverCard,
 } from '../../../lib/swap/solverCards'
 import { asCardMarket, btcDepix, solverCard } from './fixtures'
@@ -52,6 +53,15 @@ describe('pinned solver cards', () => {
     pinSolverCard('mutinynet', solverCard('other'))
     unpinSolverCard('mutinynet', 'privateer')
     expect(getPinnedSolverCards('mutinynet').map((p) => p.card.name)).toEqual(['other'])
+  })
+
+  it('unpins all cards for one network, leaving other networks alone', () => {
+    pinSolverCard('mutinynet', solverCard())
+    pinSolverCard('mutinynet', solverCard('other'))
+    pinSolverCard('bitcoin', solverCard('elsewhere'))
+    unpinAllSolverCards('mutinynet')
+    expect(getPinnedSolverCards('mutinynet')).toEqual([])
+    expect(getPinnedSolverCards('bitcoin').map((p) => p.card.name)).toEqual(['elsewhere'])
   })
 
   it('survives a corrupt storage blob and drops unshaped entries', () => {

--- a/src/test/lib/swap/solverCards.test.ts
+++ b/src/test/lib/swap/solverCards.test.ts
@@ -1,5 +1,12 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-import { getPinnedSolverCards, pinSolverCard, unpinSolverCard } from '../../../lib/swap/solverCards'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Network } from '@arkade-os/solver-discovery'
+import {
+  getPinnedSolverCards,
+  MAX_CARD_JSON_BYTES,
+  MAX_PINNED_CARDS_PER_NETWORK,
+  pinSolverCard,
+  unpinSolverCard,
+} from '../../../lib/swap/solverCards'
 import { asCardMarket, btcDepix, solverCard } from './fixtures'
 
 const STORAGE_KEY = 'pinnedSolverCards'
@@ -51,6 +58,52 @@ describe('pinned solver cards', () => {
     localStorage.setItem(STORAGE_KEY, '{not json')
     expect(getPinnedSolverCards('mutinynet')).toEqual([])
     localStorage.setItem(STORAGE_KEY, JSON.stringify([null, { network: 'mutinynet' }, 42]))
+    expect(getPinnedSolverCards('mutinynet')).toEqual([])
+  })
+
+  it('keeps shaped entries while dropping junk from the same blob', () => {
+    pinSolverCard('mutinynet', solverCard())
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([null, 42, { network: 'mutinynet' }, ...stored]))
+    expect(getPinnedSolverCards('mutinynet').map((p) => p.card.name)).toEqual(['privateer'])
+  })
+
+  it('refuses networks solver discovery does not know', () => {
+    const result = pinSolverCard('testnet' as unknown as Network, solverCard())
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.errors.join()).toContain('not supported')
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('rejects a card bigger than the storage budget', () => {
+    // the schema caps no field length, so a pathological name inflates the card
+    const result = pinSolverCard('mutinynet', solverCard('x'.repeat(MAX_CARD_JSON_BYTES)))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.errors.join()).toContain('too large')
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('caps the number of pinned solvers per network', () => {
+    for (let i = 0; i < MAX_PINNED_CARDS_PER_NETWORK; i++) {
+      expect(pinSolverCard('mutinynet', solverCard(`solver-${i}`)).ok).toBe(true)
+    }
+    expect(pinSolverCard('mutinynet', solverCard('one-too-many')).ok).toBe(false)
+    // replacing at the cap still works, and other networks are unaffected
+    expect(pinSolverCard('mutinynet', solverCard('solver-0')).ok).toBe(true)
+    expect(pinSolverCard('bitcoin', solverCard('elsewhere')).ok).toBe(true)
+  })
+
+  it('reports a failed storage write instead of pretending success', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    try {
+      const result = pinSolverCard('mutinynet', solverCard())
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.errors.join()).toContain('could not save')
+    } finally {
+      spy.mockRestore()
+    }
     expect(getPinnedSolverCards('mutinynet')).toEqual([])
   })
 })

--- a/src/test/lib/swap/solverCards.test.ts
+++ b/src/test/lib/swap/solverCards.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getPinnedSolverCards, pinSolverCard, unpinSolverCard } from '../../../lib/swap/solverCards'
+import { asCardMarket, btcDepix, solverCard } from './fixtures'
+
+const STORAGE_KEY = 'pinnedSolverCards'
+
+describe('pinned solver cards', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('pins a schema-valid card and lists it for its network only', () => {
+    const result = pinSolverCard('mutinynet', solverCard())
+    expect(result.ok).toBe(true)
+    expect(getPinnedSolverCards('mutinynet').map((p) => p.card.name)).toEqual(['privateer'])
+    expect(getPinnedSolverCards('bitcoin')).toEqual([])
+  })
+
+  it('rejects an invalid card with the schema errors, storing nothing', () => {
+    const result = pinSolverCard('mutinynet', { ...solverCard(), version: 1 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.errors.join()).toContain('/version must be 0')
+    expect(getPinnedSolverCards('mutinynet')).toEqual([])
+  })
+
+  it('rejects non-object input without throwing', () => {
+    expect(pinSolverCard('mutinynet', 'not a card').ok).toBe(false)
+    expect(pinSolverCard('mutinynet', null).ok).toBe(false)
+  })
+
+  it('replaces a re-pinned card of the same name on the same network', () => {
+    pinSolverCard('mutinynet', solverCard())
+    pinSolverCard('mutinynet', solverCard('privateer', [asCardMarket(btcDepix)]))
+    const pinned = getPinnedSolverCards('mutinynet')
+    expect(pinned).toHaveLength(1)
+    expect(pinned[0].card.markets[0].pair).toBe('BTC/DePix')
+  })
+
+  it('keeps same-named cards on other networks when replacing', () => {
+    pinSolverCard('bitcoin', solverCard())
+    pinSolverCard('mutinynet', solverCard('privateer', [asCardMarket(btcDepix)]))
+    expect(getPinnedSolverCards('bitcoin')[0].card.markets[0].pair).toBe('BTC/USDT')
+  })
+
+  it('unpins by network and name', () => {
+    pinSolverCard('mutinynet', solverCard())
+    pinSolverCard('mutinynet', solverCard('other'))
+    unpinSolverCard('mutinynet', 'privateer')
+    expect(getPinnedSolverCards('mutinynet').map((p) => p.card.name)).toEqual(['other'])
+  })
+
+  it('survives a corrupt storage blob and drops unshaped entries', () => {
+    localStorage.setItem(STORAGE_KEY, '{not json')
+    expect(getPinnedSolverCards('mutinynet')).toEqual([])
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([null, { network: 'mutinynet' }, 42]))
+    expect(getPinnedSolverCards('mutinynet')).toEqual([])
+  })
+})

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -13,6 +13,8 @@ import { mockAspContextValue, mockWalletContextValue } from '../screens/mocks'
 const cancelOffer = vi.hoisted(() => vi.fn())
 const createOffer = vi.hoisted(() => vi.fn())
 const getVtxos = vi.hoisted(() => vi.fn())
+const getEmulatorInfo = vi.hoisted(() => vi.fn(async () => ({})))
+const discoverMarkets = vi.hoisted(() => vi.fn(async (): Promise<unknown[]> => []))
 
 vi.mock('@arkade-os/sdk', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@arkade-os/sdk')>()),
@@ -20,7 +22,7 @@ vi.mock('@arkade-os/sdk', async (importOriginal) => ({
     getVtxos = getVtxos
   },
   RestEmulatorProvider: class {
-    getInfo = async () => ({})
+    getInfo = getEmulatorInfo
   },
 }))
 
@@ -30,10 +32,11 @@ vi.mock('../../lib/swap/offer', async (importOriginal) => ({
   createOffer,
 }))
 
-// keep the discovery effect off the network; these tests hand plans in directly
+// keep the discovery effect off the network; most tests hand plans in
+// directly, the refresh tests script discoverMarkets per call
 vi.mock('../../lib/swap/markets', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../lib/swap/markets')>()),
-  discoverMarkets: async () => [],
+  discoverMarkets,
 }))
 
 const pendingSwap: AssetSwap = {
@@ -216,5 +219,74 @@ describe('AssetSwapsProvider cancellation', () => {
     resolveVtxos({ vtxos: [{ txid: pendingSwap.fundingTxid, virtualStatus: { state: 'settled' } }] })
 
     await waitFor(() => expect(getAssetSwaps()[0].status).toBe('fulfilled'))
+  })
+})
+
+function MarketsHarness() {
+  const { markets, refreshMarkets, swapAvailable } = useContext(AssetSwapsContext)
+  return (
+    <>
+      <span data-testid='market-count'>{markets.length}</span>
+      <span data-testid='swap-available'>{String(swapAvailable)}</span>
+      <button onClick={refreshMarkets}>Refresh</button>
+    </>
+  )
+}
+
+function renderMarketsProvider() {
+  render(
+    // mutinynet so the emulator probe (mocked above) arms swapAvailable
+    <AspContext.Provider
+      value={
+        { ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet', url: '' } } as any
+      }
+    >
+      <WalletContext.Provider
+        value={
+          {
+            ...mockWalletContextValue,
+            reloadWallet: vi.fn().mockResolvedValue(undefined),
+            svcWallet: { identity: {} },
+          } as any
+        }
+      >
+        <AssetSwapsProvider>
+          <MarketsHarness />
+        </AssetSwapsProvider>
+      </WalletContext.Provider>
+    </AspContext.Provider>,
+  )
+}
+
+describe('AssetSwapsProvider market discovery refresh', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    discoverMarkets.mockImplementation(async () => [])
+    getEmulatorInfo.mockImplementation(async () => ({}))
+  })
+
+  afterEach(() => localStorage.clear())
+
+  it('re-runs discovery when refreshMarkets is called (the Settings pin/remove wiring)', async () => {
+    renderMarketsProvider()
+    await waitFor(() => expect(discoverMarkets).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('market-count').textContent).toBe('0')
+
+    discoverMarkets.mockResolvedValueOnce([btcUsdt])
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() => expect(screen.getByTestId('market-count').textContent).toBe('1'))
+  })
+
+  it('keeps the verified emulator when a refresh re-probe fails', async () => {
+    discoverMarkets.mockImplementation(async () => [btcUsdt])
+    renderMarketsProvider()
+    await waitFor(() => expect(screen.getByTestId('swap-available').textContent).toBe('true'))
+
+    // a pin/remove refresh with a transiently failing probe must not flip
+    // swaps off — the co-signer did not change
+    getEmulatorInfo.mockRejectedValueOnce(new Error('probe down'))
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() => expect(discoverMarkets).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('swap-available').textContent).toBe('true')
   })
 })

--- a/src/test/screens/settings/solvers.test.tsx
+++ b/src/test/screens/settings/solvers.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Solvers from '../../../screens/Settings/Solvers'
+import { AspContext } from '../../../providers/asp'
+import { AssetSwapsContext } from '../../../providers/assetSwaps'
+import { getPinnedSolverCards } from '../../../lib/swap/solverCards'
+import { mockAspContextValue } from '../mocks'
+import { solverCard } from '../../lib/swap/fixtures'
+
+const refreshMarkets = vi.fn()
+
+const renderSolvers = (network = 'mutinynet') =>
+  render(
+    <AspContext.Provider
+      value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network } } as any}
+    >
+      <AssetSwapsContext.Provider
+        value={{
+          markets: [],
+          refreshMarkets,
+          swapAvailable: false,
+          swaps: [],
+          createSwap: vi.fn(),
+          cancelSwap: vi.fn(),
+        }}
+      >
+        <Solvers />
+      </AssetSwapsContext.Provider>
+    </AspContext.Provider>,
+  )
+
+const typeCard = (value: string) => fireEvent.change(screen.getByLabelText('Solver card JSON'), { target: { value } })
+const addButton = () => screen.getByRole('button', { name: /add solver/i })
+
+describe('Solvers settings screen', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    refreshMarkets.mockClear()
+  })
+
+  it('pins a pasted card, refreshes markets and lists the solver', () => {
+    renderSolvers()
+    typeCard(JSON.stringify(solverCard()))
+    fireEvent.click(addButton())
+    expect(screen.getByTestId('pinned-solver-privateer')).toBeTruthy()
+    expect(screen.getByText(/1 market: BTC\/USDT/)).toBeTruthy()
+    expect(getPinnedSolverCards('mutinynet')).toHaveLength(1)
+    expect(refreshMarkets).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects broken JSON with an error and stores nothing', () => {
+    renderSolvers()
+    typeCard('{not json')
+    fireEvent.click(addButton())
+    expect(screen.getByTestId('error-message').textContent).toMatch(/not valid json/i)
+    expect(getPinnedSolverCards('mutinynet')).toHaveLength(0)
+    expect(refreshMarkets).not.toHaveBeenCalled()
+  })
+
+  it('surfaces schema errors from the card validator', () => {
+    renderSolvers()
+    typeCard(JSON.stringify({ ...solverCard(), version: 1 }))
+    fireEvent.click(addButton())
+    expect(screen.getByTestId('error-message').textContent).toContain('/version must be 0')
+    expect(getPinnedSolverCards('mutinynet')).toHaveLength(0)
+  })
+
+  it('removes a pinned solver and refreshes markets', () => {
+    renderSolvers()
+    typeCard(JSON.stringify(solverCard()))
+    fireEvent.click(addButton())
+    fireEvent.click(screen.getByRole('button', { name: 'Remove solver privateer' }))
+    expect(screen.queryByTestId('pinned-solver-privateer')).toBeNull()
+    expect(getPinnedSolverCards('mutinynet')).toHaveLength(0)
+    expect(refreshMarkets).toHaveBeenCalledTimes(2)
+  })
+
+  it('disables the add button while the input is empty', () => {
+    renderSolvers()
+    expect((addButton() as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/src/test/screens/settings/solvers.test.tsx
+++ b/src/test/screens/settings/solvers.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Solvers from '../../../screens/Settings/Solvers'
 import { AspContext } from '../../../providers/asp'
 import { AssetSwapsContext } from '../../../providers/assetSwaps'
+import { getUserRegistries } from '../../../lib/swap/markets'
 import { getPinnedSolverCards, pinSolverCard } from '../../../lib/swap/solverCards'
 import { mockAspContextValue } from '../mocks'
 import { solverCard } from '../../lib/swap/fixtures'
@@ -92,5 +93,43 @@ describe('Solvers settings screen', () => {
     renderSolvers('testnet')
     expect(screen.getByText('Solver cards are not supported on this network.')).toBeTruthy()
     expect(screen.queryByLabelText('Solver card JSON')).toBeNull()
+  })
+
+  it('shows the raw card.json behind a details toggle', () => {
+    pinSolverCard('mutinynet', solverCard())
+    renderSolvers()
+    expect(screen.getByText('View card.json')).toBeTruthy()
+    expect(screen.getByText(/"name": "privateer"/)).toBeTruthy()
+  })
+
+  it('follows and unfollows a registry, refreshing markets both times', () => {
+    renderSolvers()
+    fireEvent.change(screen.getByTestId('registry-url'), { target: { value: 'https://r.example.com/m.json' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add registry' }))
+    expect(getUserRegistries('mutinynet')).toEqual(['https://r.example.com/m.json'])
+    expect(screen.getByText('https://r.example.com/m.json')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove registry https://r.example.com/m.json' }))
+    expect(getUserRegistries('mutinynet')).toEqual([])
+    expect(refreshMarkets).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects an invalid registry URL inline, storing nothing', () => {
+    renderSolvers()
+    fireEvent.change(screen.getByTestId('registry-url'), { target: { value: 'nope' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add registry' }))
+    expect(screen.getByText(/not a valid registry/i)).toBeTruthy()
+    expect(getUserRegistries('mutinynet')).toEqual([])
+    expect(refreshMarkets).not.toHaveBeenCalled()
+  })
+
+  it('reset removes every pinned solver and drops the markets cache', () => {
+    pinSolverCard('mutinynet', solverCard())
+    localStorage.setItem('swapMarkets-mutinynet-r', '{}')
+    renderSolvers()
+    fireEvent.click(screen.getByRole('button', { name: /reset from registry/i }))
+    expect(screen.queryByTestId('pinned-solver-privateer')).toBeNull()
+    expect(getPinnedSolverCards('mutinynet')).toEqual([])
+    expect(localStorage.getItem('swapMarkets-mutinynet-r')).toBeNull()
+    expect(refreshMarkets).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/test/screens/settings/solvers.test.tsx
+++ b/src/test/screens/settings/solvers.test.tsx
@@ -3,31 +3,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Solvers from '../../../screens/Settings/Solvers'
 import { AspContext } from '../../../providers/asp'
 import { AssetSwapsContext } from '../../../providers/assetSwaps'
-import { getPinnedSolverCards } from '../../../lib/swap/solverCards'
+import { getPinnedSolverCards, pinSolverCard } from '../../../lib/swap/solverCards'
 import { mockAspContextValue } from '../mocks'
 import { solverCard } from '../../lib/swap/fixtures'
 
 const refreshMarkets = vi.fn()
 
-const renderSolvers = (network = 'mutinynet') =>
-  render(
-    <AspContext.Provider
-      value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network } } as any}
+const solversAt = (network: string) => (
+  <AspContext.Provider value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network } } as any}>
+    <AssetSwapsContext.Provider
+      value={{
+        markets: [],
+        refreshMarkets,
+        swapAvailable: false,
+        swaps: [],
+        createSwap: vi.fn(),
+        cancelSwap: vi.fn(),
+      }}
     >
-      <AssetSwapsContext.Provider
-        value={{
-          markets: [],
-          refreshMarkets,
-          swapAvailable: false,
-          swaps: [],
-          createSwap: vi.fn(),
-          cancelSwap: vi.fn(),
-        }}
-      >
-        <Solvers />
-      </AssetSwapsContext.Provider>
-    </AspContext.Provider>,
-  )
+      <Solvers />
+    </AssetSwapsContext.Provider>
+  </AspContext.Provider>
+)
+
+const renderSolvers = (network = 'mutinynet') => render(solversAt(network))
 
 const typeCard = (value: string) => fireEvent.change(screen.getByLabelText('Solver card JSON'), { target: { value } })
 const addButton = () => screen.getByRole('button', { name: /add solver/i })
@@ -78,5 +77,20 @@ describe('Solvers settings screen', () => {
   it('disables the add button while the input is empty', () => {
     renderSolvers()
     expect((addButton() as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('loads the pinned list once the network resolves after mount', () => {
+    pinSolverCard('mutinynet', solverCard())
+    const { rerender } = render(solversAt(''))
+    expect(screen.getByText(/connect to a server first/i)).toBeTruthy()
+    expect(screen.queryByTestId('pinned-solver-privateer')).toBeNull()
+    rerender(solversAt('mutinynet'))
+    expect(screen.getByTestId('pinned-solver-privateer')).toBeTruthy()
+  })
+
+  it('blocks networks solver discovery does not support instead of taking dead pins', () => {
+    renderSolvers('testnet')
+    expect(screen.getByText('Solver cards are not supported on this network.')).toBeTruthy()
+    expect(screen.queryByLabelText('Solver card JSON')).toBeNull()
   })
 })


### PR DESCRIPTION
Closes #828.

The swap page depended entirely on the public solver registry, so a solver operator who prefers not to list publicly could not be used at all. This adds **Settings → Advanced → Solvers**: paste a solver's `card.json` and its markets join discovery for the connected network.

## How it works

- **`src/lib/swap/solverCards.ts`** — pinned-card storage (`pinnedSolverCards` in localStorage), schema-validated with the SDK's `validateCard`. Cards are pinned per network; re-pinning the same solver name replaces it (a solver shipping an updated card). Caps: 10 solvers per network, 64 KB per card. Failed storage writes are reported, not swallowed.
- **`src/lib/swap/markets.ts`** — `discoverMarkets` merges pinned cards on every call, *outside* the hourly registry cache: pin/remove takes effect immediately, pinned markets survive registry outages, and networks with no registry at all (the privacy-solver case) work too. Merging matches a single `discover()` call: byte-identical listings collapse via the SDK's `stableStringify` and markets rank per pair by `fee_bps`, registry winning ties.
- **`src/providers/assetSwaps.tsx`** — new `refreshMarkets()` on the context; the reset-on-network-switch and the discovery run are now separate effects, so a refresh keeps the last good markets and the verified emulator URL (one failed re-probe can't flip `swapAvailable` off).
- **`src/screens/Settings/Solvers.tsx`** — the new screen: paste box with schema errors inline, pinned-solver list with market pairs and remove, gated on `isNetwork` (a testnet ASP gets a clear "not supported" state instead of a silently dead pin), plus a trust warning since prices come from the card's advertised feed URL.
- **Swap screen** — the quote details now show which solver serves the quote, with pinned ones marked "added manually", so a hand-added card is distinguishable from a registry-vetted solver.
- Bumps `@arkade-os/solver-discovery` 0.1.4 → 0.1.5 (re-exports `stableStringify`, used for the merge identity).

## Testing

- 33 new tests: pinned-card storage (caps, write failure, junk-blob recovery), discovery merge (cache interplay, dedupe, ranking, tiebreak, no-registry and unreachable-registry paths), the Solvers screen (add/remove/errors, network gating, late-resolving network), and provider-level tests for the `refreshMarkets` wiring and emulator retention.
- Full unit suite: 537 passed. `tsc --noEmit`, ESLint, and Prettier clean.

## Notes for reviewers

- A pinned card can legitimately out-rank a registry market on fee — that's the ranking contract; the swap screen's new Solver row makes the provenance visible. Deeper mitigations (e.g. signature verification against `discovery_pubkey`, asset-id collision warnings in the picker) are left as follow-ups.
- `sig`/`discovery_pubkey` on pasted cards are schema-checked but not verified — the SDK does not expose verification; pinning is an explicit act of trust, and the UI says so.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zvw1GkHvsTG41EBvZdYHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pi69y3bTXNsy9M38q6h5zY)_