### PR TITLE
Add Lightning swap outage notice

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -379,6 +379,48 @@ iframe {
   margin-top: 0.25rem;
 }
 
+.lightning-swap-notice {
+  display: grid;
+  grid-template-columns: 2.25rem minmax(0, 1fr);
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.875rem;
+  border-radius: 1rem;
+  background: var(--orangebg);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--orange) 24%, transparent),
+    var(--elevation-sm);
+}
+
+.lightning-swap-notice__icon {
+  display: flex;
+  width: 2.25rem;
+  height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.625rem;
+  background: color-mix(in srgb, var(--orange) 16%, transparent);
+  color: var(--orange);
+}
+
+.lightning-swap-notice__title,
+.lightning-swap-notice__description {
+  font-size: var(--text-sm-size);
+  line-height: var(--text-sm-line);
+}
+
+.lightning-swap-notice__title {
+  color: var(--fg);
+  font-weight: 600;
+  text-wrap: balance;
+}
+
+.lightning-swap-notice__description {
+  margin-top: 0.125rem;
+  color: var(--neutral-700);
+  text-wrap: pretty;
+}
+
 .home-quick-actions {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/src/screens/Wallet/Index.tsx
+++ b/src/screens/Wallet/Index.tsx
@@ -26,6 +26,7 @@ import RecentActivitySection from './RecentActivitySection'
 import { usePortfolioBalanceDisplay } from '../../hooks/usePortfolioBalanceDisplay'
 import { useReducedMotion } from '../../hooks/useReducedMotion'
 import { BackupContext } from '@/providers/backup'
+import BoltOutlineIcon from '../../icons/BoltOutline'
 
 export default function Wallet() {
   const { aspInfo } = useContext(AspContext)
@@ -133,6 +134,23 @@ export default function Wallet() {
             <WalletStaggerChild animate={shouldStagger} className='home-stack__actions'>
               <HomeQuickActions />
             </WalletStaggerChild>
+            {aspInfo.network === 'bitcoin' ? (
+              <WalletStaggerChild animate={shouldStagger}>
+                <section aria-labelledby='lightning-swap-notice-title' className='lightning-swap-notice' role='status'>
+                  <span aria-hidden='true' className='lightning-swap-notice__icon'>
+                    <BoltOutlineIcon />
+                  </span>
+                  <div>
+                    <p className='lightning-swap-notice__title' id='lightning-swap-notice-title'>
+                      Lightning swaps are temporarily unavailable
+                    </p>
+                    <p className='lightning-swap-notice__description'>
+                      We are working to restore service as soon as possible.
+                    </p>
+                  </div>
+                </section>
+              </WalletStaggerChild>
+            ) : null}
             {hasHomeNotices ? (
               <WalletStaggerChild animate={shouldStagger}>
                 <FlexCol gap='0.75rem'>

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -58,6 +58,32 @@ describe('Wallet screen', () => {
     expect(screen.getByText(/Swaps are coming soon/i)).toBeInTheDocument()
   })
 
+  it('shows the Lightning service notice on bitcoin mainnet only', () => {
+    const mainnetAspContext = {
+      ...mockAspContextValue,
+      aspInfo: { ...mockAspContextValue.aspInfo, network: 'bitcoin' },
+    }
+    const { rerender } = render(
+      <AspContext.Provider value={mainnetAspContext as any}>
+        <Wallet />
+      </AspContext.Provider>,
+    )
+
+    expect(screen.getByRole('status', { name: 'Lightning swaps are temporarily unavailable' })).toHaveTextContent(
+      'We are working to restore service as soon as possible.',
+    )
+
+    rerender(
+      <AspContext.Provider value={mockAspContextValue as any}>
+        <Wallet />
+      </AspContext.Provider>,
+    )
+
+    expect(
+      screen.queryByRole('status', { name: 'Lightning swaps are temporarily unavailable' }),
+    ).not.toBeInTheDocument()
+  })
+
   it('opens the bitcoin detail page from the bitcoin asset row', async () => {
     const user = userEvent.setup()
     const navigate = vi.fn()

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -61,10 +61,10 @@ describe('Wallet screen', () => {
   it('shows the Lightning service notice on bitcoin mainnet only', () => {
     const mainnetAspContext = {
       ...mockAspContextValue,
-      aspInfo: { ...mockAspContextValue.aspInfo, network: 'bitcoin' },
+      aspInfo: { ...mockAspContextValue.aspInfo, network: 'bitcoin' as const },
     }
     const { rerender } = render(
-      <AspContext.Provider value={mainnetAspContext as any}>
+      <AspContext.Provider value={mainnetAspContext}>
         <Wallet />
       </AspContext.Provider>,
     )
@@ -74,7 +74,7 @@ describe('Wallet screen', () => {
     )
 
     rerender(
-      <AspContext.Provider value={mockAspContextValue as any}>
+      <AspContext.Provider value={mockAspContextValue}>
         <Wallet />
       </AspContext.Provider>,
     )


### PR DESCRIPTION
## Summary

- Adds a calm warning banner beneath the wallet home quick actions while Lightning swaps are unavailable.
- Shows the notice on bitcoin mainnet only, leaving Arkade and non-mainnet experiences unchanged.
- Uses the existing Lightning bolt icon, warning color tokens, and accessible status semantics.

## User-visible behavior

The wallet home screen now displays:

> **Lightning swaps are temporarily unavailable**
>
> We are working to restore service as soon as possible.

The banner is informational and has no dismiss or navigation action.

## Affected files

- `src/screens/Wallet/Index.tsx` — renders the mainnet-only Lightning service notice below the quick actions.
- `src/index.css` — adds the token-based amber surface, icon treatment, typography, and layout.
- `src/test/screens/wallet/index.test.tsx` — verifies the notice copy and mainnet-only visibility with a type-safe ASP context fixture.

## Verification

- `bun run test:unit -- src/test/screens/wallet/index.test.tsx` — 6 tests passed.
- `bun run lint` — passed.
- `bun run build` — passed. Existing warnings remain for the local Node engine version, worker output configuration, dynamic imports, and bundle size.
- Verified the final rendered copy and layout in the funded wallet home screen with no browser console errors.
- Addressed CodeRabbit's review by removing unnecessary ASP context casts; the focused test and lint check pass after the fix.
- No unrelated files or behavior were changed.

## Visual proof

<img width="1280" height="720" alt="lightning-swap-banner-copy-updated" src="https://github.com/user-attachments/assets/a0a46190-f6fa-4284-a6e5-36a513af2753" />
