### PR TITLE
Confirm app payment and signing requests

### DIFF
--- a/src/components/BridgeConfirmSheet.tsx
+++ b/src/components/BridgeConfirmSheet.tsx
@@ -1,0 +1,40 @@
+import Button from './Button'
+import FlexCol from './FlexCol'
+import SheetModal from './SheetModal'
+import Table, { TableData } from './Table'
+import Text, { TextSecondary } from './Text'
+import Title from './Title'
+import type { ConfirmationRequest } from '../lib/appRequest'
+
+interface BridgeConfirmSheetProps {
+  onApprove: () => void
+  onReject: () => void
+  request: ConfirmationRequest | null
+}
+
+export default function BridgeConfirmSheet({ onApprove, onReject, request }: BridgeConfirmSheetProps) {
+  const data: TableData = (request?.rows ?? []).map(({ label, value }) => [label, value])
+
+  return (
+    <SheetModal isOpen={Boolean(request)} onClose={onReject}>
+      {request ? (
+        <FlexCol gap='1.5rem' testId='bridge-confirm-sheet'>
+          <FlexCol gap='0.25rem'>
+            <Title text={request.action} />
+            <TextSecondary>{request.app} is asking your wallet to do this</TextSecondary>
+          </FlexCol>
+          <Table data={data} variant='receipt' />
+          {request.note ? (
+            <Text small thin wrap color='neutral-500'>
+              {request.note}
+            </Text>
+          ) : null}
+          <FlexCol gap='0.5rem'>
+            <Button label={request.confirmLabel} onClick={onApprove} testId='bridge-confirm-approve' />
+            <Button label='Cancel' onClick={onReject} secondary testId='bridge-confirm-reject' />
+          </FlexCol>
+        </FlexCol>
+      ) : null}
+    </SheetModal>
+  )
+}

--- a/src/hooks/useBridgeConfirmation.ts
+++ b/src/hooks/useBridgeConfirmation.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { ConfirmationRequest } from '../lib/appRequest'
+
+/**
+ * Gate for actions an embedded app asks the wallet to perform. At most one
+ * request is live at a time, and it never outlives the screen that opened it.
+ */
+export function useBridgeConfirmation() {
+  const [request, setRequest] = useState<ConfirmationRequest | null>(null)
+  const pending = useRef<((approved: boolean) => void) | null>(null)
+
+  const settle = useCallback((approved: boolean) => {
+    const resolve = pending.current
+    pending.current = null
+    setRequest(null)
+    resolve?.(approved)
+  }, [])
+
+  const requestConfirmation = useCallback((next: ConfirmationRequest): Promise<boolean> => {
+    if (pending.current) return Promise.resolve(false)
+    return new Promise<boolean>((resolve) => {
+      pending.current = resolve
+      setRequest(next)
+    })
+  }, [])
+
+  useEffect(
+    () => () => {
+      const resolve = pending.current
+      pending.current = null
+      resolve?.(false)
+    },
+    [],
+  )
+
+  const approve = useCallback(() => settle(true), [settle])
+  const reject = useCallback(() => settle(false), [settle])
+
+  return { approve, reject, request, requestConfirmation }
+}

--- a/src/lib/appRequest.ts
+++ b/src/lib/appRequest.ts
@@ -1,0 +1,116 @@
+import { Transaction, getNetwork, type NetworkName } from '@arkade-os/sdk'
+import { hexToBytes } from '@noble/hashes/utils.js'
+import { prettyNumber } from './format'
+
+export interface ConfirmationRow {
+  label: string
+  value: string
+}
+
+export interface ConfirmationRequest {
+  app: string
+  action: string
+  confirmLabel: string
+  note?: string
+  rows: ConfirmationRow[]
+}
+
+export const isValidSendAmount = (amount: number): boolean =>
+  Number.isFinite(amount) && Number.isInteger(amount) && amount > 0
+
+const satsLabel = (amount: number): string => `${prettyNumber(amount, 0)} ${amount === 1 ? 'sat' : 'sats'}`
+
+export const sendConfirmation = (
+  app: string,
+  address: string,
+  amount: number,
+  offchain: boolean,
+): ConfirmationRequest => ({
+  app,
+  action: 'Confirm payment',
+  confirmLabel: 'Send',
+  note: offchain ? undefined : 'This payment leaves Arkade and settles on-chain, with on-chain fees.',
+  rows: [
+    { label: 'Amount', value: satsLabel(amount) },
+    { label: 'To', value: address },
+    { label: 'Network', value: offchain ? 'Arkade' : 'Bitcoin' },
+  ],
+})
+
+export interface PsbtOutput {
+  address: string
+  amount: number
+}
+
+export interface PsbtSummary {
+  inputCount: number
+  inputTotal: number
+  outputs: PsbtOutput[]
+  outputTotal: number
+  fee: number
+}
+
+type PsbtInput = ReturnType<Transaction['getInput']>
+
+/** Witness inputs carry the prevout directly; legacy ones reference it by index in the funding tx. */
+const inputAmount = (input: PsbtInput): number | undefined => {
+  const witnessAmount = input.witnessUtxo?.amount
+  if (witnessAmount !== undefined) return Number(witnessAmount)
+
+  const prevouts = input.nonWitnessUtxo?.outputs
+  const index = input.index
+  if (!prevouts || index === undefined || index < 0 || index >= prevouts.length) return undefined
+
+  const amount = prevouts[index]?.amount
+  return amount === undefined ? undefined : Number(amount)
+}
+
+/** Returns null when the transaction cannot be described in terms the user can act on. */
+export const summarizePsbt = (psbt: string, network: NetworkName): PsbtSummary | null => {
+  try {
+    const tx = Transaction.fromPSBT(hexToBytes(psbt))
+    if (tx.inputsLength === 0 || tx.outputsLength === 0) return null
+
+    let inputTotal = 0
+    for (let i = 0; i < tx.inputsLength; i++) {
+      const amount = inputAmount(tx.getInput(i))
+      if (amount === undefined) return null
+      inputTotal += amount
+    }
+
+    const btcNetwork = getNetwork(network)
+    const outputs: PsbtOutput[] = []
+    for (let i = 0; i < tx.outputsLength; i++) {
+      const address = tx.getOutputAddress(i, btcNetwork)
+      const amount = tx.getOutput(i).amount
+      if (!address || amount === undefined) return null
+      outputs.push({ address, amount: Number(amount) })
+    }
+
+    const outputTotal = outputs.reduce((total, output) => total + output.amount, 0)
+    if (outputTotal > inputTotal) return null
+
+    return { inputCount: tx.inputsLength, inputTotal, outputs, outputTotal, fee: inputTotal - outputTotal }
+  } catch {
+    return null
+  }
+}
+
+export const signConfirmation = (app: string, summary: PsbtSummary): ConfirmationRequest => {
+  const many = summary.outputs.length > 1
+  return {
+    app,
+    action: 'Confirm signature',
+    confirmLabel: 'Sign',
+    rows: [
+      ...summary.outputs.map((output, index) => ({
+        label: `${many ? `${index + 1}. ` : ''}Sends ${satsLabel(output.amount)} to`,
+        value: output.address,
+      })),
+      { label: 'Network fee', value: satsLabel(summary.fee) },
+      // transaction-level totals: the signer covers only the inputs it holds keys for, which is not known here
+      { label: 'Input total', value: satsLabel(summary.inputTotal) },
+      { label: 'Inputs in transaction', value: String(summary.inputCount) },
+    ],
+  }
+}

--- a/src/screens/Apps/Lendasat/Index.tsx
+++ b/src/screens/Apps/Lendasat/Index.tsx
@@ -11,11 +11,17 @@ import * as secp from '@noble/secp256k1'
 import { secp256k1 } from '@noble/curves/secp256k1.js'
 import { hmac } from '@noble/hashes/hmac.js'
 import { collaborativeExit, getReceivingAddresses } from '../../../lib/asp'
-import { Transaction, isValidArkAddress } from '@arkade-os/sdk'
+import { Transaction, isValidArkAddress, type NetworkName } from '@arkade-os/sdk'
 import { isBTCAddress } from '../../../lib/address'
+import { isValidSendAmount, sendConfirmation, signConfirmation, summarizePsbt } from '../../../lib/appRequest'
+import { useBridgeConfirmation } from '../../../hooks/useBridgeConfirmation'
+import BridgeConfirmSheet from '../../../components/BridgeConfirmSheet'
+import { AspContext } from '../../../providers/asp'
 import { NavigationContext, Pages } from '@/providers/navigation'
 
 const { bytesToHex, hexToBytes } = utils
+
+const APP_NAME = 'Lendasat'
 
 // Set up SHA256 for @noble/secp256k1
 secp.hashes.sha256 = sha256
@@ -24,6 +30,10 @@ secp.hashes.hmacSha256 = (key, msg) => hmac(sha256, key, msg)
 export default function AppLendasat() {
   const { wallet, svcWallet } = useContext(WalletContext)
   const { navigate } = useContext(NavigationContext)
+  const { aspInfo } = useContext(AspContext)
+  const { approve, reject, request, requestConfirmation } = useBridgeConfirmation()
+
+  const network = aspInfo.network as NetworkName
 
   const [arkAddress, setArkAddress] = useState<string | null>(null)
   const [boardingAddress, setBoardingAddress] = useState<string | null>(null)
@@ -72,19 +82,21 @@ export default function AppLendasat() {
           }
 
           switch (asset) {
-            case 'bitcoin':
-              if (isValidArkAddress(address)) {
-                const txId = await svcWallet?.send({ amount, address })
-                if (txId) {
-                  return txId
-                } else {
-                  throw new Error('Unable to send bitcoin')
-                }
-              } else if (isBTCAddress(address)) {
-                return await collaborativeExit(svcWallet, amount, address)
-              } else {
-                throw Error(`Unsupported address ${address}`)
-              }
+            case 'bitcoin': {
+              if (!isValidSendAmount(amount)) throw new Error('Invalid amount')
+
+              const offchain = isValidArkAddress(address)
+              if (!offchain && !isBTCAddress(address)) throw Error(`Unsupported address ${address}`)
+
+              const approved = await requestConfirmation(sendConfirmation(APP_NAME, address, amount, offchain))
+              if (!approved) throw new Error('Payment declined')
+
+              if (!offchain) return await collaborativeExit(svcWallet, amount, address)
+
+              const txId = await svcWallet.send({ amount, address })
+              if (!txId) throw new Error('Unable to send bitcoin')
+              return txId
+            }
             case 'UsdcPol':
             case 'UsdtPol':
             case 'UsdcEth':
@@ -143,6 +155,13 @@ export default function AppLendasat() {
           if (!svcWallet) {
             throw Error('Wallet not initialized')
           }
+
+          const summary = summarizePsbt(psbt, network)
+          if (!summary) throw new Error('Unable to describe this transaction')
+
+          const approved = await requestConfirmation(signConfirmation(APP_NAME, summary))
+          if (!approved) throw new Error('Signature declined')
+
           const psbtBytes = hexToBytes(psbt)
           const tx = Transaction.fromPSBT(psbtBytes)
           const signedTx = await svcWallet.identity.sign(tx)
@@ -175,7 +194,7 @@ export default function AppLendasat() {
     return () => {
       provider.destroy()
     }
-  }, [wallet.pubkey, svcWallet, arkAddress, boardingAddress])
+  }, [wallet.pubkey, svcWallet, arkAddress, boardingAddress, network, requestConfirmation])
 
   return (
     <>
@@ -194,6 +213,7 @@ export default function AppLendasat() {
           </FlexCol>
         </Padded>
       </Content>
+      <BridgeConfirmSheet request={request} onApprove={approve} onReject={reject} />
     </>
   )
 }

--- a/src/screens/Apps/Satora/Index.tsx
+++ b/src/screens/Apps/Satora/Index.tsx
@@ -8,12 +8,17 @@ import { WalletProvider, type LoanAsset, AddressType } from '@lendasat/lendasat-
 import { collaborativeExit, getReceivingAddresses } from '../../../lib/asp'
 import { isBTCAddress } from '../../../lib/address'
 import { isValidArkAddress } from '@arkade-os/sdk'
+import { isValidSendAmount, sendConfirmation } from '../../../lib/appRequest'
+import { useBridgeConfirmation } from '../../../hooks/useBridgeConfirmation'
+import BridgeConfirmSheet from '../../../components/BridgeConfirmSheet'
 
 const IFRAME_URL = import.meta.env.VITE_SATORA_IFRAME_URL || 'https://app.satora.io'
 const DEFAULT_SWAP_PATH = '/arkade:BTC/polygon:USDC'
+const APP_NAME = 'Satora'
 
 export default function AppSatora() {
   const { svcWallet } = useContext(WalletContext)
+  const { approve, reject, request, requestConfirmation } = useBridgeConfirmation()
   const [arkAddress, setArkAddress] = useState<string | null>(null)
 
   const iframeRef = useRef<HTMLIFrameElement>(null)
@@ -72,24 +77,24 @@ export default function AppSatora() {
             throw Error('Wallet not initialized')
           }
 
-          if (!Number.isFinite(amount) || !Number.isInteger(amount) || amount <= 0) {
+          if (!isValidSendAmount(amount)) {
             throw new Error('Invalid amount')
           }
 
           switch (asset) {
-            case 'bitcoin':
-              if (isValidArkAddress(address)) {
-                const txId = await svcWallet?.send({ amount, address })
-                if (txId) {
-                  return txId
-                } else {
-                  throw new Error('Unable to send bitcoin')
-                }
-              } else if (isBTCAddress(address)) {
-                return await collaborativeExit(svcWallet, amount, address)
-              } else {
-                throw Error(`Unsupported address ${address}`)
-              }
+            case 'bitcoin': {
+              const offchain = isValidArkAddress(address)
+              if (!offchain && !isBTCAddress(address)) throw Error(`Unsupported address ${address}`)
+
+              const approved = await requestConfirmation(sendConfirmation(APP_NAME, address, amount, offchain))
+              if (!approved) throw new Error('Payment declined')
+
+              if (!offchain) return await collaborativeExit(svcWallet, amount, address)
+
+              const txId = await svcWallet.send({ amount, address })
+              if (!txId) throw new Error('Unable to send bitcoin')
+              return txId
+            }
             case 'UsdcPol':
             case 'UsdtPol':
             case 'UsdcEth':
@@ -116,7 +121,7 @@ export default function AppSatora() {
     return () => {
       provider.destroy()
     }
-  }, [svcWallet, arkAddress])
+  }, [svcWallet, arkAddress, requestConfirmation])
 
   return (
     <>
@@ -135,6 +140,7 @@ export default function AppSatora() {
           </FlexCol>
         </Padded>
       </Content>
+      <BridgeConfirmSheet request={request} onApprove={approve} onReject={reject} />
     </>
   )
 }

--- a/src/test/hooks/useBridgeConfirmation.test.tsx
+++ b/src/test/hooks/useBridgeConfirmation.test.tsx
@@ -1,0 +1,92 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useBridgeConfirmation } from '../../hooks/useBridgeConfirmation'
+import type { ConfirmationRequest } from '../../lib/appRequest'
+
+const request: ConfirmationRequest = {
+  app: 'Lendasat',
+  action: 'Confirm payment',
+  confirmLabel: 'Send',
+  rows: [{ label: 'Amount', value: '1,000 sats' }],
+}
+
+const other: ConfirmationRequest = { ...request, action: 'Confirm signature', confirmLabel: 'Sign' }
+
+describe('useBridgeConfirmation', () => {
+  it('resolves true once approved', async () => {
+    const { result } = renderHook(() => useBridgeConfirmation())
+
+    let pending!: Promise<boolean>
+    act(() => {
+      pending = result.current.requestConfirmation(request)
+    })
+    expect(result.current.request).toEqual(request)
+
+    act(() => result.current.approve())
+
+    await expect(pending).resolves.toBe(true)
+    expect(result.current.request).toBeNull()
+  })
+
+  it('resolves false once dismissed', async () => {
+    const { result } = renderHook(() => useBridgeConfirmation())
+
+    let pending!: Promise<boolean>
+    act(() => {
+      pending = result.current.requestConfirmation(request)
+    })
+    act(() => result.current.reject())
+
+    await expect(pending).resolves.toBe(false)
+    expect(result.current.request).toBeNull()
+  })
+
+  it('resolves false when the screen goes away', async () => {
+    const { result, unmount } = renderHook(() => useBridgeConfirmation())
+
+    let pending!: Promise<boolean>
+    act(() => {
+      pending = result.current.requestConfirmation(request)
+    })
+    unmount()
+
+    await expect(pending).resolves.toBe(false)
+  })
+
+  it('resolves false for a second request while one is open', async () => {
+    const { result } = renderHook(() => useBridgeConfirmation())
+
+    let first!: Promise<boolean>
+    let second!: Promise<boolean>
+    act(() => {
+      first = result.current.requestConfirmation(request)
+      second = result.current.requestConfirmation(other)
+    })
+
+    await expect(second).resolves.toBe(false)
+    expect(result.current.request).toEqual(request)
+
+    act(() => result.current.approve())
+    await expect(first).resolves.toBe(true)
+  })
+
+  it('accepts a new request once the previous one is settled', async () => {
+    const { result } = renderHook(() => useBridgeConfirmation())
+
+    let first!: Promise<boolean>
+    act(() => {
+      first = result.current.requestConfirmation(request)
+    })
+    act(() => result.current.reject())
+    await expect(first).resolves.toBe(false)
+
+    let second!: Promise<boolean>
+    act(() => {
+      second = result.current.requestConfirmation(other)
+    })
+    expect(result.current.request).toEqual(other)
+
+    act(() => result.current.approve())
+    await expect(second).resolves.toBe(true)
+  })
+})

--- a/src/test/lib/appRequest.test.ts
+++ b/src/test/lib/appRequest.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import { hex } from '@scure/base'
+import { Address, Transaction } from '@scure/btc-signer'
+import { getNetwork } from '@arkade-os/sdk'
+import { isValidSendAmount, sendConfirmation, signConfirmation, summarizePsbt } from '../../lib/appRequest'
+
+const network = 'regtest'
+const btcNetwork = getNetwork(network)
+
+const TXID = '11'.repeat(32)
+
+const wpkhHash = (fill: number) => new Uint8Array(20).fill(fill)
+const wpkhScript = (fill: number) => Uint8Array.from([0x00, 0x14, ...wpkhHash(fill)])
+const wpkhAddress = (fill: number) => Address(btcNetwork).encode({ type: 'wpkh', hash: wpkhHash(fill) })
+
+interface BuildOptions {
+  inputs: (number | null)[]
+  outputs: { script: Uint8Array; amount: number }[]
+}
+
+const buildPsbt = ({ inputs, outputs }: BuildOptions): string => {
+  const tx = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true })
+  inputs.forEach((amount, index) => {
+    tx.addInput({
+      txid: TXID,
+      index,
+      ...(amount === null ? {} : { witnessUtxo: { script: wpkhScript(index + 1), amount: BigInt(amount) } }),
+    })
+  })
+  outputs.forEach(({ script, amount }) => tx.addOutput({ script, amount: BigInt(amount) }))
+  return hex.encode(tx.toPSBT())
+}
+
+// a funding transaction referenced in full, as legacy inputs must
+const fundingTx = (amounts: number[]): Transaction => {
+  const tx = new Transaction({ allowUnknownInputs: true })
+  tx.addInput({ txid: '22'.repeat(32), index: 0 })
+  amounts.forEach((amount, index) => tx.addOutput({ script: wpkhScript(index + 1), amount: BigInt(amount) }))
+  return tx
+}
+
+const buildLegacyPsbt = (funding: Transaction, index: number, outputAmount: number): string => {
+  const tx = new Transaction()
+  tx.addInput({ txid: funding.id, index, nonWitnessUtxo: funding.toBytes(true, false) })
+  tx.addOutput({ script: wpkhScript(9), amount: BigInt(outputAmount) })
+  return hex.encode(tx.toPSBT())
+}
+
+describe('isValidSendAmount', () => {
+  it('accepts whole positive amounts', () => {
+    expect(isValidSendAmount(1)).toBe(true)
+    expect(isValidSendAmount(21_000)).toBe(true)
+  })
+
+  it('rejects zero, negative, fractional and non-finite amounts', () => {
+    expect(isValidSendAmount(0)).toBe(false)
+    expect(isValidSendAmount(-1)).toBe(false)
+    expect(isValidSendAmount(1.5)).toBe(false)
+    expect(isValidSendAmount(NaN)).toBe(false)
+    expect(isValidSendAmount(Infinity)).toBe(false)
+  })
+})
+
+describe('summarizePsbt', () => {
+  it('describes inputs, outputs and fee', () => {
+    const psbt = buildPsbt({
+      inputs: [6_000, 4_000],
+      outputs: [
+        { script: wpkhScript(7), amount: 7_500 },
+        { script: wpkhScript(8), amount: 2_300 },
+      ],
+    })
+
+    expect(summarizePsbt(psbt, network)).toEqual({
+      inputCount: 2,
+      inputTotal: 10_000,
+      outputs: [
+        { address: wpkhAddress(7), amount: 7_500 },
+        { address: wpkhAddress(8), amount: 2_300 },
+      ],
+      outputTotal: 9_800,
+      fee: 200,
+    })
+  })
+
+  it('reads the amount of an input that references its funding transaction', () => {
+    const psbt = buildLegacyPsbt(fundingTx([1_111, 6_000]), 1, 5_800)
+
+    expect(summarizePsbt(psbt, network)).toEqual({
+      inputCount: 1,
+      inputTotal: 6_000,
+      outputs: [{ address: wpkhAddress(9), amount: 5_800 }],
+      outputTotal: 5_800,
+      fee: 200,
+    })
+  })
+
+  it('returns null when an input points past the outputs of its funding transaction', () => {
+    const psbt = buildLegacyPsbt(fundingTx([1_111, 6_000]), 1, 5_800)
+    const tx = Transaction.fromPSBT(hex.decode(psbt), { allowUnknownInputs: true })
+    tx.updateInput(0, { index: 5 }, true)
+
+    expect(summarizePsbt(hex.encode(tx.toPSBT()), network)).toBeNull()
+  })
+
+  it('returns null when an input amount is unknown', () => {
+    const psbt = buildPsbt({ inputs: [6_000, null], outputs: [{ script: wpkhScript(7), amount: 5_000 }] })
+    expect(summarizePsbt(psbt, network)).toBeNull()
+  })
+
+  it('returns null when an output has no representable destination', () => {
+    const opReturn = Uint8Array.from([0x6a, 0x04, 0x01, 0x02, 0x03, 0x04])
+    const psbt = buildPsbt({ inputs: [6_000], outputs: [{ script: opReturn, amount: 0 }] })
+    expect(summarizePsbt(psbt, network)).toBeNull()
+  })
+
+  it('returns null when outputs exceed inputs', () => {
+    const psbt = buildPsbt({ inputs: [1_000], outputs: [{ script: wpkhScript(7), amount: 2_000 }] })
+    expect(summarizePsbt(psbt, network)).toBeNull()
+  })
+
+  it('returns null when there is nothing to describe', () => {
+    expect(summarizePsbt('not hex at all', network)).toBeNull()
+    expect(summarizePsbt('', network)).toBeNull()
+    expect(summarizePsbt(hex.encode(new Transaction().toPSBT()), network)).toBeNull()
+  })
+
+  it('returns null when the network is not known yet', () => {
+    const psbt = buildPsbt({ inputs: [6_000], outputs: [{ script: wpkhScript(7), amount: 5_000 }] })
+    expect(summarizePsbt(psbt, '' as never)).toBeNull()
+  })
+})
+
+describe('sendConfirmation', () => {
+  it('names the Arkade route and adds no on-chain caveat', () => {
+    const confirmation = sendConfirmation('Satora', 'tark1qexample', 1_000, true)
+    expect(confirmation.note).toBeUndefined()
+    expect(confirmation.rows).toEqual([
+      { label: 'Amount', value: '1,000 sats' },
+      { label: 'To', value: 'tark1qexample' },
+      { label: 'Network', value: 'Arkade' },
+    ])
+  })
+
+  it('names the Bitcoin route and its cost', () => {
+    const confirmation = sendConfirmation('Satora', 'bcrt1qexample', 1, false)
+    expect(confirmation.note).toContain('on-chain')
+    expect(confirmation.rows).toEqual([
+      { label: 'Amount', value: '1 sat' },
+      { label: 'To', value: 'bcrt1qexample' },
+      { label: 'Network', value: 'Bitcoin' },
+    ])
+  })
+})
+
+describe('signConfirmation', () => {
+  const summary = (outputs: { address: string; amount: number }[]) => ({
+    inputCount: 1,
+    inputTotal: 10_000,
+    outputs,
+    outputTotal: outputs.reduce((total, output) => total + output.amount, 0),
+    fee: 200,
+  })
+
+  it('leaves a single destination unnumbered', () => {
+    const { rows } = signConfirmation('Lendasat', summary([{ address: 'bcrt1qone', amount: 9_800 }]))
+    expect(rows[0]).toEqual({ label: 'Sends 9,800 sats to', value: 'bcrt1qone' })
+  })
+
+  it('numbers each destination when there is more than one', () => {
+    const { rows } = signConfirmation(
+      'Lendasat',
+      summary([
+        { address: 'bcrt1qone', amount: 5_000 },
+        { address: 'bcrt1qtwo', amount: 4_800 },
+      ]),
+    )
+    expect(rows).toEqual([
+      { label: '1. Sends 5,000 sats to', value: 'bcrt1qone' },
+      { label: '2. Sends 4,800 sats to', value: 'bcrt1qtwo' },
+      { label: 'Network fee', value: '200 sats' },
+      { label: 'Input total', value: '10,000 sats' },
+      { label: 'Inputs in transaction', value: '1' },
+    ])
+  })
+})

--- a/src/test/screens/apps/bridge-confirmation.test.tsx
+++ b/src/test/screens/apps/bridge-confirmation.test.tsx
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { ReactNode } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { hex } from '@scure/base'
+import { Transaction as BtcTransaction } from '@scure/btc-signer'
+import { AspContext } from '../../../providers/asp'
+import { WalletContext } from '../../../providers/wallet'
+import { ToastProvider } from '../../../components/Toast'
+import { mockAspContextValue, mockWalletContextValue } from '../mocks'
+import fixtures from '../../fixtures.json'
+
+const bridge = vi.hoisted(() => ({ handlers: undefined as any }))
+
+vi.mock('@lendasat/lendasat-wallet-bridge', () => ({
+  AddressType: { ARK: 'ARK', BITCOIN: 'BITCOIN', LOAN_ASSET: 'LOAN_ASSET' },
+  WalletProvider: class {
+    constructor(handlers: any) {
+      bridge.handlers = handlers
+    }
+    listen() {}
+    destroy() {}
+  },
+}))
+
+const asp = vi.hoisted(() => ({ collaborativeExit: vi.fn(), getReceivingAddresses: vi.fn() }))
+
+vi.mock('../../../lib/asp', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/asp')>()),
+  collaborativeExit: asp.collaborativeExit,
+  getReceivingAddresses: asp.getReceivingAddresses,
+}))
+
+// the drawer primitive behind SheetModal reads layout on pointer release, which jsdom cannot provide
+vi.mock('../../../components/SheetModal', () => ({
+  default: ({ children, isOpen }: { children?: ReactNode; isOpen: boolean }) => (isOpen ? <div>{children}</div> : null),
+}))
+
+const ARK_ADDRESS = fixtures.lib.address.ark[0].address
+const BTC_ADDRESS = 'bcrt1pj7fdvrpdsn0cl6722tmcvwcw4yqpe46020g43nhgzl90qq4aqjrs33du9f'
+
+const TXID = '11'.repeat(32)
+const wpkhScript = (fill: number) => Uint8Array.from([0x00, 0x14, ...new Uint8Array(20).fill(fill)])
+
+const signablePsbt = () => {
+  const tx = new BtcTransaction()
+  tx.addInput({ txid: TXID, index: 0, witnessUtxo: { script: wpkhScript(1), amount: BigInt(10_000) } })
+  tx.addOutput({ script: wpkhScript(7), amount: BigInt(9_800) })
+  return hex.encode(tx.toPSBT())
+}
+
+// a legacy input, which names its amount through the funding transaction rather than a witness utxo
+const legacyPsbt = () => {
+  const funding = new BtcTransaction({ allowUnknownInputs: true })
+  funding.addInput({ txid: '22'.repeat(32), index: 0 })
+  funding.addOutput({ script: wpkhScript(1), amount: BigInt(1_111) })
+  funding.addOutput({ script: wpkhScript(2), amount: BigInt(10_000) })
+
+  const tx = new BtcTransaction()
+  tx.addInput({ txid: funding.id, index: 1, nonWitnessUtxo: funding.toBytes(true, false) })
+  tx.addOutput({ script: wpkhScript(7), amount: BigInt(9_800) })
+  return hex.encode(tx.toPSBT())
+}
+
+const undescribablePsbt = () => {
+  const tx = new BtcTransaction({ allowUnknownInputs: true })
+  tx.addInput({ txid: TXID, index: 0 })
+  tx.addOutput({ script: wpkhScript(7), amount: BigInt(9_800) })
+  return hex.encode(tx.toPSBT())
+}
+
+const svcWallet = {
+  send: vi.fn(),
+  identity: {
+    sign: vi.fn(),
+    compressedPublicKey: vi.fn().mockResolvedValue(new Uint8Array(33)),
+  },
+}
+
+const renderApp = async (Screen: () => JSX.Element) => {
+  render(
+    <AspContext.Provider value={mockAspContextValue as any}>
+      <WalletContext.Provider value={{ ...mockWalletContextValue, svcWallet } as any}>
+        <ToastProvider>
+          <Screen />
+        </ToastProvider>
+      </WalletContext.Provider>
+    </AspContext.Provider>,
+  )
+  await waitFor(() => expect(bridge.handlers?.onSendToAddress).toBeDefined())
+}
+
+beforeEach(() => {
+  bridge.handlers = undefined
+  vi.clearAllMocks()
+  svcWallet.send.mockResolvedValue('sent-txid')
+  svcWallet.identity.sign.mockImplementation((tx: any) => Promise.resolve(tx))
+  asp.collaborativeExit.mockResolvedValue('exit-txid')
+  asp.getReceivingAddresses.mockResolvedValue({ offchainAddr: ARK_ADDRESS, boardingAddr: 'bcrt1qboarding' })
+})
+
+describe.each([
+  ['Lendasat', () => import('../../../screens/Apps/Lendasat/Index')],
+  ['Satora', () => import('../../../screens/Apps/Satora/Index')],
+])('%s payment requests', (app, load) => {
+  const mount = async () => renderApp((await load()).default)
+
+  it('sends only after the user approves', async () => {
+    await mount()
+
+    const result = bridge.handlers.onSendToAddress(ARK_ADDRESS, 1_000, 'bitcoin')
+
+    await screen.findByTestId('bridge-confirm-sheet')
+    expect(screen.getByText(`${app} is asking your wallet to do this`)).toBeInTheDocument()
+    expect(screen.getByTestId('Amount').textContent).toBe('1,000 sats')
+    expect(screen.getByTestId('Network').textContent).toBe('Arkade')
+    expect(svcWallet.send).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByTestId('bridge-confirm-approve'))
+
+    await expect(result).resolves.toBe('sent-txid')
+    expect(svcWallet.send).toHaveBeenCalledWith({ amount: 1_000, address: ARK_ADDRESS })
+  })
+
+  it('does not send when the user cancels', async () => {
+    await mount()
+
+    const declined = expect(bridge.handlers.onSendToAddress(ARK_ADDRESS, 1_000, 'bitcoin')).rejects.toThrow(
+      'Payment declined',
+    )
+    await screen.findByTestId('bridge-confirm-sheet')
+    await userEvent.click(screen.getByTestId('bridge-confirm-reject'))
+
+    await declined
+    expect(svcWallet.send).not.toHaveBeenCalled()
+  })
+
+  it('names the on-chain route before leaving Arkade', async () => {
+    await mount()
+
+    const result = bridge.handlers.onSendToAddress(BTC_ADDRESS, 2_500, 'bitcoin')
+
+    await screen.findByTestId('bridge-confirm-sheet')
+    expect(screen.getByTestId('Network').textContent).toBe('Bitcoin')
+    expect(asp.collaborativeExit).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByTestId('bridge-confirm-approve'))
+
+    await expect(result).resolves.toBe('exit-txid')
+    expect(asp.collaborativeExit).toHaveBeenCalledWith(svcWallet, 2_500, BTC_ADDRESS)
+  })
+
+  it('does not exit on-chain when the user cancels', async () => {
+    await mount()
+
+    const declined = expect(bridge.handlers.onSendToAddress(BTC_ADDRESS, 2_500, 'bitcoin')).rejects.toThrow(
+      'Payment declined',
+    )
+    await screen.findByTestId('bridge-confirm-sheet')
+    await userEvent.click(screen.getByTestId('bridge-confirm-reject'))
+
+    await declined
+    expect(asp.collaborativeExit).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid amount without prompting', async () => {
+    await mount()
+
+    await expect(bridge.handlers.onSendToAddress(ARK_ADDRESS, 1.5, 'bitcoin')).rejects.toThrow('Invalid amount')
+    expect(screen.queryByTestId('bridge-confirm-sheet')).not.toBeInTheDocument()
+    expect(svcWallet.send).not.toHaveBeenCalled()
+  })
+
+  it('turns down a second request while one is open', async () => {
+    await mount()
+
+    const first = bridge.handlers.onSendToAddress(ARK_ADDRESS, 1_000, 'bitcoin')
+    await screen.findByTestId('bridge-confirm-sheet')
+
+    await expect(bridge.handlers.onSendToAddress(ARK_ADDRESS, 9_999, 'bitcoin')).rejects.toThrow('Payment declined')
+
+    await userEvent.click(screen.getByTestId('bridge-confirm-approve'))
+    await expect(first).resolves.toBe('sent-txid')
+    expect(svcWallet.send).toHaveBeenCalledTimes(1)
+    expect(svcWallet.send).toHaveBeenCalledWith({ amount: 1_000, address: ARK_ADDRESS })
+  })
+})
+
+describe('Lendasat signing requests', () => {
+  const mount = async () => renderApp((await import('../../../screens/Apps/Lendasat/Index')).default)
+
+  it('signs only after the user approves', async () => {
+    await mount()
+
+    const result = bridge.handlers.onSignPsbt(signablePsbt())
+
+    await screen.findByTestId('bridge-confirm-sheet')
+    expect(screen.getByTestId('Input total').textContent).toBe('10,000 sats')
+    expect(screen.getByTestId('Network fee').textContent).toBe('200 sats')
+    expect(screen.getByTestId('Inputs in transaction').textContent).toBe('1')
+    expect(svcWallet.identity.sign).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByTestId('bridge-confirm-approve'))
+
+    await result
+    expect(svcWallet.identity.sign).toHaveBeenCalledTimes(1)
+  })
+
+  it('prompts for a legacy input instead of turning it away', async () => {
+    await mount()
+
+    const result = bridge.handlers.onSignPsbt(legacyPsbt())
+
+    await screen.findByTestId('bridge-confirm-sheet')
+    expect(screen.getByTestId('Input total').textContent).toBe('10,000 sats')
+    expect(screen.getByTestId('Network fee').textContent).toBe('200 sats')
+
+    await userEvent.click(screen.getByTestId('bridge-confirm-approve'))
+
+    await result
+    expect(svcWallet.identity.sign).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not sign when the user cancels', async () => {
+    await mount()
+
+    const declined = expect(bridge.handlers.onSignPsbt(signablePsbt())).rejects.toThrow('Signature declined')
+    await screen.findByTestId('bridge-confirm-sheet')
+    await userEvent.click(screen.getByTestId('bridge-confirm-reject'))
+
+    await declined
+    expect(svcWallet.identity.sign).not.toHaveBeenCalled()
+  })
+
+  it('turns down a transaction it cannot describe, without prompting', async () => {
+    await mount()
+
+    await expect(bridge.handlers.onSignPsbt(undescribablePsbt())).rejects.toThrow('Unable to describe this transaction')
+    expect(screen.queryByTestId('bridge-confirm-sheet')).not.toBeInTheDocument()
+    expect(svcWallet.identity.sign).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Users should see and approve what an embedded app asks their wallet to do. Lendasat and Satora requests now go through a confirmation sheet.

- Payments show amount, destination, and whether the route is Arkade or on-chain.
- Signing requests are decoded first — destinations, amounts, fee, and transaction-level input totals. A transaction that cannot be summarised into something explainable is turned down rather than shown as a hex blob.
- One request at a time; a pending prompt never survives leaving the screen, and dismissing it declines.
- Amount validation is shared by both integrations.

Both integrations need a manual pass against real flows before merge, in particular whether either app fires requests in sequence and would now hit the concurrent-request rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts for Bitcoin payments and transaction signing, including destination, amount, fees, and optional notes.
  * Added approval and cancellation controls for bridge transfers.
  * Added transaction summaries before signing, including inputs, outputs, totals, and fees.
  * Added support for distinguishing collaborative exits from standard wallet sends.

* **Bug Fixes**
  * Improved validation for payment amounts, addresses, malformed transactions, and unsupported requests.
  * Prevented declined, duplicate, or incomplete requests from proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->