### PR TITLE
Add standard security headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN echo "export const gitCommit = '${GIT_COMMIT}'" > src/_gitCommit.ts && \
 
 FROM nginx:alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx-security-headers.conf /etc/nginx/security-headers.conf
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/nginx-security-headers.conf
+++ b/nginx-security-headers.conf
@@ -1,0 +1,7 @@
+# Included from every block in nginx.conf that sets its own add_header: a
+# location-level add_header discards all headers inherited from the parent,
+# so these have to be repeated wherever that happens.
+add_header X-Frame-Options "DENY";
+add_header Content-Security-Policy "frame-ancestors 'none'";
+add_header Referrer-Policy "strict-origin-when-cross-origin";
+add_header X-Content-Type-Options "nosniff";

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,8 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    include /etc/nginx/security-headers.conf;
+
     location / {
         try_files $uri $uri/ /index.html;
     }
@@ -16,10 +18,12 @@ server {
     location ~ \.mjs$ {
         default_type application/javascript;
         add_header Cache-Control "no-cache";
+        include /etc/nginx/security-headers.conf;
     }
 
     location ~* \.(?:css|js|svg|png|jpg|jpeg|gif|ico|woff2?|ttf|eot|map)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        include /etc/nginx/security-headers.conf;
     }
 }

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/*
+  X-Frame-Options: DENY
+  Content-Security-Policy: frame-ancestors 'none'
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff


### PR DESCRIPTION
Adds `X-Frame-Options`, `Content-Security-Policy: frame-ancestors 'none'`, `Referrer-Policy` and `X-Content-Type-Options` to both deployments.

- nginx: headers live in `nginx-security-headers.conf` and are included in the `server` block and in each `location` that sets its own `add_header` — a location-level `add_header` drops everything inherited from the parent.
- Cloudflare Pages: `public/_headers`, copied verbatim by Vite.

The CSP carries only `frame-ancestors`, so scripts and connections are unrestricted and no existing integration is affected.

Verified on a local image build: all four headers present on `/`, `/wallet-service-worker.mjs`, `/assets/*.js` and `/manifest.json`, with the existing `Cache-Control` values intact.