### PR TITLE
Fix swap rate display to show pre-fee market price

### DIFF
--- a/src/lib/swap/markets.ts
+++ b/src/lib/swap/markets.ts
@@ -1,6 +1,7 @@
 import {
   bestMarket,
   discover,
+  displayPrice,
   isNetwork,
   type DiscoveredMarket,
   type OfferPlan,
@@ -114,6 +115,21 @@ export const findMarket = (
   const givingBase = bestMarket(markets, { baseId: fromId, quoteId: toId, wantSide: 'quote' })
   if (givingBase) return { market: givingBase, give: 'base' }
   return { market: bestMarket(markets, { baseId: toId, quoteId: fromId, wantSide: 'base' }), give: 'quote' }
+}
+
+/** The market feed's pre-fee price oriented give→receive, in whole display
+ * units. Derived from the plan's exact price rational — plan.priceDisplay
+ * truncates at 8 fraction digits, which zeroes or skews small prices, and the
+ * give-quote inversion would amplify that loss. Assumes the wallet's
+ * safetyBps of 0 (QUOTE_OPTIONS): fee_bps is then the only gap between this
+ * rate and the plan's net payout. */
+export const preFeeDisplayRate = (plan: OfferPlan): number => {
+  const { num, den } = displayPrice(plan.price, {
+    baseDecimals: plan.market.base_asset.decimals,
+    quoteDecimals: plan.market.quote_asset.decimals,
+  })
+  const rate = plan.give === 'base' ? Number(num) / Number(den) : Number(den) / Number(num)
+  return Number.isFinite(rate) && rate > 0 ? rate : 0
 }
 
 export type PlanError = 'insufficient-balance' | 'side-disabled' | 'below-min' | 'above-max' | 'below-dust'

--- a/src/lib/swapDisplay.ts
+++ b/src/lib/swapDisplay.ts
@@ -104,8 +104,12 @@ export function swapAmountBeforeFee(tx: Tx): SwapDisplayAmount | undefined {
   return swapAssetDisplayAmount(toAmount + fee, toDecimals, toTicker)
 }
 
-/** Rate the covenant enforced: receive-asset units bought by one unit of the
- * sent asset, recomputed from the stored atomic amounts. */
+/** Rate the swap was priced at, quoted pre-fee like the live composer's Rate
+ * row: the covenant pins the net payout, so gross it back up by the stored
+ * feeBps — the receipt's Swap fees row itemizes that same fee, and a
+ * net-derived rate would count it twice. Restored swaps may lack feeBps;
+ * then the net rate is all we have (matching the net Swap to row shown in
+ * that case). */
 export function swapPriceRateLabel(tx: Tx): string | undefined {
   const swap = tx.assetSwap
   if (!swap) return undefined
@@ -113,13 +117,14 @@ export function swapPriceRateLabel(tx: Tx): string | undefined {
   if (fromAmount === undefined || toAmount === undefined || fromDecimals === undefined || toDecimals === undefined)
     return undefined
   if (fromAmount <= BigInt(0) || toAmount <= BigInt(0)) return undefined
+  const grossToAmount = toAmount + (swapFeeAtomic(tx) ?? BigInt(0))
   // BTC always displays in sats (0 decimals) elsewhere on the receipt, but a
   // rate quoted per satoshi ("1 sats = 0.0000006 USD") is unreadable — quote
   // it per whole BTC instead, same as the live composer's rate line.
   const fromRateDecimals = swap.fromAssetId === 'btc' ? 8 : fromDecimals
   const toRateDecimals = swap.toAssetId === 'btc' ? 8 : toDecimals
   const fromUnits = new Decimal(fromAmount.toString()).div(Decimal.pow(10, fromRateDecimals))
-  const toUnits = new Decimal(toAmount.toString()).div(Decimal.pow(10, toRateDecimals))
+  const toUnits = new Decimal(grossToAmount.toString()).div(Decimal.pow(10, toRateDecimals))
   const rate = toUnits.div(fromUnits)
   const fromTicker = swapRouteTicker(swap.fromAssetId, swap.fromTicker)
   const toTicker = swapRouteTicker(swap.toAssetId, swap.toTicker)

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -22,7 +22,14 @@ import { extractError } from '../../../lib/error'
 import { formatFiatAmountParts, normalizeBitcoinUnit, prettyFiatAmount, prettyNumber } from '../../../lib/format'
 import { hapticLight, hapticSubtle, hapticTap } from '../../../lib/haptics'
 import { swapRouteTicker } from '../../../lib/swapDisplay'
-import { BTC_ASSET_ID, findMarket, makeCachedFeedFetch, QUOTE_OPTIONS, validatePlan } from '../../../lib/swap/markets'
+import {
+  BTC_ASSET_ID,
+  findMarket,
+  makeCachedFeedFetch,
+  preFeeDisplayRate,
+  QUOTE_OPTIONS,
+  validatePlan,
+} from '../../../lib/swap/markets'
 import { type AssetSwapQuoteSnapshot } from '../../../lib/swap/store'
 import { Currencies, Unit } from '../../../lib/types'
 import { AspContext } from '../../../providers/asp'
@@ -1332,11 +1339,10 @@ function buildQuoteFromPlan(
   const giveEstimate = fromCurrencyAvailable ? (fromUnitsProtocol * fromUsd) / unitOfAccountUsd : 0
   const selectedCurrencyAmount =
     plan && toAsset && grossUp > 0 && receivedCurrencyAmount > 0 ? receivedCurrencyAmount * grossUp : giveEstimate
-  // the Fees row on the same card itemizes the fee, so the Rate row quotes
-  // the market feed's pre-fee price — the number a user checks against the
-  // exchange; deriving it from the net receive amount baked the fee into the
-  // rate, reading as a price consistently fee_bps below the market
-  const rate = plan && toAsset ? preFeeDisplayRate(plan) : 0
+  // the review drawer's Fees row itemizes the fee, so the Rate row quotes the
+  // market feed's pre-fee price — a net-derived rate would count the fee
+  // twice and read consistently fee_bps below the market
+  const rate = plan ? preFeeDisplayRate(plan) : 0
   // the market fee is deducted from the payout, so show it in the receive
   // asset (like the Swap/Receive rows), not the wallet's fiat display currency:
   // the fee is the gross-minus-net gap
@@ -1365,15 +1371,6 @@ function buildQuoteFromPlan(
     // next to their amount and confirmed
     giveCurrencyValue: fromCurrencyAvailable ? (entryMode === 'fiat' ? giveEstimate : selectedCurrencyAmount) : 0,
   }
-}
-
-/** The market feed's pre-fee price oriented from→to: plan.priceDisplay is
- * always quote-per-base (whole display units), flipped when the user gives
- * the quote side. */
-function preFeeDisplayRate(plan: OfferPlan): number {
-  const price = Number(plan.priceDisplay)
-  if (!price || !Number.isFinite(price)) return 0
-  return plan.give === 'base' ? price : 1 / price
 }
 
 /** BTC's USD price and the solver's plan.*.display are both in whole-BTC
@@ -1470,17 +1467,17 @@ function formatLimitMessage(
   fromAsset: SwapAsset,
 ): string {
   if (!limit) return ''
-  const price = Number(plan.priceDisplay)
-  if (!price) return ''
+  const rate = preFeeDisplayRate(plan)
+  if (!rate) return ''
   const limitReceiveProtocol = Number(limit.display)
-  // the limits bound the NET receive side (post-fee), but priceDisplay is the
-  // pre-fee rate — gross the bound up by the market fee or the suggested give
-  // amount pays out just under the minimum
+  // the limits bound the NET receive side (post-fee), but the rate is the
+  // pre-fee price — gross the bound up by the market fee or the suggested
+  // give amount pays out just under the minimum
   const feeFraction = plan.market.fee_bps / 10_000
   const grossUp = feeFraction < 1 ? 1 / (1 - feeFraction) : 1
-  // priceDisplay is quote-per-base; convert the receive-side limit back to
-  // the give side using whichever side the plan actually gives
-  const giveProtocol = (plan.give === 'base' ? limitReceiveProtocol / price : limitReceiveProtocol * price) * grossUp
+  // the rate is oriented give→receive, so dividing the receive-side limit by
+  // it lands back on the give side in both market orientations
+  const giveProtocol = (limitReceiveProtocol / rate) * grossUp
   // the market card also bounds the give side directly (atomic units of the
   // deposit asset); the user must satisfy whichever constraint is tighter —
   // e.g. a 1,000-sat card floor outranks a smaller converted receive minimum

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -1332,7 +1332,11 @@ function buildQuoteFromPlan(
   const giveEstimate = fromCurrencyAvailable ? (fromUnitsProtocol * fromUsd) / unitOfAccountUsd : 0
   const selectedCurrencyAmount =
     plan && toAsset && grossUp > 0 && receivedCurrencyAmount > 0 ? receivedCurrencyAmount * grossUp : giveEstimate
-  const rate = fromUnitsProtocol > 0 ? receivedProtocol / fromUnitsProtocol : 0
+  // the Fees row on the same card itemizes the fee, so the Rate row quotes
+  // the market feed's pre-fee price — the number a user checks against the
+  // exchange; deriving it from the net receive amount baked the fee into the
+  // rate, reading as a price consistently fee_bps below the market
+  const rate = plan && toAsset ? preFeeDisplayRate(plan) : 0
   // the market fee is deducted from the payout, so show it in the receive
   // asset (like the Swap/Receive rows), not the wallet's fiat display currency:
   // the fee is the gross-minus-net gap
@@ -1361,6 +1365,15 @@ function buildQuoteFromPlan(
     // next to their amount and confirmed
     giveCurrencyValue: fromCurrencyAvailable ? (entryMode === 'fiat' ? giveEstimate : selectedCurrencyAmount) : 0,
   }
+}
+
+/** The market feed's pre-fee price oriented from→to: plan.priceDisplay is
+ * always quote-per-base (whole display units), flipped when the user gives
+ * the quote side. */
+function preFeeDisplayRate(plan: OfferPlan): number {
+  const price = Number(plan.priceDisplay)
+  if (!price || !Number.isFinite(price)) return 0
+  return plan.give === 'base' ? price : 1 / price
 }
 
 /** BTC's USD price and the solver's plan.*.display are both in whole-BTC

--- a/src/test/lib/swap/markets.test.ts
+++ b/src/test/lib/swap/markets.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'
-import { planOffer, quoteOffer } from '@arkade-os/solver-discovery'
-import { discoverMarkets, findMarket, QUOTE_OPTIONS, validatePlan } from '../../../lib/swap/markets'
+import { planOffer, quoteOffer, type DiscoveredMarket } from '@arkade-os/solver-discovery'
+import { discoverMarkets, findMarket, preFeeDisplayRate, QUOTE_OPTIONS, validatePlan } from '../../../lib/swap/markets'
 import { btcDepix, btcUsdt, DEPIX_ID, MARAT_ID, maratNapo, NAPO_ID, USDT_ID } from './fixtures'
 
 const fetchMocker = createFetchMock(vi)
@@ -70,6 +70,38 @@ describe('quoteOffer with the wallet quote options', () => {
     // 10_000 sats * 600_000 depix-atomic/sat * 9970bps = 59.82 DePix
     expect(plan.receive.atomic).toBe(BigInt(5_982_000_000))
     expect(plan.receive.display).toBe('59.82')
+  })
+})
+
+describe('preFeeDisplayRate', () => {
+  it('quotes the feed price giving the base side and its inverse giving the quote side', () => {
+    const base = planOffer({ market: btcUsdt, give: 'base', giveAmount: BigInt(10_000), feedValue: 100_000 })
+    expect(preFeeDisplayRate(base)).toBe(100_000)
+    const quote = planOffer({ market: btcUsdt, give: 'quote', giveAmount: BigInt(1_000), feedValue: 100_000 })
+    expect(preFeeDisplayRate(quote)).toBe(0.00001)
+  })
+
+  it('survives display prices below the 8-decimal floor of plan.priceDisplay', () => {
+    // a registry may publish BTC as the QUOTE asset; a base token worth under
+    // a satoshi then has a display price that priceDisplay truncates to
+    // "0.00000000" — the exact rational must still price the Rate row
+    const tokenBtc: DiscoveredMarket = {
+      ...btcUsdt,
+      pair: 'TOKEN/BTC',
+      base_asset: { id: 'aa'.repeat(34), name: 'Token', ticker: 'TOK', decimals: 8 },
+      quote_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+      price_decimals: 0,
+    }
+    const base = planOffer({
+      market: tokenBtc,
+      give: 'base',
+      giveAmount: BigInt(100_000_000),
+      feedValue: '0.000000005',
+    })
+    expect(Number(base.priceDisplay)).toBe(0)
+    expect(preFeeDisplayRate(base)).toBe(5e-9)
+    const quote = planOffer({ market: tokenBtc, give: 'quote', giveAmount: BigInt(1_000), feedValue: '0.000000005' })
+    expect(preFeeDisplayRate(quote)).toBe(200_000_000)
   })
 })
 

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -468,6 +468,9 @@ describe('Wallet swap flow', () => {
     expect(screen.getByText('Confirm swap')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'USD to BTC' })).toBeInTheDocument()
     expect(screen.queryByText(/\d\.\d+ sats/)).not.toBeInTheDocument()
+    // giving the quote side inverts the pre-fee feed price: 1/63,000 per USD,
+    // not the 63,000 the un-flipped base orientation would show
+    expect(screen.getByText('1 USD = 0.00001587 BTC')).toBeInTheDocument()
   })
 
   it('prices the give side off the live quote, not an independently-estimated price that can disagree with it', async () => {

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -425,8 +425,11 @@ describe('Wallet swap flow', () => {
     await waitFor(() => expect(continueButton).toBeEnabled(), { timeout: 3_000 })
     fireEvent.click(continueButton)
     expect(screen.getByRole('heading', { name: 'BTC to USD' })).toBeInTheDocument()
-    // the review drawer's rate is quoted per whole BTC, not per satoshi
-    expect(screen.getByText(/^1 BTC = /)).toBeInTheDocument()
+    // the review drawer's rate is quoted per whole BTC, not per satoshi, and
+    // shows the feed's pre-fee price — the fee is itemized on its own row, so
+    // the rate must read $100,000 (the feed), not the net 99,700 that baking
+    // the fee in would show
+    expect(screen.getByText('1 BTC = 100,000 USD')).toBeInTheDocument()
     // the fee is shown in the receive asset (USD), not the wallet's display
     // currency — 9.97 received net of a 0.30% fee means a 0.03 USD fee
     expect(screen.getByText('0.03 USD')).toBeInTheDocument()

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -517,7 +517,9 @@ describe('Transaction screen', () => {
     expect(screen.queryByTestId('Transaction ID')).not.toBeInTheDocument()
     expect(screen.queryByText('Direction')).not.toBeInTheDocument()
     expect(screen.queryByText('Amount')).not.toBeInTheDocument()
-    expect(screen.getByTestId('Price rate')).toHaveTextContent('1 ALP = 0.5499')
+    // the rate is pre-fee like the live composer's Rate row — the gross
+    // 68.094 BET over 123.45 ALP, not the net 67.89-derived 0.5499
+    expect(screen.getByTestId('Price rate')).toHaveTextContent('1 ALP = 0.55159174')
     expect(screen.getByTestId('Network fees')).toHaveTextContent('$0.00')
     // the fee is shown in the receive asset (like the live composer), not a
     // bare percentage — 67.89 BET received net of a 0.30% fee is a 0.204 BET fee


### PR DESCRIPTION
## Summary

The swap review screen's quoted price read consistently *lower* than Binance (and every other exchange). The Rate row was derived from the **net** receive amount, so the market fee (`fee_bps`) was baked into the quoted rate — even though the same fee is already itemized on its own Fees row on the same card. The rate now quotes the market feed's **pre-fee** price, so it matches the exchange price and the fee appears exactly once.

## The bug

The rate was computed as `receive ÷ deposit`. But the solver's planned receive amount is already net of the market fee, so the displayed rate was always `feed price × (1 − fee_bps/10⁴)`:

- **BTC/USDT** (fee 30 bps): rate read **0.3% below** its feed.
- **BTC/DePix** (fee 110 bps): rate read **1.1% below** Binance — and this market's price feed literally *is* Binance (`api.binance.com/.../ticker/price?symbol=BTCBRL`), which is why the divergence was so conspicuous and always in the "lower" direction.

This also double-represented the fee: it was hidden inside the rate *and* shown on the Fees row, so the card's numbers didn't reconcile.

## The fix

**Commit 901ba49** — the Rate row quotes the solver's pre-fee feed price instead of the net-derived rate, flipped (`1/P`) when the user gives the quote side. Swapping 10,000 sats at a $100,000 feed with a 30 bps fee:

| Row | Before | After |
|---|---|---|
| Swap | 0.00010000 BTC | 0.00010000 BTC |
| Receive | 9.97 USDT | 9.97 USDT |
| Fees | 0.03 USDT | 0.03 USDT |
| Rate | 1 BTC = 99,700 USDT | 1 BTC = **100,000** USDT |

The card is now arithmetically consistent: **Receive = Swap × Rate − Fees** (0.0001 × 100,000 − 0.03 = 9.97 ✓).

**Commit 525aff1** — follow-ups from review:

- **Exact rate math**: the first commit read `plan.priceDisplay`, which the SDK truncates at 8 fraction digits ("display only, never pricing"). A market whose quote-per-base display price is below 1e-8 (e.g. a registry publishing BTC as the *quote* asset over a sub-satoshi-priced base token) would render a `0` rate, and small prices lost significant digits — amplified through `1/x` on the give-quote side. The rate is now derived from the plan's exact `price` rational via the SDK's `displayPrice`. The helper lives in `lib/swap/markets.ts` (`preFeeDisplayRate`), unit-tested for both orientations and the sub-1e-8 case, and `formatLimitMessage`'s duplicate orientation flip is folded into it.
- **Receipt consistency**: the transaction receipt's "Price rate" row still derived a net-of-fee rate from the stored amounts, so the same swap showed `100,000` at confirm time and `99,700` in activity — and the receipt double-counted the fee against its own gross "Swap to" and "Swap fees" rows. It now grosses the stored net payout back up by the persisted `feeBps`, matching the composer. Restored swaps without `feeBps` keep the net fallback, consistent with the net "Swap to" row shown in that case.
- **Coverage**: the review drawer's give-quote (USD→BTC) inverted rate is now asserted (`1 USD = 0.00001587 BTC` at a $63,000 feed) — this also addresses CodeRabbit's review comment.

## How the fee deduction works (math unchanged by this PR)

No payout amounts changed, and the wallet does no manual fee arithmetic — the fee lives in the solver's payout math, where it always was:

1. The market's `price_feed` returns the raw market price (no fee in it).
2. The solver SDK (`@arkade-os/solver-discovery`, `computeWantAmount`) computes the payout with the fee deducted from fair value: `receive = deposit × price × (1 − fee_bps/10000)`. This net amount is what gets locked into the offer and enforced by the covenant. The wallet passes `safetyBps: 0`, so `fee_bps` is the *only* concession off the feed price.
3. The wallet's Fees row displays the gross−net gap (`received × fee/(1−fee)`), i.e. the same deduction the solver applied — shown once, in the receive asset.

So the fee was never "in the feed" and is not "added manually" now: what the user receives, what the solver enforces, and what gets persisted are byte-identical to before. The Rate rows (review drawer and receipt) simply stopped disguising the fee as a worse price.

Residual (small) divergence vs Binance can still come from the feed source itself — e.g. BTC/USDT prices off CoinGecko's index per the solver registry — and from quote staleness (the wallet caches feed responses for 30s and doesn't re-quote an idle review drawer). Those are registry/product decisions, out of scope here.

## Test plan

- `swap.test.tsx` pins the exact pre-fee rate for both orientations: `1 BTC = 100,000 USD` (give base) and `1 USD = 0.00001587 BTC` (give quote, inverted).
- New `preFeeDisplayRate` unit tests in `markets.test.ts` cover both orientations plus the sub-1e-8 display price the truncated `priceDisplay` would zero out.
- `transaction.test.tsx` asserts the receipt's gross-derived rate (`1 ALP = 0.55159174`) reconciling with its gross "Swap to" row.
- Full unit suite: 64 files, 510 passed / 3 skipped. Lint and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLtvQ4AoGG11FyGQfbwByR