### PR TITLE
Disable server config on mainnet

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -36,6 +36,9 @@ export const defaultArkServer = () => {
   return mainServer
 }
 
+export const isMainnet = (network: NetworkName | string): boolean =>
+  !!network && network !== 'testnet' && network !== 'mutinynet' && network !== 'signet' && network !== 'regtest'
+
 const DELEGATE_URL: Record<NetworkName, string | null> = {
   bitcoin: 'https://delegate.arkade.money',
   mutinynet: `https://delegator.mutinynet.arkade.sh`,

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -49,6 +49,7 @@ import { ConfigContext } from './config'
 import {
   defaultPassword,
   getDelegateUrlForNetwork,
+  isMainnet,
   maxPercentage,
   mutinynetMinCheckpointExitDelaySeconds,
 } from '../lib/constants'
@@ -730,9 +731,6 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       throw err
     }
   }
-
-  const isMainnet = (network: NetworkName | string): boolean =>
-    network !== 'testnet' && network !== 'mutinynet' && network !== 'signet' && network !== 'regtest'
 
   const minCheckpointExitDelaySecondsForNetwork = (network: NetworkName | string): bigint | undefined =>
     network === 'mutinynet' ? mutinynetMinCheckpointExitDelaySeconds : network === 'regtest' ? 512n : undefined

--- a/src/screens/Settings/Advanced.tsx
+++ b/src/screens/Settings/Advanced.tsx
@@ -5,13 +5,17 @@ import Content from '../../components/Content'
 import { SettingsOptions, SettingsSections } from '../../lib/types'
 import Menu from '../../components/Menu'
 import { DevModeContext } from '../../providers/devMode'
+import { AspContext } from '../../providers/asp'
+import { isMainnet } from '../../lib/constants'
 import Padded from '../../components/Padded'
 
 export default function Advanced() {
   const { devMode } = useContext(DevModeContext)
+  const { aspInfo } = useContext(AspContext)
   const rows = options
     .filter((o) => o.section === SettingsSections.Advanced)
     .filter((o) => o.option !== SettingsOptions.Contracts || devMode)
+    .filter((o) => o.option !== SettingsOptions.Server || !isMainnet(aspInfo.network))
 
   return (
     <>

--- a/src/screens/Settings/Server.tsx
+++ b/src/screens/Settings/Server.tsx
@@ -16,6 +16,7 @@ import Scanner from '../../components/Scanner'
 import { AspContext, AspInfo } from '../../providers/asp'
 import { consoleError } from '../../lib/logs'
 import LoadingLogo from '../../components/LoadingLogo'
+import { isMainnet } from '../../lib/constants'
 
 export default function Server() {
   const { aspInfo } = useContext(AspContext)
@@ -53,7 +54,12 @@ export default function Server() {
 
   if (!svcWallet) return <LoadingLogo text='Loading...' />
 
+  // Mirrors the Advanced menu filter: block direct navigation to this screen too,
+  // but still allow recovery if the current mainnet server is unreachable.
+  const blocked = isMainnet(aspInfo.network) && !aspInfo.unreachable
+
   const handleConnect = async () => {
+    if (blocked) return
     setLoading(true)
     try {
       if (!info) return
@@ -73,6 +79,19 @@ export default function Server() {
   }
 
   if (scan) return <Scanner close={() => setScan(false)} label='Server URL' onData={setAspUrl} onError={setError} />
+
+  if (blocked) {
+    return (
+      <>
+        <Header text='Server' back />
+        <Content>
+          <Padded>
+            <WarningBox text='Server settings are unavailable on mainnet.' />
+          </Padded>
+        </Content>
+      </>
+    )
+  }
 
   return (
     <>

--- a/src/test/lib/constants.test.ts
+++ b/src/test/lib/constants.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { isMainnet } from '../../lib/constants'
+
+describe('isMainnet', () => {
+  it('returns true for bitcoin and unrecognized networks', () => {
+    expect(isMainnet('bitcoin')).toBe(true)
+    expect(isMainnet('some-future-network')).toBe(true)
+  })
+
+  it('returns false for known test networks', () => {
+    expect(isMainnet('testnet')).toBe(false)
+    expect(isMainnet('mutinynet')).toBe(false)
+    expect(isMainnet('signet')).toBe(false)
+    expect(isMainnet('regtest')).toBe(false)
+  })
+
+  it('returns false for an empty network (unreachable ASP or not yet loaded)', () => {
+    expect(isMainnet('')).toBe(false)
+  })
+})


### PR DESCRIPTION
Don't allow setting operator URL on mainnet + small refactor to extract the existing `isMainnet` helper

<img width="1392" height="811" alt="Screenshot 2026-08-04 at 12 01 46 AM" src="https://github.com/user-attachments/assets/2229f245-052d-4678-8504-d4af3738335c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced settings now hide the Server option when connected to a mainnet network.
  * Server settings now display a warning and prevent changes when connected to a reachable mainnet server.

* **Bug Fixes**
  * Network detection is now applied consistently across wallet initialization and settings.
  * Server configuration remains available when the mainnet server is unreachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->