### PR TITLE
Reduce the data included in error reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ node_modules/
 
 # plans
 docs/plans/
+plans/
 # Claude Code
 .claude/
 CLAUDE.md

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,7 @@ import * as Sentry from '@sentry/react'
 import { SwapsProvider } from './providers/swaps'
 import { AssetSwapsProvider } from './providers/assetSwaps'
 import { LnurlProvider } from './providers/lnurl'
-import { shouldInitializeSentry } from './lib/sentry'
+import { beforeSend, scrubBreadcrumb, shouldInitializeSentry } from './lib/sentry'
 import { FeesProvider } from './providers/fees'
 import { AnnouncementProvider } from './providers/announcements'
 import { ToastProvider } from './components/Toast'
@@ -44,18 +44,8 @@ if (shouldInitializeSentry(sentryDsn)) {
     enableLogs: true,
     ignoreErrors: [/null is not an object.*a\[je\]/i, /translate\.googleapis\.com.*translate_http/],
     denyUrls: [/translate\.google\.com\/translate_a\/element\.js/, /translate\.googleapis\.com/],
-    beforeSend(event, hint) {
-      const error = hint.originalException
-      const isTranslateOrigin =
-        (error instanceof Error && error.stack?.includes('translate.google.com')) ||
-        event.exception?.values?.some((v) =>
-          v.stacktrace?.frames?.some((f) => f.filename?.includes('translate.googleapis.com')),
-        )
-      if (isTranslateOrigin) {
-        return null
-      }
-      return event
-    },
+    beforeSend,
+    beforeBreadcrumb: scrubBreadcrumb,
   })
 }
 

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -98,13 +98,7 @@ export const collaborativeExit = async (wallet: IWallet, amount: number, address
   try {
     return await wallet.settle({ inputs: selectedVtxos, outputs })
   } catch (error) {
-    await captureSettleError(error, wallet, 'collaborativeExit', {
-      amount,
-      address,
-      selectedAmount,
-      changeAmount,
-      selectedVtxos: serializeForSentry(selectedVtxos),
-    })
+    captureSettleError(error, 'collaborativeExit', { amount, changeAmount, ...summarizeInputs(selectedVtxos) })
     throw error
   }
 }
@@ -148,13 +142,11 @@ export const collaborativeExitWithFees = async (
   try {
     return await wallet.settle({ inputs: selectedVtxos, outputs })
   } catch (error) {
-    await captureSettleError(error, wallet, 'collaborativeExitWithFees', {
+    captureSettleError(error, 'collaborativeExitWithFees', {
       inputAmount,
       outputAmount,
-      address,
-      selectedAmount,
       changeAmount,
-      selectedVtxos: serializeForSentry(selectedVtxos),
+      ...summarizeInputs(selectedVtxos),
     })
     throw error
   }
@@ -263,12 +255,7 @@ export const redeemNotes = async (wallet: IWallet, notes: string[]): Promise<voi
       outputs: [{ address: offchainAddr, amount }],
     })
   } catch (error) {
-    await captureSettleError(error, wallet, 'redeemNotes', {
-      notesCount: notes.length,
-      amount: amount.toString(),
-      offchainAddr,
-      inputs: serializeForSentry(inputs),
-    })
+    captureSettleError(error, 'redeemNotes', summarizeInputs(inputs))
     throw error
   }
 }
@@ -316,11 +303,10 @@ export const settleVtxos = async (
   try {
     await wallet.settle({ inputs, outputs }, console.log)
   } catch (error) {
-    await captureSettleError(error, wallet, 'settleVtxos', {
-      amount: amount.toString(),
-      dustAmount: dustAmount.toString(),
+    captureSettleError(error, 'settleVtxos', {
+      dustAmount: Number(dustAmount),
       thresholdMs,
-      inputs: serializeForSentry(inputs),
+      ...summarizeInputs(inputs),
     })
     throw error
   }
@@ -378,25 +364,19 @@ export const delegateVtxos = async (wallet: ServiceWorkerWallet): Promise<void> 
   }
 }
 
-const serializeForSentry = (value: any): string => {
-  return JSON.stringify(value, (key, val) => (typeof val === 'bigint' ? val.toString() : val))
-}
+// Settle diagnostics are limited to shape and size; inputs are never serialized.
+const summarizeInputs = (inputs: { value: number }[]): { count: number; totalValue: number } => ({
+  count: inputs.length,
+  totalValue: inputs.reduce((sum, input) => sum + input.value, 0),
+})
 
-const captureSettleError = async (
+const captureSettleError = (
   error: unknown,
-  wallet: IWallet,
   functionName: string,
-  baseContext: Record<string, any>,
-): Promise<void> => {
-  const settleContext: Record<string, any> = { ...baseContext }
-  try {
-    settleContext.walletAddress = await wallet.getAddress()
-  } catch {
-    // Ignore if getAddress fails
-  }
+  context: Record<string, number | undefined>,
+): void => {
   Sentry.captureException(error, {
     tags: { function: functionName },
-    contexts: { settle: settleContext },
+    contexts: { settle: context },
   })
-  throw error
 }

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -21,6 +21,7 @@ import { getConfirmedAndNotExpiredUtxos } from './utxo'
 import * as Sentry from '@sentry/react'
 import { hex } from '@scure/base'
 import { readTransactionActivityMetadata } from './storage'
+import { walletFingerprint } from './sentry'
 
 const emptyFees: FeeInfo = {
   intentFee: { offchainInput: '', offchainOutput: '', onchainInput: '', onchainOutput: '' },
@@ -98,7 +99,11 @@ export const collaborativeExit = async (wallet: IWallet, amount: number, address
   try {
     return await wallet.settle({ inputs: selectedVtxos, outputs })
   } catch (error) {
-    captureSettleError(error, 'collaborativeExit', { amount, changeAmount, ...summarizeInputs(selectedVtxos) })
+    await captureSettleError(error, wallet, 'collaborativeExit', {
+      amount,
+      changeAmount,
+      ...summarizeInputs(selectedVtxos),
+    })
     throw error
   }
 }
@@ -142,7 +147,7 @@ export const collaborativeExitWithFees = async (
   try {
     return await wallet.settle({ inputs: selectedVtxos, outputs })
   } catch (error) {
-    captureSettleError(error, 'collaborativeExitWithFees', {
+    await captureSettleError(error, wallet, 'collaborativeExitWithFees', {
       inputAmount,
       outputAmount,
       changeAmount,
@@ -255,7 +260,7 @@ export const redeemNotes = async (wallet: IWallet, notes: string[]): Promise<voi
       outputs: [{ address: offchainAddr, amount }],
     })
   } catch (error) {
-    captureSettleError(error, 'redeemNotes', summarizeInputs(inputs))
+    await captureSettleError(error, wallet, 'redeemNotes', summarizeInputs(inputs))
     throw error
   }
 }
@@ -303,7 +308,7 @@ export const settleVtxos = async (
   try {
     await wallet.settle({ inputs, outputs }, console.log)
   } catch (error) {
-    captureSettleError(error, 'settleVtxos', {
+    await captureSettleError(error, wallet, 'settleVtxos', {
       dustAmount: Number(dustAmount),
       thresholdMs,
       ...summarizeInputs(inputs),
@@ -370,13 +375,20 @@ const summarizeInputs = (inputs: { value: number }[]): { count: number; totalVal
   totalValue: inputs.reduce((sum, input) => sum + input.value, 0),
 })
 
-const captureSettleError = (
+const captureSettleError = async (
   error: unknown,
+  wallet: IWallet,
   functionName: string,
   context: Record<string, number | undefined>,
-): void => {
+): Promise<void> => {
+  const settle: Record<string, number | string | undefined> = { ...context }
+  try {
+    settle.wallet = walletFingerprint(await wallet.getAddress())
+  } catch {
+    // report without it if the address is unavailable
+  }
   Sentry.captureException(error, {
     tags: { function: functionName },
-    contexts: { settle: context },
+    contexts: { settle },
   })
 }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -25,8 +25,9 @@ const REDACTED = '[redacted]'
 // 40 hex chars = 20 bytes (HASH160): the shortest bitcoin-sized value.
 const HEX_RUN = /[0-9a-f]{40,}/gi
 // 6 chars = the bech32 checksum, the minimum after the separator (BIP173).
-const BECH32 = /\b(?:bc|tb|bcrt|ark|tark)1[02-9ac-hj-np-z]{6,}/gi
-const SENSITIVE_KEY = /preimage|secret|seckey|priv|mnemonic|seed|addr|script|pubkey|outpoint/i
+const BECH32 = /\b(?:bc|tb|bcrt|ark|tark|nsec)1[02-9ac-hj-np-z]{6,}/gi
+const SENSITIVE_KEY =
+  /preimage|secret|seckey|priv|mnemonic|seed|addr|script|pubkey|outpoint|auth|cookie|token|password|passphrase|api[-_]?key|session/i
 
 const scrubString = (value: string): string => value.replace(HEX_RUN, REDACTED).replace(BECH32, REDACTED)
 

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,4 +1,6 @@
 import type { Breadcrumb, ErrorEvent, EventHint } from '@sentry/react'
+import { sha256 } from '@noble/hashes/sha2.js'
+import { hex, utf8 } from '@scure/base'
 
 /**
  * Check if the current environment is production (not localhost)
@@ -78,6 +80,13 @@ export const scrubEvent = (event: ErrorEvent): ErrorEvent => {
   }
   return event
 }
+
+/**
+ * Correlate reports coming from the same wallet without naming it. 16 hex chars
+ * = 8 bytes, collision-free at wallet scale; the address hashed carries a
+ * 32-byte key, so the digest has no enumerable input space.
+ */
+export const walletFingerprint = (address: string): string => hex.encode(sha256(utf8.decode(address))).slice(0, 16)
 
 const isTranslateNoise = (event: ErrorEvent, hint: EventHint): boolean => {
   const error = hint.originalException

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,3 +1,5 @@
+import type { Breadcrumb, ErrorEvent, EventHint } from '@sentry/react'
+
 /**
  * Check if the current environment is production (not localhost)
  * @returns true if the hostname is not localhost or 127.0.0.1
@@ -15,3 +17,78 @@ export const isProduction = (): boolean => {
 export const shouldInitializeSentry = (dsn: string | undefined): boolean => {
   return Boolean(dsn) && isProduction()
 }
+
+const REDACTED = '[redacted]'
+
+// 40 hex chars = 20 bytes (HASH160): the shortest bitcoin-sized value.
+const HEX_RUN = /[0-9a-f]{40,}/gi
+// 6 chars = the bech32 checksum, the minimum after the separator (BIP173).
+const BECH32 = /\b(?:bc|tb|bcrt|ark|tark)1[02-9ac-hj-np-z]{6,}/gi
+const SENSITIVE_KEY = /preimage|secret|seckey|priv|mnemonic|seed|addr|script|pubkey|outpoint/i
+
+const scrubString = (value: string): string => value.replace(HEX_RUN, REDACTED).replace(BECH32, REDACTED)
+
+const scrubValue = (value: unknown, seen: WeakSet<object> = new WeakSet()): unknown => {
+  if (typeof value === 'string') return scrubString(value)
+  if (typeof value !== 'object' || value === null) return value
+  if (seen.has(value)) return REDACTED
+  seen.add(value)
+  if (Array.isArray(value)) return value.map((item) => scrubValue(item, seen))
+  return Object.fromEntries(
+    Object.entries(value).map(([key, val]) => [key, SENSITIVE_KEY.test(key) ? REDACTED : scrubValue(val, seen)]),
+  )
+}
+
+const toOrigin = (url: string): string => {
+  try {
+    return new URL(url, window.location.origin).origin
+  } catch {
+    return REDACTED
+  }
+}
+
+/**
+ * Keep request breadcrumbs to the origin: paths and query strings carry wallet
+ * scripts and outpoints.
+ */
+export const scrubBreadcrumb = (breadcrumb: Breadcrumb): Breadcrumb => {
+  const { data, message } = breadcrumb
+  const url = data?.url
+  return {
+    ...breadcrumb,
+    ...(data
+      ? { data: scrubValue(typeof url === 'string' ? { ...data, url: toOrigin(url) } : data) as Breadcrumb['data'] }
+      : {}),
+    ...(message ? { message: scrubString(message) } : {}),
+  }
+}
+
+/**
+ * Reports carry counts, amounts and error shapes only — key material, addresses
+ * and scripts are removed whatever the call site attached.
+ */
+export const scrubEvent = (event: ErrorEvent): ErrorEvent => {
+  if (event.contexts) event.contexts = scrubValue(event.contexts) as ErrorEvent['contexts']
+  if (event.extra) event.extra = scrubValue(event.extra) as ErrorEvent['extra']
+  if (event.tags) event.tags = scrubValue(event.tags) as ErrorEvent['tags']
+  if (event.request) event.request = scrubValue(event.request) as ErrorEvent['request']
+  if (event.breadcrumbs) event.breadcrumbs = event.breadcrumbs.map(scrubBreadcrumb)
+  for (const exception of event.exception?.values ?? []) {
+    if (exception.value) exception.value = scrubString(exception.value)
+  }
+  return event
+}
+
+const isTranslateNoise = (event: ErrorEvent, hint: EventHint): boolean => {
+  const error = hint.originalException
+  return (
+    (error instanceof Error && error.stack?.includes('translate.google.com')) ||
+    event.exception?.values?.some((v) =>
+      v.stacktrace?.frames?.some((f) => f.filename?.includes('translate.googleapis.com')),
+    ) ||
+    false
+  )
+}
+
+export const beforeSend = (event: ErrorEvent, hint: EventHint): ErrorEvent | null =>
+  isTranslateNoise(event, hint) ? null : scrubEvent(event)

--- a/src/test/lib/asp.test.ts
+++ b/src/test/lib/asp.test.ts
@@ -31,6 +31,7 @@ vi.mock('@arkade-os/sdk', async (importOriginal) => {
 import { ArkNote } from '@arkade-os/sdk'
 import { getAspInfo, aspErrorText, emptyAspInfo, byExpiryAsc, getTxHistory, redeemNotes } from '../../lib/asp'
 import { saveTransactionActivityMetadata } from '../../lib/storage'
+import { walletFingerprint } from '../../lib/sentry'
 import fixtures from '../fixtures.json'
 
 beforeEach(() => {
@@ -97,7 +98,7 @@ describe('settle failure reporting', () => {
     },
   }
 
-  it('reports input count and total only', async () => {
+  it('reports input count, total and a wallet fingerprint only', async () => {
     const note = new ArkNote(new Uint8Array(32).fill(7), 1000).toString()
 
     await expect(redeemNotes(failingWallet as any, [note])).rejects.toThrow('settle failed')
@@ -105,7 +106,11 @@ describe('settle failure reporting', () => {
     const [, options] = captureException.mock.calls[0]
     const { settle } = options.contexts
 
-    expect(settle).toEqual({ count: 1, totalValue: 1000 })
+    expect(settle).toEqual({
+      count: 1,
+      totalValue: 1000,
+      wallet: walletFingerprint(fixtures.lib.address.ark[0].address),
+    })
     expect(JSON.stringify(settle)).not.toMatch(/[0-9a-f]{20,}/i)
   })
 })

--- a/src/test/lib/asp.test.ts
+++ b/src/test/lib/asp.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }))
+vi.mock('@sentry/react', () => ({ captureException }))
+
 // Keep the real SDK (so ArkError stays a real class for the instanceof check in
 // getAspInfo) and only override RestArkProvider to control what getInfo throws.
 vi.mock('@arkade-os/sdk', async (importOriginal) => {
@@ -25,11 +28,14 @@ vi.mock('@arkade-os/sdk', async (importOriginal) => {
   }
 })
 
-import { getAspInfo, aspErrorText, emptyAspInfo, byExpiryAsc, getTxHistory } from '../../lib/asp'
+import { ArkNote } from '@arkade-os/sdk'
+import { getAspInfo, aspErrorText, emptyAspInfo, byExpiryAsc, getTxHistory, redeemNotes } from '../../lib/asp'
 import { saveTransactionActivityMetadata } from '../../lib/storage'
+import fixtures from '../fixtures.json'
 
 beforeEach(() => {
   localStorage.clear()
+  captureException.mockClear()
 })
 
 describe('byExpiryAsc', () => {
@@ -79,6 +85,28 @@ describe('getAspInfo', () => {
     const info = await getAspInfo('down.example.com')
     expect(info.unreachable).toBe(true)
     expect(info.outdated).toBeFalsy()
+  })
+})
+
+describe('settle failure reporting', () => {
+  const failingWallet = {
+    getAddress: async () => fixtures.lib.address.ark[0].address,
+    getBoardingAddress: async () => fixtures.lib.address.btc[0],
+    settle: async () => {
+      throw new Error('settle failed')
+    },
+  }
+
+  it('reports input count and total only', async () => {
+    const note = new ArkNote(new Uint8Array(32).fill(7), 1000).toString()
+
+    await expect(redeemNotes(failingWallet as any, [note])).rejects.toThrow('settle failed')
+
+    const [, options] = captureException.mock.calls[0]
+    const { settle } = options.contexts
+
+    expect(settle).toEqual({ count: 1, totalValue: 1000 })
+    expect(JSON.stringify(settle)).not.toMatch(/[0-9a-f]{20,}/i)
   })
 })
 

--- a/src/test/lib/sentry.test.ts
+++ b/src/test/lib/sentry.test.ts
@@ -178,6 +178,30 @@ describe('Sentry utilities', () => {
       expect(scrubEvent(event).exception?.values?.[0].value).toBe('settle failed for [redacted]')
     })
 
+    it('removes credentials from nested request headers', () => {
+      const event = {
+        request: {
+          url: 'https://arkade.money/',
+          headers: { Authorization: 'Bearer s3cr3t', Cookie: 'session=abc', 'X-API-Key': 'k-123' },
+        },
+      } as unknown as ErrorEvent
+
+      const request = JSON.stringify(scrubEvent(event).request)
+
+      expect(request).not.toContain('s3cr3t')
+      expect(request).not.toContain('abc')
+      expect(request).not.toContain('k-123')
+      expect(request).toContain('https://arkade.money/')
+    })
+
+    it('removes an nsec carried under a benign key', () => {
+      const event = {
+        contexts: { restore: { input: `entered ${fixtures.lib.privatekey.secret.nsec}` } },
+      } as unknown as ErrorEvent
+
+      expect(scrubEvent(event).contexts?.restore).toEqual({ input: 'entered [redacted]' })
+    })
+
     it('leaves an unrelated event untouched', () => {
       const event = { contexts: { app: { app_version: '1.2.3' } } } as unknown as ErrorEvent
 

--- a/src/test/lib/sentry.test.ts
+++ b/src/test/lib/sentry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import type { ErrorEvent } from '@sentry/react'
-import { isProduction, scrubBreadcrumb, scrubEvent, shouldInitializeSentry } from '../../lib/sentry'
+import { isProduction, scrubBreadcrumb, scrubEvent, shouldInitializeSentry, walletFingerprint } from '../../lib/sentry'
 import fixtures from '../fixtures.json'
 
 describe('Sentry utilities', () => {
@@ -182,6 +182,26 @@ describe('Sentry utilities', () => {
       const event = { contexts: { app: { app_version: '1.2.3' } } } as unknown as ErrorEvent
 
       expect(scrubEvent(event).contexts?.app).toEqual({ app_version: '1.2.3' })
+    })
+  })
+
+  describe('walletFingerprint', () => {
+    const [first, second] = fixtures.lib.address.ark
+
+    it('is stable, short and does not contain the address', () => {
+      expect(walletFingerprint(first.address)).toBe(walletFingerprint(first.address))
+      expect(walletFingerprint(first.address)).toMatch(/^[0-9a-f]{16}$/)
+      expect(first.address).not.toContain(walletFingerprint(first.address))
+    })
+
+    it('separates wallets', () => {
+      expect(walletFingerprint(first.address)).not.toBe(walletFingerprint(second.address))
+    })
+
+    it('survives scrubbing', () => {
+      const event = { contexts: { settle: { wallet: walletFingerprint(first.address) } } } as unknown as ErrorEvent
+
+      expect(scrubEvent(event).contexts?.settle).toEqual({ wallet: walletFingerprint(first.address) })
     })
   })
 

--- a/src/test/lib/sentry.test.ts
+++ b/src/test/lib/sentry.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { isProduction, shouldInitializeSentry } from '../../lib/sentry'
+import type { ErrorEvent } from '@sentry/react'
+import { isProduction, scrubBreadcrumb, scrubEvent, shouldInitializeSentry } from '../../lib/sentry'
+import fixtures from '../fixtures.json'
 
 describe('Sentry utilities', () => {
   let originalHostname: string
@@ -141,6 +143,62 @@ describe('Sentry utilities', () => {
         writable: true,
       })
       expect(shouldInitializeSentry('https://sentry.io/test-dsn')).toBe(true)
+    })
+  })
+
+  describe('scrubEvent', () => {
+    const arkAddress = fixtures.lib.address.ark[0].address
+    const script = fixtures.lib.address.ark[0].vtxoTaprootKey
+
+    it('removes key material, addresses and scripts from contexts', () => {
+      const event = {
+        contexts: {
+          settle: {
+            count: 2,
+            totalValue: 1000,
+            walletAddress: arkAddress,
+            note: { preimage: 'a'.repeat(64) },
+            inputs: [`${script}:0`],
+          },
+        },
+      } as unknown as ErrorEvent
+
+      const settle = scrubEvent(event).contexts?.settle as Record<string, unknown>
+
+      expect(settle).toMatchObject({ count: 2, totalValue: 1000 })
+      expect(JSON.stringify(settle)).not.toMatch(/[0-9a-f]{20,}/i)
+      expect(JSON.stringify(settle)).not.toContain('tark1')
+    })
+
+    it('removes them from exception messages too', () => {
+      const event = {
+        exception: { values: [{ value: `settle failed for ${arkAddress}` }] },
+      } as unknown as ErrorEvent
+
+      expect(scrubEvent(event).exception?.values?.[0].value).toBe('settle failed for [redacted]')
+    })
+
+    it('leaves an unrelated event untouched', () => {
+      const event = { contexts: { app: { app_version: '1.2.3' } } } as unknown as ErrorEvent
+
+      expect(scrubEvent(event).contexts?.app).toEqual({ app_version: '1.2.3' })
+    })
+  })
+
+  describe('scrubBreadcrumb', () => {
+    it('keeps request urls to their origin', () => {
+      const crumb = scrubBreadcrumb({
+        category: 'fetch',
+        data: { method: 'GET', status_code: 500, url: `https://arkade.computer/v1/vtxos/${'ab'.repeat(32)}?page=1` },
+      })
+
+      expect(crumb.data).toEqual({ method: 'GET', status_code: 500, url: 'https://arkade.computer' })
+    })
+
+    it('leaves non-request breadcrumbs alone', () => {
+      const crumb = scrubBreadcrumb({ category: 'ui.click', message: 'button#send' })
+
+      expect(crumb).toEqual({ category: 'ui.click', message: 'button#send' })
     })
   })
 })


### PR DESCRIPTION
Settle failures now report input count, amounts and a short wallet fingerprint instead of serialized inputs and addresses.

- allowlist serializer for settle diagnostics, replacing the full `JSON.stringify` of inputs
- `walletAddress` replaced by `sha256(address)` truncated to 8 bytes, so reports from one wallet still correlate
- event and breadcrumb scrubbers in `lib/sentry.ts`, wired in from `index.tsx`: request breadcrumbs keep their origin only, and known-sensitive keys and long hex/bech32 values are redacted wherever they appear
- Google Translate noise filter moved into `lib/sentry.ts` alongside them

Support looking up a report by address needs to hash it first — `walletFingerprint` is exported for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Privacy & Security**
  - Sensitive error-reporting data is now scrubbed, including wallet addresses, key material, scripts, URLs, and exception details.
  - Wallets are represented by privacy-preserving fingerprints.
  - Settlement diagnostics now report summarized counts and totals instead of detailed input data.
  - Unrelated error information remains available for troubleshooting.

- **Bug Fixes**
  - Google Translate-related noise is filtered from error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->