### PR TITLE
Skip plain Branta lookups

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -67,12 +67,20 @@ const brantaClient = new BrantaService({
   privacy: 'strict',
 })
 
-const isPlainOnchainTypedRecipient = (value: string): boolean => {
+export const isPlainOnchainTypedRecipient = (value: string): boolean => {
   if (isBTCAddress(value)) return true
   if (!isBip21(value.toLowerCase())) return false
 
   try {
-    return Boolean(decodeBip21(value).address)
+    const decoded = decodeBip21(value)
+    return Boolean(
+      decoded.address &&
+        isBTCAddress(decoded.address) &&
+        !decoded.arkAddress &&
+        !decoded.invoice &&
+        !decoded.lnUrl &&
+        !decoded.assetId,
+    )
   } catch {
     return false
   }

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -67,6 +67,17 @@ const brantaClient = new BrantaService({
   privacy: 'strict',
 })
 
+const isPlainOnchainTypedRecipient = (value: string): boolean => {
+  if (isBTCAddress(value)) return true
+  if (!isBip21(value.toLowerCase())) return false
+
+  try {
+    return Boolean(decodeBip21(value).address)
+  } catch {
+    return false
+  }
+}
+
 function AssetIcon({ asset }: { asset: AssetOption | null }) {
   const { aspInfo } = useContext(AspContext)
   const { isVerifiedAsset } = useContext(WalletContext)
@@ -408,6 +419,12 @@ export default function SendForm() {
 
     setBrantaPayment(null)
     setBrantaVerifyUrl(undefined)
+
+    if (!rawScanData && isPlainOnchainTypedRecipient(typed)) {
+      setBrantaLoading(false)
+      return
+    }
+
     let cancelled = false
 
     const runLookup = () => {

--- a/src/test/screens/wallet/send-form.test.ts
+++ b/src/test/screens/wallet/send-form.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { isPlainOnchainTypedRecipient } from '../../../screens/Wallet/Send/Form'
+
+const BTC_ADDRESS = 'bcrt1pq6gt72nxevsxk5fwl3h2sx56jeah6qfzh98mksxyakkg5l0q65gsa27khh'
+const ARK_ADDRESS =
+  'ARK1QQ4HFSSPRTCGNJZF8QLW2F78YVJAU5KLDFUGG29K34Y7J96Q2W4T4USH2JZ072D0ALD83VLWZRKDG24R40WRCM8XJW6AX7YPNJHTEZGU4A9R8D'
+
+describe('isPlainOnchainTypedRecipient', () => {
+  it('returns true for a bare BTC address', () => {
+    expect(isPlainOnchainTypedRecipient(BTC_ADDRESS)).toBe(true)
+  })
+
+  it('returns true for a BIP21 URI with a valid BTC address only', () => {
+    expect(isPlainOnchainTypedRecipient(`bitcoin:${BTC_ADDRESS}`)).toBe(true)
+  })
+
+  it('returns false for a BIP21 URI with a malformed address', () => {
+    expect(isPlainOnchainTypedRecipient('bitcoin:not-an-address')).toBe(false)
+  })
+
+  it('returns false for a BIP21 URI mixing a BTC address with an ark address', () => {
+    expect(isPlainOnchainTypedRecipient(`bitcoin:${BTC_ADDRESS}?ark=${ARK_ADDRESS}`)).toBe(false)
+  })
+
+  it('returns false for a BIP21 URI mixing a BTC address with a lightning invoice', () => {
+    expect(isPlainOnchainTypedRecipient(`bitcoin:${BTC_ADDRESS}?lightning=lnbc1abc`)).toBe(false)
+  })
+
+  it('returns false for a BIP21 URI mixing a BTC address with an lnurl', () => {
+    expect(isPlainOnchainTypedRecipient(`bitcoin:${BTC_ADDRESS}?lightning=lnurl1abc`)).toBe(false)
+  })
+
+  it('returns false for a BIP21 URI mixing a BTC address with an assetId', () => {
+    expect(isPlainOnchainTypedRecipient(`bitcoin:${BTC_ADDRESS}?assetid=someasset`)).toBe(false)
+  })
+
+  it('returns false for an ark-only BIP21 URI', () => {
+    expect(isPlainOnchainTypedRecipient(`bitcoin:?ark=${ARK_ADDRESS}`)).toBe(false)
+  })
+
+  it('returns false for a non-BIP21, non-address value', () => {
+    expect(isPlainOnchainTypedRecipient('not a recipient at all')).toBe(false)
+  })
+})


### PR DESCRIPTION
Skips Branta typed lookups for plain on-chain recipients in strict privacy mode, avoiding expected SDK privacy exceptions in the send screen console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directly entered Bitcoin addresses and valid BIP21 recipients can now proceed without unnecessary Branta verification.
  * QR-scanned inputs and other recipient types continue through the existing verification process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->