### PR TITLE
fix(wallet): gate Lightning swaps on service availability

### DIFF
--- a/src/providers/swaps.tsx
+++ b/src/providers/swaps.tsx
@@ -108,6 +108,12 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
 
   // create ArkadeSwaps with SwapManager on first run with svcWallet
   useEffect(() => {
+    setArkadeSwaps(null)
+    setFees(null)
+    setArkToBtcFees(null)
+    setBtcToArkFees(null)
+    setSwapsInitError(null)
+
     if (!aspInfo.network || !svcWallet) return
     const baseUrl = BASE_URLS[aspInfo.network as Network]
     if (!baseUrl) return // No boltz server for this network

--- a/src/providers/swaps.tsx
+++ b/src/providers/swaps.tsx
@@ -106,7 +106,6 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
   const connected = config.apps.boltz.connected
   const apiUrl = BASE_URLS[aspInfo.network as Network] ?? null
 
-  // create ArkadeSwaps with SwapManager on first run with svcWallet
   useEffect(() => {
     setArkadeSwaps(null)
     setFees(null)
@@ -152,7 +151,6 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
       warn: (...args: unknown[]) => consoleLog(...args),
     })
 
-    // Cleanup on unmount
     return () => {
       cancelled = true
       if (disposeArkadeSwaps) disposeArkadeSwaps().catch(consoleError)

--- a/src/providers/swaps.tsx
+++ b/src/providers/swaps.tsx
@@ -103,17 +103,14 @@ export const SwapsProvider = ({ children }: { children: ReactNode }) => {
   const [arkadeSwaps, setArkadeSwaps] = useState<ServiceWorkerArkadeSwaps | null>(null)
   const [swapsInitError, setSwapsInitError] = useState<string | null>(null)
   const [fees, setFees] = useState<FeesResponse | null>(null)
-  const [apiUrl, setApiUrl] = useState<string | null>(null)
-
   const connected = config.apps.boltz.connected
+  const apiUrl = BASE_URLS[aspInfo.network as Network] ?? null
 
   // create ArkadeSwaps with SwapManager on first run with svcWallet
   useEffect(() => {
     if (!aspInfo.network || !svcWallet) return
     const baseUrl = BASE_URLS[aspInfo.network as Network]
     if (!baseUrl) return // No boltz server for this network
-
-    setApiUrl(baseUrl)
 
     const network = aspInfo.network as Network
     const swapProvider = new BoltzSwapProvider({ apiUrl: baseUrl, network, referralId: 'arkade-money' })

--- a/src/screens/Wallet/Index.tsx
+++ b/src/screens/Wallet/Index.tsx
@@ -27,6 +27,7 @@ import { usePortfolioBalanceDisplay } from '../../hooks/usePortfolioBalanceDispl
 import { useReducedMotion } from '../../hooks/useReducedMotion'
 import { BackupContext } from '@/providers/backup'
 import BoltOutlineIcon from '../../icons/BoltOutline'
+import { SwapsContext } from '../../providers/swaps'
 
 export default function Wallet() {
   const { aspInfo } = useContext(AspContext)
@@ -35,6 +36,7 @@ export default function Wallet() {
   const { backupAndUpdateConfig } = useContext(BackupContext)
   const { isInitialLoad } = useContext(NavigationContext)
   const { nudge, nudgeCheckComplete } = useContext(NudgeContext)
+  const { getApiUrl } = useContext(SwapsContext)
 
   const [error, setError] = useState(false)
   const [homeScrolled, setHomeScrolled] = useState(false)
@@ -134,7 +136,7 @@ export default function Wallet() {
             <WalletStaggerChild animate={shouldStagger} className='home-stack__actions'>
               <HomeQuickActions />
             </WalletStaggerChild>
-            {aspInfo.network === 'bitcoin' ? (
+            {aspInfo.network === 'bitcoin' && !getApiUrl() ? (
               <WalletStaggerChild animate={shouldStagger}>
                 <section aria-labelledby='lightning-swap-notice-title' className='lightning-swap-notice' role='status'>
                   <span aria-hidden='true' className='lightning-swap-notice__icon'>

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -215,7 +215,9 @@ export default function ReceiveQRCode() {
 
     setSwapsTimedOut(false)
 
-    Promise.allSettled([createBtcAddress(), createLightningInvoice()]).then(([btc, lightning]) => {
+    const lightningInvoice = lnExpected ? createLightningInvoice() : Promise.resolve(null)
+
+    Promise.allSettled([createBtcAddress(), lightningInvoice]).then(([btc, lightning]) => {
       if (btc.status === 'fulfilled') {
         const pendingSwap = btc.value as BoltzChainSwap
         const btcAddr = pendingSwap.response.lockupDetails.lockupAddress
@@ -230,7 +232,7 @@ export default function ReceiveQRCode() {
             consoleError(error, 'Error claiming chain swap:')
           })
       }
-      if (lightning.status === 'fulfilled') {
+      if (lightning.status === 'fulfilled' && lightning.value) {
         const pendingSwap = lightning.value as BoltzReverseSwap
         const inv = pendingSwap.response.invoice
         setInvoice(inv)

--- a/src/screens/Wallet/Receive/QrCode.tsx
+++ b/src/screens/Wallet/Receive/QrCode.tsx
@@ -70,7 +70,8 @@ export default function ReceiveQRCode() {
   const { navigate } = useContext(NavigationContext)
   const { recvInfo, setRecvInfo } = useContext(FlowContext)
   const { notifyPaymentReceived } = useContext(NotificationsContext)
-  const { arkadeSwaps, swapsInitError, connected, createBtcToArkSwap, createReverseSwap } = useContext(SwapsContext)
+  const { arkadeSwaps, swapsInitError, connected, createBtcToArkSwap, createReverseSwap, getApiUrl } =
+    useContext(SwapsContext)
   const { assetMetadataCache, svcWallet } = useContext(WalletContext)
   const { minSwapAllowed, validBtcToArk, validLnSwap, utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
 
@@ -98,6 +99,7 @@ export default function ReceiveQRCode() {
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
   const isAssetReceive = assetId && assetId !== ''
   const hasError = Boolean(addressError)
+  const lightningSwapsAvailable = Boolean(getApiUrl())
 
   const [noPaymentMethods, setNoPaymentMethods] = useState(false)
   const [arkAddress, setArkAddress] = useState(offchainAddr)
@@ -133,7 +135,8 @@ export default function ReceiveQRCode() {
   }, [svcWallet])
 
   const lnurlSession = useContext(LnurlContext)
-  const isAmountlessLnurl = !satoshis && !isAssetReceive && !!lnurlServerUrl && lnurlSession.active
+  const isAmountlessLnurl =
+    lightningSwapsAvailable && !satoshis && !isAssetReceive && !!lnurlServerUrl && lnurlSession.active
   // LNURL is amountless by nature: only surface it when no amount is set. The
   // session keeps running underneath — we just hide it from the QR + copy list.
   const displayLnurl = isAmountlessLnurl ? lnurlSession.lnurl : ''
@@ -192,7 +195,7 @@ export default function ReceiveQRCode() {
       return
     }
 
-    const lnExpected = connected && !isAssetReceive
+    const lnExpected = lightningSwapsAvailable && connected && !isAssetReceive
 
     if (!arkadeSwaps) {
       if (!lnExpected || swapsInitError) {
@@ -243,7 +246,7 @@ export default function ReceiveQRCode() {
       }
       setShowQrCode(true)
     })
-  }, [satoshis, svcWallet, arkadeSwaps, swapsInitError, addressesLoaded])
+  }, [satoshis, svcWallet, arkadeSwaps, swapsInitError, addressesLoaded, lightningSwapsAvailable])
 
   // Build BIP21 URI
   useEffect(() => {
@@ -474,7 +477,7 @@ export default function ReceiveQRCode() {
                   Requesting {prettyNumber(satoshis, 0)} {unitLabel}
                 </Text>
               ) : null}
-              {(!satoshis || satoshis < minSwapAllowed()) && !isAssetReceive ? (
+              {lightningSwapsAvailable && (!satoshis || satoshis < minSwapAllowed()) && !isAssetReceive ? (
                 <Text small color='neutral-500'>
                   {minSwapAllowed()} sats min for Lightning
                 </Text>

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -61,6 +61,7 @@ import { testDomains } from '../../../lib/constants'
 import UnverifiedBadge from '../../../components/UnverifiedBadge'
 
 const isProductionEnv = !testDomains.some((d) => window.location.hostname.includes(d))
+const LIGHTNING_UNAVAILABLE_MESSAGE = 'Lightning is temporarily unavailable'
 
 const brantaClient = new BrantaService({
   baseUrl: isProductionEnv ? 'Production' : 'Staging',
@@ -174,6 +175,13 @@ export default function SendForm() {
   const lightningSwapsAvailable = Boolean(getApiUrl())
   const lnUrlArkMethod = lnUrlResponse?.transferAmounts?.find((method) => method.method === 'Ark' && method.available)
   const lnUrlSupportsArkade = Boolean(lnUrlArkMethod)
+  const pastedLightningInvoice = !isAssetSend && isLightningInvoice(recipient.toLowerCase().replace(/^lightning:/, ''))
+  const lightningOnlyRecipient =
+    !lightningSwapsAvailable &&
+    !sendInfo.address &&
+    !sendInfo.arkAddress &&
+    Boolean(sendInfo.invoice || pastedLightningInvoice || (sendInfo.lnUrl && lnUrlResponse && !lnUrlSupportsArkade))
+  const recipientErrorMessage = lightningOnlyRecipient ? LIGHTNING_UNAVAILABLE_MESSAGE : recipientError
 
   const DUST_AMOUNT = 330
   const RECIPIENT_DEBOUNCE_MS = 800
@@ -958,7 +966,7 @@ export default function SendForm() {
             <FlexCol gap='1.25rem' className='send-form-stack'>
               <ErrorMessage error={Boolean(error)} text={error} />
               <InputAddress
-                error={recipientError}
+                error={recipientErrorMessage}
                 focus={focus === 'recipient'}
                 label='Recipient address'
                 name='send-address'

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -171,6 +171,9 @@ export default function SendForm() {
   )
   const activeAsset = accountAsset ?? selectedAsset
   const isAssetSend = activeAsset !== null
+  const lightningSwapsAvailable = Boolean(getApiUrl())
+  const lnUrlArkMethod = lnUrlResponse?.transferAmounts?.find((method) => method.method === 'Ark' && method.available)
+  const lnUrlSupportsArkade = Boolean(lnUrlArkMethod)
 
   const DUST_AMOUNT = 330
   const RECIPIENT_DEBOUNCE_MS = 800
@@ -361,11 +364,17 @@ export default function SendForm() {
         if (isAssetSend) {
           return setRecipientError('Assets can only be sent to Arkade addresses')
         }
+        const satoshis = getInvoiceSatoshis(lowerCaseData)
+        if (!lightningSwapsAvailable) {
+          setSendInfo({ ...sendInfo, address: '', arkAddress: '', invoice: lowerCaseData, lnUrl: '', satoshis })
+          if (satoshis) setAmountTextValue(getTextValue(satoshis))
+          setAmountIsReadOnly(Boolean(satoshis))
+          return
+        }
         if (!connected) {
           setRecipientError('Lightning swaps not enabled')
           return setNudgeBoltz(true)
         }
-        const satoshis = getInvoiceSatoshis(lowerCaseData)
         if (!satoshis) return setRecipientError('Invoice must have amount defined')
         setSendInfo({ ...sendInfo, invoice: lowerCaseData, satoshis })
         setAmountTextValue(getTextValue(satoshis))
@@ -388,13 +397,16 @@ export default function SendForm() {
         }
       }
       if (isValidLnUrl(lowerCaseData)) {
+        if (!lightningSwapsAvailable) {
+          return setSendInfo({ ...sendInfo, address: '', arkAddress: '', invoice: '', lnUrl: lowerCaseData })
+        }
         return setSendInfo({ ...sendInfo, lnUrl: lowerCaseData })
       }
       setRecipientError('Invalid recipient address')
       setReadyToParse(false)
     }
     parseRecipient()
-  }, [recipient, isAssetSend, readyToParse])
+  }, [recipient, isAssetSend, readyToParse, lightningSwapsAvailable])
 
   // fetch branta payment info for the current recipient (SDK strict mode gates non-ZK)
   useEffect(() => {
@@ -594,7 +606,7 @@ export default function SendForm() {
     if (!proceed) return
     if (!sendInfo.address && !sendInfo.arkAddress && !sendInfo.invoice) return
     if (sendInfo.arkAddress || sendInfo.pendingSwap) return navigate(Pages.SendDetails)
-    if (sendInfo.invoice) {
+    if (sendInfo.invoice && lightningSwapsAvailable) {
       createSubmarineSwap(sendInfo.invoice)
         .then((pendingSwap) => {
           if (!pendingSwap) return handleError('Unable to create swap')
@@ -612,7 +624,7 @@ export default function SendForm() {
         })
         .catch(() => navigate(Pages.SendDetails))
     }
-  }, [proceed, sendInfo.address, sendInfo.arkAddress, sendInfo.invoice, sendInfo.pendingSwap])
+  }, [proceed, sendInfo.address, sendInfo.arkAddress, sendInfo.invoice, sendInfo.pendingSwap, lightningSwapsAvailable])
 
   // deal with fees deduction from amount
   useEffect(() => {
@@ -728,14 +740,12 @@ export default function SendForm() {
   }
 
   const handleContinue = async () => {
+    if (lightningOnlyPayment) return
     setProcessing(true)
     const satoshis = sendInfo.satoshis ?? 0
     try {
-      if (sendInfo.lnUrl && lnUrlResponse) {
-        // Check if Ark method is available
-        const arkMethod = lnUrlResponse.transferAmounts?.find((method) => method.method === 'Ark' && method.available)
-
-        if (arkMethod) {
+      if (sendInfo.lnUrl && lnUrlResponse && (lightningSwapsAvailable || lnUrlSupportsArkade)) {
+        if (lnUrlArkMethod) {
           // Fetch Ark address instead of Lightning invoice
           const arkResponse = await fetchArkAddress(sendInfo.lnUrl)
           if (!isValidArkAddress(arkResponse.address)) {
@@ -827,6 +837,8 @@ export default function SendForm() {
   }
 
   const { address, arkAddress, lnUrl, invoice, satoshis } = sendInfo
+  const lightningOnlyPayment =
+    !lightningSwapsAvailable && !address && !arkAddress && Boolean(invoice || (lnUrl && !lnUrlSupportsArkade))
 
   const assetAmt = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
@@ -838,7 +850,8 @@ export default function SendForm() {
       tryingToSelfSend ||
       Boolean(error) ||
       processing
-    : !((address || arkAddress || lnUrl || invoice) && satoshis && satoshis > 0) ||
+    : lightningOnlyPayment ||
+      !((address || arkAddress || lnUrl || invoice) && satoshis && satoshis > 0) ||
       (lnUrlResponse?.maxSendable && satoshis > lnUrlResponse.maxSendable) ||
       (lnUrlResponse?.minSendable && satoshis < lnUrlResponse.minSendable) ||
       amountIsAboveMaxLimit(satoshis) ||

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -120,7 +120,7 @@ export const mockSwapsContextValue = {
     throw new Error('Lightning not initialized')
   },
   getSwapHistory: async () => [],
-  getApiUrl: () => null,
+  getApiUrl: (): string | null => null,
   restoreSwaps: async () => 0,
   toggleConnection: () => {},
 }

--- a/src/test/screens/wallet/index.test.tsx
+++ b/src/test/screens/wallet/index.test.tsx
@@ -7,6 +7,7 @@ import {
   mockAspContextValue,
   mockConfigContextValue,
   mockNavigationContextValue,
+  mockSwapsContextValue,
   mockWalletContextValue,
 } from '../mocks'
 import { ConfigContext } from '../../../providers/config'
@@ -15,6 +16,7 @@ import { AssetSwapsContext } from '../../../providers/assetSwaps'
 import { AssetsContext } from '../../../providers/assets'
 import { AspContext } from '../../../providers/asp'
 import { MUTINYNET_USDT_ASSET_ID } from '../../../lib/accountAssets'
+import { SwapsContext } from '../../../providers/swaps'
 
 describe('Wallet screen', () => {
   it('renders the wallet screen with the correct elements', async () => {
@@ -58,14 +60,16 @@ describe('Wallet screen', () => {
     expect(screen.getByText(/Swaps are coming soon/i)).toBeInTheDocument()
   })
 
-  it('shows the Lightning service notice on bitcoin mainnet only', () => {
+  it('shows the Lightning service notice only when the mainnet Boltz endpoint is unavailable', () => {
     const mainnetAspContext = {
       ...mockAspContextValue,
       aspInfo: { ...mockAspContextValue.aspInfo, network: 'bitcoin' as const },
     }
     const { rerender } = render(
       <AspContext.Provider value={mainnetAspContext}>
-        <Wallet />
+        <SwapsContext.Provider value={{ ...mockSwapsContextValue, getApiUrl: () => null }}>
+          <Wallet />
+        </SwapsContext.Provider>
       </AspContext.Provider>,
     )
 
@@ -74,8 +78,22 @@ describe('Wallet screen', () => {
     )
 
     rerender(
+      <AspContext.Provider value={mainnetAspContext}>
+        <SwapsContext.Provider value={{ ...mockSwapsContextValue, getApiUrl: () => 'https://boltz.test' }}>
+          <Wallet />
+        </SwapsContext.Provider>
+      </AspContext.Provider>,
+    )
+
+    expect(
+      screen.queryByRole('status', { name: 'Lightning swaps are temporarily unavailable' }),
+    ).not.toBeInTheDocument()
+
+    rerender(
       <AspContext.Provider value={mockAspContextValue}>
-        <Wallet />
+        <SwapsContext.Provider value={{ ...mockSwapsContextValue, getApiUrl: () => null }}>
+          <Wallet />
+        </SwapsContext.Provider>
       </AspContext.Provider>,
     )
 

--- a/src/test/screens/wallet/receive-qrcode.test.tsx
+++ b/src/test/screens/wallet/receive-qrcode.test.tsx
@@ -193,6 +193,32 @@ describe('Receive QR Code screen', () => {
     expect(screen.queryByText(/sats min for Lightning/)).not.toBeInTheDocument()
   })
 
+  it('does not create a Lightning invoice from a stale swap instance when the endpoint is unavailable', async () => {
+    const createReverseSwap = vi.fn()
+
+    renderReceiveQrCode({
+      swaps: {
+        connected: true,
+        arkadeSwaps: {} as any,
+        createReverseSwap,
+        getApiUrl: () => null,
+      },
+      flow: {
+        recvInfo: {
+          ...mockFlowContextValue.recvInfo,
+          satoshis: 50000,
+          offchainAddr: 'ark1testaddr',
+          boardingAddr: 'bc1testaddr',
+        },
+      },
+      wallet: { svcWallet: mockSvcWallet as any },
+    })
+
+    await act(async () => {})
+
+    expect(createReverseSwap).not.toHaveBeenCalled()
+  })
+
   it('shows the Lightning minimum only when a Boltz endpoint is configured', () => {
     const { rerender } = render(buildTree(tapFixture()))
 

--- a/src/test/screens/wallet/receive-qrcode.test.tsx
+++ b/src/test/screens/wallet/receive-qrcode.test.tsx
@@ -175,6 +175,34 @@ describe('Receive QR Code screen', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('shows QR immediately when the Boltz endpoint is unavailable, even if swaps are enabled', () => {
+    renderReceiveQrCode({
+      swaps: { connected: true, arkadeSwaps: null, getApiUrl: () => null },
+      flow: {
+        recvInfo: {
+          ...mockFlowContextValue.recvInfo,
+          satoshis: 50000,
+          offchainAddr: 'ark1testaddr',
+          boardingAddr: 'bc1testaddr',
+        },
+      },
+      wallet: { svcWallet: mockSvcWallet as any },
+    })
+
+    expect(screen.queryByText('Generating QR code...')).not.toBeInTheDocument()
+    expect(screen.queryByText(/sats min for Lightning/)).not.toBeInTheDocument()
+  })
+
+  it('shows the Lightning minimum only when a Boltz endpoint is configured', () => {
+    const { rerender } = render(buildTree(tapFixture()))
+
+    expect(screen.queryByText(/sats min for Lightning/)).not.toBeInTheDocument()
+
+    rerender(buildTree({ ...tapFixture(), swaps: { getApiUrl: () => 'https://boltz.test' } }))
+
+    expect(screen.getByText('0 sats min for Lightning')).toBeInTheDocument()
+  })
+
   // UX Constraint 2c: When LN init already failed, don't wait — show QR + warning immediately
   it('shows QR immediately with warning when swapsInitError is set (no 5s wait)', async () => {
     renderReceiveQrCode({
@@ -182,6 +210,7 @@ describe('Receive QR Code screen', () => {
         connected: true,
         arkadeSwaps: null,
         swapsInitError: 'SwapManager not supported',
+        getApiUrl: () => 'https://boltz.test',
       },
       flow: {
         recvInfo: {
@@ -369,7 +398,11 @@ describe('Receive QR Code screen', () => {
 
   // Bug 2: amountless LNURL belongs in the QR; with an amount it must not.
   it('includes the LNURL in the QR when no amount is set', async () => {
-    renderReceiveQrCode({ ...tapFixture(), lnurl: { lnurl: 'LNURL1TESTXYZ', active: true } })
+    renderReceiveQrCode({
+      ...tapFixture(),
+      swaps: { connected: false, arkadeSwaps: null, getApiUrl: () => 'https://boltz.test' },
+      lnurl: { lnurl: 'LNURL1TESTXYZ', active: true },
+    })
 
     const qrButton = await screen.findByRole('button', { name: 'Copy QR code' })
     await act(async () => {
@@ -381,7 +414,7 @@ describe('Receive QR Code screen', () => {
 
   it('drops the LNURL from the QR once an amount is set', async () => {
     renderReceiveQrCode({
-      swaps: { connected: false, arkadeSwaps: null },
+      swaps: { connected: false, arkadeSwaps: null, getApiUrl: () => 'https://boltz.test' },
       flow: {
         recvInfo: {
           ...mockFlowContextValue.recvInfo,

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -104,7 +104,7 @@ describe('Send screen', () => {
     expect(screen.queryByText('Unable to create swap')).not.toBeInTheDocument()
   })
 
-  it('detects a pasted Lightning invoice without showing an outage error', async () => {
+  it('explains why a pasted Lightning invoice is unavailable', async () => {
     vi.useFakeTimers()
     try {
       const setSendInfo = vi.fn()
@@ -130,7 +130,7 @@ describe('Send screen', () => {
           satoshis: fixtures.lib.bolt11.amountSats,
         }),
       )
-      expect(screen.queryByText(/Lightning swaps not enabled|Unable to create swap/)).not.toBeInTheDocument()
+      expect(screen.getByText('Lightning is temporarily unavailable')).toBeInTheDocument()
     } finally {
       vi.useRealTimers()
     }
@@ -219,6 +219,33 @@ describe('Send screen', () => {
 
     await waitFor(() => screen.getByDisplayValue('21'))
     expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+    fetchMocker.disableMocks()
+  })
+
+  it('explains when an LNURL only supports unavailable Lightning', async () => {
+    const fetchMocker = createFetchMock(vi)
+    fetchMocker.enableMocks()
+    fetchMocker.mockResponseOnce(
+      JSON.stringify({
+        callback: 'https://pay.staging.galoy.io/.well-known/lnurlp/testing',
+        minSendable: 21000,
+        maxSendable: 21000,
+        metadata: 'mock-metadata',
+      }),
+    )
+    const lnUrl = fixtures.lib.lnurl[0].lnUrlOrAddress
+
+    renderSendForm({
+      flowContext: {
+        ...mockFlowContextValue,
+        sendInfo: { ...emptySendInfo, lnUrl, recipient: lnUrl, satoshis: 21 },
+      },
+      swapsContext: { ...mockSwapsContextValue, getApiUrl: () => null },
+      walletContext: readyWalletContext,
+    })
+
+    expect(await screen.findByText('Lightning is temporarily unavailable')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
     fetchMocker.disableMocks()
   })
 

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -24,12 +24,24 @@ import { FiatContext } from '../../../providers/fiat'
 import { SwapsContext } from '../../../providers/swaps'
 import { OptionsContext } from '../../../providers/options'
 import { Currencies, Unit } from '../../../lib/types'
+import fixtures from '../../fixtures.json'
 
 describe('Send screen', () => {
+  const readyWalletContext = {
+    ...mockWalletContextValue,
+    availableBalance: 1_000_000,
+    svcWallet: {
+      ...mockSvcWallet,
+      getAddress: () => 'tark1mockoffchain',
+      getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+    } as any,
+  }
+
   const renderSendForm = ({
     configContext = mockConfigContextValue,
     fiatContext = mockFiatContextValue,
     flowContext = mockFlowContextValue,
+    swapsContext = mockSwapsContextValue,
     walletContext = { ...mockWalletContextValue, svcWallet: mockSvcWallet as any },
   } = {}) =>
     render(
@@ -37,7 +49,7 @@ describe('Send screen', () => {
         <AspContext.Provider value={mockAspContextValue}>
           <ConfigContext.Provider value={configContext as any}>
             <FiatContext.Provider value={fiatContext as any}>
-              <SwapsContext.Provider value={mockSwapsContextValue as any}>
+              <SwapsContext.Provider value={swapsContext as any}>
                 <OptionsContext.Provider value={mockOptionsContextValue as any}>
                   <FlowContext.Provider value={flowContext as any}>
                     <WalletContext.Provider value={walletContext as any}>
@@ -68,6 +80,79 @@ describe('Send screen', () => {
     expect(screen.getByText('Recipient address')).toBeInTheDocument()
     expect(screen.getByText('Continue')).toBeInTheDocument()
   })
+
+  it('blocks a Lightning-only payment before attempting a swap when the Boltz endpoint is unavailable', () => {
+    const createSubmarineSwap = vi.fn()
+    const invoice = fixtures.lib.bolt11.invoice
+
+    renderSendForm({
+      flowContext: {
+        ...mockFlowContextValue,
+        sendInfo: { ...emptySendInfo, invoice, recipient: invoice, satoshis: fixtures.lib.bolt11.amountSats },
+      },
+      swapsContext: {
+        ...mockSwapsContextValue,
+        connected: true,
+        createSubmarineSwap,
+        getApiUrl: () => null,
+      },
+      walletContext: readyWalletContext,
+    })
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+    expect(createSubmarineSwap).not.toHaveBeenCalled()
+    expect(screen.queryByText('Unable to create swap')).not.toBeInTheDocument()
+  })
+
+  it('detects a pasted Lightning invoice without showing an outage error', async () => {
+    vi.useFakeTimers()
+    try {
+      const setSendInfo = vi.fn()
+      const invoice = fixtures.lib.bolt11.invoice
+
+      renderSendForm({
+        flowContext: { ...mockFlowContextValue, sendInfo: { ...emptySendInfo }, setSendInfo },
+        swapsContext: { ...mockSwapsContextValue, connected: true, getApiUrl: () => null },
+        walletContext: readyWalletContext,
+      })
+
+      fireEvent.change(document.querySelector('input[name="send-address"]') as HTMLInputElement, {
+        target: { value: invoice },
+      })
+      await act(async () => vi.advanceTimersByTimeAsync(1_000))
+
+      expect(setSendInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: '',
+          arkAddress: '',
+          invoice,
+          lnUrl: '',
+          satoshis: fixtures.lib.bolt11.amountSats,
+        }),
+      )
+      expect(screen.queryByText(/Lightning swaps not enabled|Unable to create swap/)).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a non-Lightning route available from a mixed payment request during the outage', () => {
+    renderSendForm({
+      flowContext: {
+        ...mockFlowContextValue,
+        sendInfo: {
+          ...emptySendInfo,
+          address: 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7',
+          invoice: fixtures.lib.bolt11.invoice,
+          satoshis: fixtures.lib.bolt11.amountSats,
+        },
+      },
+      swapsContext: { ...mockSwapsContextValue, getApiUrl: () => null },
+      walletContext: readyWalletContext,
+    })
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
   it('fills the amount field when an LNURL resolves to a fixed amount', async () => {
     // regression: a fixed-amount LNURL (minSendable === maxSendable) must
     // populate the read-only amount input instead of leaving it blank
@@ -82,9 +167,10 @@ describe('Send screen', () => {
       }),
     )
     const lnUrl = 'lnurl1dp68gurn8ghj7urp0yh8xarpva5kueewvaskcmme9e5k7tewwajkcmpdddhx7amw9akxuatjd3cz7ar9wd6xjmn8h9qlv7'
-    const flowValue = { ...mockFlowContextValue, sendInfo: { ...emptySendInfo, lnUrl, recipient: lnUrl } }
+    const flowValue = { ...mockFlowContextValue, sendInfo: { ...emptySendInfo, lnUrl, recipient: lnUrl, satoshis: 21 } }
     const walletValue = {
       ...mockWalletContextValue,
+      availableBalance: 1_000_000,
       balance: 1_000_000,
       svcWallet: {
         ...mockSvcWallet,
@@ -100,6 +186,39 @@ describe('Send screen', () => {
     const amountInput = await waitFor(() => screen.getByDisplayValue('21'))
     expect(amountInput).toHaveAttribute('name', 'send-amount')
     expect(amountInput).toHaveAttribute('readonly')
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+    fetchMocker.disableMocks()
+  })
+
+  it('keeps an Arkade-capable LNURL available without a Boltz endpoint', async () => {
+    const fetchMocker = createFetchMock(vi)
+    fetchMocker.enableMocks()
+    fetchMocker.mockResponseOnce(
+      JSON.stringify({
+        callback: 'https://pay.staging.galoy.io/.well-known/lnurlp/testing',
+        minSendable: 21000,
+        maxSendable: 21000,
+        metadata: 'mock-metadata',
+        transferAmounts: [{ method: 'Ark', available: true }],
+      }),
+    )
+    const lnUrl = fixtures.lib.lnurl[0].lnUrlOrAddress
+    const flowValue = { ...mockFlowContextValue, sendInfo: { ...emptySendInfo, lnUrl, recipient: lnUrl, satoshis: 21 } }
+    const walletValue = {
+      ...mockWalletContextValue,
+      availableBalance: 1_000_000,
+      balance: 1_000_000,
+      svcWallet: {
+        ...mockSvcWallet,
+        getAddress: () => 'tark1mockoffchain',
+        getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+      } as any,
+    }
+
+    renderSendForm({ flowContext: flowValue, walletContext: walletValue })
+
+    await waitFor(() => screen.getByDisplayValue('21'))
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
     fetchMocker.disableMocks()
   })
 


### PR DESCRIPTION
## Summary

- Uses the configured Boltz endpoint as the wallet's shared Lightning swap availability signal.
- Clears stale swap provider and fee state when endpoint configuration changes, preventing a prior provider from creating a reverse swap.
- Shows the existing homepage outage notice only on bitcoin mainnet when no Boltz endpoint is configured.
- Keeps Receive immediately usable with Arkade and on-chain payment options while removing unavailable Lightning and LNURL affordances.
- Detects Lightning-only BOLT11 and LNURL payments in Send and blocks them before swap creation, avoiding the misleading `Unable to create swap` error.
- Preserves valid non-Lightning alternatives from mixed payment requests and Arkade-capable LNURLs.
- Addresses review feedback by showing `Lightning is temporarily unavailable` beside unsupported Lightning-only recipients and removing two misleading effect-lifecycle comments.

## User-visible behavior

- The homepage notice disappears automatically when `VITE_BOLTZ_URL` is restored.
- Receive no longer shows `0 sats min for Lightning`, advertises an LNURL, waits for Lightning initialization, or creates a reverse swap while the endpoint is absent.
- Pasted or scanned Lightning-only payments explain that Lightning is temporarily unavailable and keep the primary action disabled without attempting swap creation.
- Arkade and on-chain payments remain available, including fallback routes included alongside Lightning data.

## Scope

- `src/providers/swaps.tsx` — derives the active API URL synchronously, clears provider and endpoint-specific fee state whenever swap configuration changes, and removes two inaccurate lifecycle comments identified in review.
- `src/screens/Wallet/Index.tsx` — ties the existing Lightning outage notice to missing mainnet Boltz configuration.
- `src/screens/Wallet/Receive/QrCode.tsx` — skips unavailable Lightning initialization and reverse-swap creation while retaining Arkade and on-chain QR data.
- `src/screens/Wallet/Send/Form.tsx` — recognizes unavailable BOLT11/LNURL routes, surfaces a concise inline explanation, prevents swap creation, and retains usable Arkade/on-chain alternatives.
- `src/test/screens/wallet/index.test.tsx` — covers homepage notice visibility by network and endpoint availability.
- `src/test/screens/wallet/receive-qrcode.test.tsx` — covers immediate QR rendering, conditional Lightning/LNURL affordances, and stale-provider protection.
- `src/test/screens/wallet/send.test.tsx` — covers BOLT11 detection and explanation, Lightning-only LNURL explanation, mixed-route fallback, and Arkade-capable LNURLs.

No files were added, moved, or deleted. No dependencies were added, and no unrelated product behavior was changed.

## Verification

- `bun run test -- src/test/screens/wallet/send.test.tsx` — 17 passed after the final review changes.
- `bun run test:unit src/test/screens/wallet/receive-qrcode.test.tsx` — 15 passed, 2 pre-existing tests skipped after the earlier review fix.
- `bun run lint` — passed locally and in the commit hook.
- `bunx prettier --check src/providers/swaps.tsx src/screens/Wallet/Send/Form.tsx src/test/screens/wallet/send.test.tsx` — passed.
- `bun run build` — passed. The existing Node engine, public-directory, dynamic-import, and chunk-size warnings remain unchanged.
- `git diff --check` — passed.
- A three-way merge simulation against current `origin/master` (`ddfc6bf0`) produced no conflict markers; GitHub reports the PR as mergeable and clean.
- GitHub `CI / test`, both Cloudflare deployments, and CodeRabbit passed on final commit `4015d0f`; all four Playwright E2E jobs remained in progress with no failures at the five-minute observation cutoff.
- Arkana's incremental review found the three review-fix commits clean with no new issues.
- Fresh mobile verification in the Codex in-app browser showed the inline unavailable-Lightning explanation, a disabled Continue action, and no console errors.
- Earlier responsive verification covered 375×667, 768×1024, 1440×900, and 1920×1080 with no horizontal overflow.

The initial full unit run passed 539 tests with 3 skips. A later concurrent full run hit 5 unrelated `swap.test.tsx` failures/timeouts; the remaining timed-out case passed immediately when rerun alone.

## Visual evidence

### Homepage outage notice

<img width="375" height="667" alt="wallet-lightning-outage-home" src="https://github.com/user-attachments/assets/1ea9cc4a-79a7-45c3-b235-f67caf024dd7" />

### Receive without Lightning affordances

<img width="375" height="667" alt="wallet-receive-without-lightning" src="https://github.com/user-attachments/assets/81ef8c86-39c3-4b2a-a91e-51a2f05329cf" />

### Lightning invoice explains unavailable service

<img width="390" height="844" alt="arkade-wallet-pr875-lightning-unavailable-20260807" src="https://github.com/user-attachments/assets/7c423e73-d112-4be4-8516-d4d0142f7784" />


## Latest TypeScript fix

- `src/test/screens/mocks.ts` — widens the shared `getApiUrl` mock return type from inferred `null` to `string | null`, matching the production context contract and fixing all four reported TS2322 errors.
- User-visible behavior is unchanged; this is test typing only.
- No files were added, moved, or deleted. No dependencies or unrelated behavior changed.
- Current `master` was merged conflict-free so the branch passes the repository's required base verification.

### Verification

- `bunx tsc --noEmit` — passed with current master dependencies.
- `bunx vitest run src/test/screens/wallet/receive-qrcode.test.tsx` — 15 passed, 2 pre-existing skips.
- `bunx vitest run src/test/screens/wallet/swap.test.tsx` — 39 passed when isolated; the full parallel unit run's five swap-suite failures were load-related timeouts.
- `bunx eslint src/test/screens/mocks.ts` — passed.
- `bunx prettier --check src/test/screens/mocks.ts` — passed.
- Commit hook full lint and formatting checks — passed.
- `git diff --check` and master-base/PR-target verification — passed.
- Fresh GitHub `CI / test`, CodeRabbit, and both Cloudflare deployments passed on `fd0ac9c`; four Playwright E2E jobs remained pending with no failures at the five-minute observation cap.

### TypeScript fix proof

<img width="1280" height="720" alt="pr-875-typescript-fix" src="https://github.com/user-attachments/assets/3b193b8a-9651-444e-95cd-b7b199a14ca0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lightning payment handling when swap services are temporarily unavailable.
  * Limited outage notices to affected Bitcoin networks.
  * Preserved compatible invoices and payment options without requiring swaps.
  * Prevented unsupported Lightning-only payments and displayed clearer temporary-unavailability messages.
  * Updated receive QR and LNURL flows to avoid stale invoices, incorrect warnings, and unavailable swap actions.

* **Tests**
  * Added coverage for unavailable swap services across wallet, receive, send, invoice, and LNURL payment flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->