### PR TITLE
Validate backup events on load

### DIFF
--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -1,7 +1,19 @@
-import { finalizeEvent, generateSecretKey, getPublicKey, nip44, SimplePool, UnsignedEvent, Event } from 'nostr-tools'
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  nip44,
+  SimplePool,
+  UnsignedEvent,
+  Event,
+  verifyEvent,
+} from 'nostr-tools'
 import { EncryptedDirectMessage } from 'nostr-tools/kinds'
 import { consoleError } from './logs'
 import { toXOnlyHex } from './keys'
+
+/** A loaded event, with the local time it arrived at (seconds). */
+export type BackupEvent = Event & { receivedAt: number }
 
 const nostrAppName = 'arkade_backup'
 const defaultRelays = ['wss://relay.damus.io', 'wss://relay.primal.net', 'wss://nostr.arkade.sh']
@@ -74,23 +86,28 @@ export class NostrStorage {
    * Load last message from Nostr
    * @returns the decrypted message
    */
-  async load(): Promise<Event[]> {
+  async load(): Promise<BackupEvent[]> {
     const self = this
-    const events: Event[] = []
+    const events: BackupEvent[] = []
     let timeoutHandler: ReturnType<typeof setTimeout>
 
     if (!this.seckey) throw new Error('Secret key is required for loading data')
 
     return Promise.race([
-      new Promise<Event[]>((resolve) => {
+      new Promise<BackupEvent[]>((resolve) => {
         const sub = this.pool.subscribeMany(
           this.relays,
           { kinds: [4], '#p': [this.pubkey], '#t': [nostrAppName] },
           {
             onevent(event: Event) {
+              // relays are not trusted to have checked the signature themselves
+              if (!verifyEvent(event)) {
+                consoleError(new Error(`Invalid signature on event ${event.id}`), 'Skipped event')
+                return
+              }
               try {
                 const content = self.decryptEvent(event)
-                events.push({ ...event, content })
+                events.push({ ...event, content, receivedAt: Math.floor(Date.now() / 1000) })
               } catch (error) {
                 consoleError(error, 'Failed to decrypt event')
               }
@@ -103,7 +120,7 @@ export class NostrStorage {
           },
         )
       }),
-      new Promise<Event[]>((resolve) => {
+      new Promise<BackupEvent[]>((resolve) => {
         timeoutHandler = setTimeout(() => {
           consoleError(new Error('Load timeout'), 'Failed to load backup data')
           resolve([])

--- a/src/providers/backup.tsx
+++ b/src/providers/backup.tsx
@@ -51,7 +51,9 @@ export const BackupProvider = ({ children }: { children: ReactNode }) => {
   // restore() awaits the network for up to 10s, so a closed-over config can still
   // be the pre-hydration default by the time it resolves (see wallet.tsx)
   const configRef = useRef(config)
-  configRef.current = config
+  useEffect(() => {
+    configRef.current = config
+  }, [config])
 
   // initialize NostrStorage when we have a pubkey and nostrBackup is enabled
   useEffect(() => {

--- a/src/providers/backup.tsx
+++ b/src/providers/backup.tsx
@@ -8,7 +8,7 @@ import {
 import { Config } from '../lib/types'
 import { ConfigContext } from './config'
 import { consoleError } from '@/lib/logs'
-import { NostrStorage } from '@/lib/nostr'
+import { BackupEvent, NostrStorage } from '@/lib/nostr'
 import { readSolverCardsFromStorage, saveSolverCardsToStorage } from '@/lib/storage'
 import { LocalCardInput } from '@arkade-os/solver-discovery'
 import { ReactNode, createContext, useContext, useEffect, useRef } from 'react'
@@ -186,7 +186,7 @@ export const BackupProvider = ({ children }: { children: ReactNode }) => {
   /**
    * Initially data was saved in a unique event, until we reached the size limit.
    * Now we can have multiple events, so we need to load and merge them.
-   * Events are sorted by created_at to have a deterministic order.
+   * Events are sorted to have a deterministic order.
    * The map in swaps is used to avoid duplicates and use the latest data.
    * @returns Data stored on Nostr
    */
@@ -212,8 +212,10 @@ export const BackupProvider = ({ children }: { children: ReactNode }) => {
 
     const events = await nostrProvider.load()
 
-    // Events are sorted by created_at to have a deterministic order.
-    const sorted = events.sort((a, b) => a.created_at - b.created_at)
+    // An event ranks by the earlier of its own timestamp and its arrival, so its
+    // position never depends on a clock we don't control. Ids break ties.
+    const sortKey = (e: BackupEvent) => Math.min(e.created_at, e.receivedAt)
+    const sorted = events.sort((a, b) => sortKey(a) - sortKey(b) || a.id.localeCompare(b.id))
 
     for (const event of sorted) {
       if (!event.content) continue

--- a/src/providers/backup.tsx
+++ b/src/providers/backup.tsx
@@ -48,6 +48,11 @@ export const BackupProvider = ({ children }: { children: ReactNode }) => {
 
   const nostrStorage = useRef<NostrStorage | null>(null)
 
+  // restore() awaits the network for up to 10s, so a closed-over config can still
+  // be the pre-hydration default by the time it resolves (see wallet.tsx)
+  const configRef = useRef(config)
+  configRef.current = config
+
   // initialize NostrStorage when we have a pubkey and nostrBackup is enabled
   useEffect(() => {
     if (!config.pubkey || !config.nostrBackup) return
@@ -161,8 +166,8 @@ export const BackupProvider = ({ children }: { children: ReactNode }) => {
 
     const data = (await loadData(provider)) as NostrStorageData
 
-    // we enforce delegates on restore
-    if (data?.config) updateConfig({ ...data.config, delegate: true })
+    // we enforce delegates on restore, and the server stays the locally configured one
+    if (data?.config) updateConfig({ ...data.config, aspUrl: configRef.current.aspUrl, delegate: true })
 
     if (data?.solverCards) saveSolverCardsToStorage(data.solverCards)
 

--- a/src/test/lib/mnemonic.test.ts
+++ b/src/test/lib/mnemonic.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, beforeEach } from 'vitest'
 import { setMnemonic, getMnemonic, hasMnemonic, deriveNostrKeyFromMnemonic } from '../../lib/mnemonic'
 import { NSEC_STORAGE_KEY } from '@/lib/storageKeys'
+import { MnemonicIdentity } from '@arkade-os/sdk'
+import { getPublicKey } from 'nostr-tools'
+import { hex } from '@scure/base'
+import { toXOnlyHex } from '@/lib/keys'
 
 const testMnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
 const testPassword = 'testpassword'
@@ -66,6 +70,13 @@ describe('mnemonic storage', () => {
 
     it('should throw on invalid mnemonic', () => {
       expect(() => deriveNostrKeyFromMnemonic('invalid words here', false)).toThrow('Invalid mnemonic phrase')
+    })
+
+    // the p tag on backup events is config.pubkey, which comes from the identity
+    it.each([true, false])('should match the wallet identity key (mainnet: %s)', async (isMainnet) => {
+      const identity = MnemonicIdentity.fromMnemonic(testMnemonic, { isMainnet })
+      const identityPubkey = toXOnlyHex(hex.encode(await identity.compressedPublicKey()))
+      expect(getPublicKey(deriveNostrKeyFromMnemonic(testMnemonic, isMainnet))).toBe(identityPubkey)
     })
   })
 })

--- a/src/test/lib/nostr.test.ts
+++ b/src/test/lib/nostr.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { finalizeEvent, generateSecretKey, getPublicKey, nip44, type Event } from 'nostr-tools'
+import { EncryptedDirectMessage } from 'nostr-tools/kinds'
+import { NostrStorage } from '../../lib/nostr'
+
+// jsdom's TextEncoder returns a cross-realm Uint8Array that @noble/hashes rejects
+const encode = TextEncoder.prototype.encode
+TextEncoder.prototype.encode = function (input?: string) {
+  return Uint8Array.from(encode.call(this, input))
+}
+
+// events the mocked relay pool hands to the subscription
+let relayEvents: Event[] = []
+
+vi.mock('nostr-tools', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('nostr-tools')>()
+  class MockPool {
+    subscribeMany(_relays: string[], _filter: unknown, handlers: { onevent: (e: Event) => void; oneose: () => void }) {
+      // relays deliver asynchronously; load() closes the subscription on eose
+      queueMicrotask(() => {
+        for (const event of relayEvents) handlers.onevent(event)
+        handlers.oneose()
+      })
+      return { close: () => {} }
+    }
+  }
+  return { ...actual, SimplePool: MockPool }
+})
+
+const seckey = generateSecretKey()
+const pubkey = getPublicKey(seckey)
+
+const makeEvent = (payload: string, createdAt = Math.floor(Date.now() / 1000)): Event => {
+  const sk = generateSecretKey()
+  return finalizeEvent(
+    {
+      kind: EncryptedDirectMessage,
+      tags: [
+        ['p', pubkey],
+        ['t', 'arkade_backup'],
+      ],
+      created_at: createdAt,
+      content: nip44.encrypt(payload, nip44.getConversationKey(sk, pubkey)),
+    },
+    sk,
+  )
+}
+
+// relays deliver JSON, so drop the in-memory verification flag nostr-tools caches
+const asDelivered = (event: Event): Event => JSON.parse(JSON.stringify(event))
+
+describe('NostrStorage.load', () => {
+  beforeEach(() => {
+    relayEvents = []
+  })
+
+  it('returns decrypted events', async () => {
+    relayEvents = [asDelivered(makeEvent('{"hello":"world"}'))]
+
+    const events = await new NostrStorage({ seckey }).load()
+
+    expect(events).toHaveLength(1)
+    expect(events[0].content).toBe('{"hello":"world"}')
+    expect(events[0].receivedAt).toBeGreaterThan(0)
+  })
+
+  it('skips an event whose signature does not match', async () => {
+    const tampered = { ...asDelivered(makeEvent('{"hello":"world"}')), sig: '00'.repeat(64) }
+    relayEvents = [tampered]
+
+    expect(await new NostrStorage({ seckey }).load()).toHaveLength(0)
+  })
+
+  it('keeps valid events alongside an invalid one', async () => {
+    const valid = asDelivered(makeEvent('{"keep":true}'))
+    const tampered = { ...asDelivered(makeEvent('{"drop":true}')), sig: '00'.repeat(64) }
+    relayEvents = [tampered, valid]
+
+    const events = await new NostrStorage({ seckey }).load()
+
+    expect(events.map((e) => e.content)).toEqual(['{"keep":true}'])
+  })
+
+  it('requires a secret key', async () => {
+    await expect(new NostrStorage({ pubkey }).load()).rejects.toThrow('Secret key is required')
+  })
+})

--- a/src/test/providers/backup.test.tsx
+++ b/src/test/providers/backup.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { useContext } from 'react'
+import { BackupContext, BackupProvider } from '../../providers/backup'
+import { ConfigContext } from '../../providers/config'
+import { mockConfigContextValue } from '../screens/mocks'
+import type { Config } from '../../lib/types'
+
+const mocks = vi.hoisted(() => ({
+  events: [] as any[],
+  saveSwap: vi.fn(),
+}))
+
+vi.mock('@/lib/nostr', () => ({
+  NostrStorage: class {
+    async load() {
+      return mocks.events
+    }
+    async save() {}
+  },
+}))
+
+vi.mock('@arkade-os/boltz-swap', () => ({
+  IndexedDbSwapRepository: class {
+    saveSwap = mocks.saveSwap
+  },
+}))
+
+const localConfig: Config = { ...mockConfigContextValue.config, aspUrl: 'https://local.server' }
+
+let counter = 0
+const makeEvent = (data: unknown, created_at: number, receivedAt: number) => ({
+  id: `event-${counter++}`,
+  kind: 4,
+  pubkey: 'pubkey',
+  sig: 'sig',
+  tags: [],
+  content: JSON.stringify(data),
+  created_at,
+  receivedAt,
+})
+
+let restore: (seckey: Uint8Array) => Promise<void>
+
+function Capture() {
+  restore = useContext(BackupContext).restore
+  return null
+}
+
+function renderProvider(updateConfig: (c: Config) => void) {
+  const configContextValue = { ...mockConfigContextValue, config: localConfig, updateConfig }
+  return render(
+    <ConfigContext.Provider value={configContextValue as any}>
+      <BackupProvider>
+        <Capture />
+      </BackupProvider>
+    </ConfigContext.Provider>,
+  )
+}
+
+describe('BackupProvider restore', () => {
+  beforeEach(() => {
+    mocks.events = []
+    mocks.saveSwap.mockClear()
+    localStorage.clear()
+  })
+
+  it('keeps the local server and applies the rest of the restored config', async () => {
+    const updateConfig = vi.fn()
+    mocks.events = [
+      makeEvent({ config: { ...localConfig, aspUrl: 'https://other.server', showBalance: false } }, 100, 100),
+    ]
+
+    renderProvider(updateConfig)
+    await restore(new Uint8Array(32))
+
+    await waitFor(() => expect(updateConfig).toHaveBeenCalledTimes(1))
+    expect(updateConfig.mock.calls[0][0]).toMatchObject({
+      aspUrl: 'https://local.server',
+      showBalance: false,
+      delegate: true,
+    })
+  })
+
+  it('ranks an event by its arrival when that precedes its timestamp', async () => {
+    const updateConfig = vi.fn()
+    const now = Math.floor(Date.now() / 1000)
+    mocks.events = [
+      makeEvent(
+        { config: { ...localConfig, showBalance: false }, reverseSwaps: [{ id: 'swap-a' }] },
+        now + 1_000_000,
+        now - 60,
+      ),
+      makeEvent({ config: { ...localConfig, showBalance: true } }, now - 10, now),
+    ]
+
+    renderProvider(updateConfig)
+    await restore(new Uint8Array(32))
+
+    await waitFor(() => expect(updateConfig).toHaveBeenCalledTimes(1))
+    expect(updateConfig.mock.calls[0][0]).toMatchObject({ showBalance: true })
+    // the event is ranked lower, not dropped
+    expect(mocks.saveSwap).toHaveBeenCalledWith({ id: 'swap-a' })
+  })
+})

--- a/src/test/providers/backup.test.tsx
+++ b/src/test/providers/backup.test.tsx
@@ -5,9 +5,10 @@ import { BackupContext, BackupProvider } from '../../providers/backup'
 import { ConfigContext } from '../../providers/config'
 import { mockConfigContextValue } from '../screens/mocks'
 import type { Config } from '../../lib/types'
+import type { BackupEvent } from '../../lib/nostr'
 
 const mocks = vi.hoisted(() => ({
-  events: [] as any[],
+  events: [] as BackupEvent[],
   saveSwap: vi.fn(),
 }))
 
@@ -29,8 +30,8 @@ vi.mock('@arkade-os/boltz-swap', () => ({
 const localConfig: Config = { ...mockConfigContextValue.config, aspUrl: 'https://local.server' }
 
 let counter = 0
-const makeEvent = (data: unknown, created_at: number, receivedAt: number) => ({
-  id: `event-${counter++}`,
+const makeEvent = (data: unknown, created_at: number, receivedAt: number, id = `event-${counter++}`): BackupEvent => ({
+  id,
   kind: 4,
   pubkey: 'pubkey',
   sig: 'sig',
@@ -101,5 +102,20 @@ describe('BackupProvider restore', () => {
     expect(updateConfig.mock.calls[0][0]).toMatchObject({ showBalance: true })
     // the event is ranked lower, not dropped
     expect(mocks.saveSwap).toHaveBeenCalledWith({ id: 'swap-a' })
+  })
+
+  it('breaks ties on event id, whatever order the relay delivers them in', async () => {
+    const updateConfig = vi.fn()
+    const now = Math.floor(Date.now() / 1000)
+    mocks.events = [
+      makeEvent({ config: { ...localConfig, showBalance: true } }, now, now, 'event-b'),
+      makeEvent({ config: { ...localConfig, showBalance: false } }, now, now, 'event-a'),
+    ]
+
+    renderProvider(updateConfig)
+    await restore(new Uint8Array(32))
+
+    await waitFor(() => expect(updateConfig).toHaveBeenCalledTimes(1))
+    expect(updateConfig.mock.calls[0][0]).toMatchObject({ showBalance: true })
   })
 })


### PR DESCRIPTION
Nostr backup read path:

- events are checked against their signature before being decrypted
- an event ranks in the merge by the earlier of its own timestamp and its arrival, with ids breaking ties
- restore keeps the locally configured Ark server

Adds unit tests for `nostr.ts` and `BackupProvider.restore`, plus a guard that the backup key matches the wallet identity key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup restoration reliability by rejecting tampered or invalid events.
  * Preserved the locally configured server URL during restores.
  * Enabled delegates consistently when restoring configuration.
  * Improved event ordering using creation and arrival times, with stable tie-breaking.
  * Restored embedded swap data more reliably.

* **Tests**
  * Added coverage for backup decryption, configuration merging, event ordering, key derivation, and swap restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->