### PR TITLE
Show both legs of a Lightning send on its receipt

### DIFF
--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -177,14 +177,7 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     ['Destination', destination, <TypeIcon key='destination-icon' />],
     ['Funded', fundedTxid, <HashIcon key='funded-icon' />, offchainTxOnClick(fundedTxid)],
     [spendLabel ?? 'Completed', spendTxid, <HashIcon key='spend-icon' />, offchainTxOnClick(spendTxid)],
-    // A two-leg receipt names its funding tx on the Funded row, so a
-    // Transaction ID row would only repeat it under a vaguer label.
-    [
-      'Transaction ID',
-      fundedTxid ? undefined : txid,
-      <HashIcon key='txid-icon' />,
-      showTxidLink ? txidOnClick : undefined,
-    ],
+    ['Transaction ID', txid, <HashIcon key='txid-icon' />, showTxidLink ? txidOnClick : undefined],
     ...assetIdRows,
     ['Direction', direction, <DirectionIcon key='direction-icon' />],
     ['Type', type, <TypeIcon key='type-icon' />],

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -177,7 +177,14 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     ['Destination', destination, <TypeIcon key='destination-icon' />],
     ['Funded', fundedTxid, <HashIcon key='funded-icon' />, offchainTxOnClick(fundedTxid)],
     [spendLabel ?? 'Completed', spendTxid, <HashIcon key='spend-icon' />, offchainTxOnClick(spendTxid)],
-    ['Transaction ID', txid, <HashIcon key='txid-icon' />, showTxidLink ? txidOnClick : undefined],
+    // A two-leg receipt names its funding tx on the Funded row, so a
+    // Transaction ID row would only repeat it under a vaguer label.
+    [
+      'Transaction ID',
+      fundedTxid ? undefined : txid,
+      <HashIcon key='txid-icon' />,
+      showTxidLink ? txidOnClick : undefined,
+    ],
     ...assetIdRows,
     ['Direction', direction, <DirectionIcon key='direction-icon' />],
     ['Type', type, <TypeIcon key='type-icon' />],

--- a/src/hooks/useLnSendReceipt.ts
+++ b/src/hooks/useLnSendReceipt.ts
@@ -1,0 +1,80 @@
+import { useContext, useEffect, useState } from 'react'
+import { RestIndexerProvider } from '@arkade-os/sdk'
+import { AspContext } from '../providers/asp'
+import { WalletContext } from '../providers/wallet'
+import { getTxHistory } from '../lib/asp'
+import { lnSendSpender } from '../lib/lnSwap'
+import { consoleError } from '../lib/logs'
+import { saveTransactionActivityMetadata } from '../lib/storage'
+import { Tx } from '../lib/types'
+
+/** The two txids a Lightning-send receipt shows, and what to call the second. */
+export interface LnSendReceipt {
+  /** The tx the wallet signed: it funded the lockup covenant. */
+  fundedTxid: string
+  /** The tx that spent that covenant — absent while the swap is in flight. */
+  spentTxid?: string
+  /** Row label for `spentTxid`, naming which spend it was. */
+  spendLabel: string
+}
+
+/**
+ * The receipt for a Lightning send: its funding tx and the tx that ended it.
+ *
+ * A Lightning send does not settle when the funding tx does. Funding the
+ * lockup covenant is only acceptance; the payment is finished by a second
+ * transaction the wallet never signs — the solver's claim once it has paid the
+ * invoice, or the refund back to us when it could not. Showing one anonymous
+ * "Transaction ID" for the first leg says nothing about which of those
+ * happened, so this resolves the second leg and the receipt shows both, the
+ * way an asset swap already does.
+ *
+ * Resolution runs here, on the screen that displays it, rather than in a
+ * background monitor: the answer is only ever read on this receipt, it is
+ * permanent once known, and the covenant is a public script — asking about it
+ * costs one indexer call and nothing else waits on it. A failed lookup is
+ * silent for the same reason: the funding leg is true regardless, and the
+ * pending receipt is what an unfinished swap should look like anyway.
+ *
+ * Returns undefined for anything that is not a Lightning send, so callers can
+ * branch on its presence.
+ */
+export function useLnSendReceipt(tx: Tx | undefined): LnSendReceipt | undefined {
+  const { aspInfo } = useContext(AspContext)
+  const { svcWallet } = useContext(WalletContext)
+  const [resolved, setResolved] = useState<{ spentTxid: string; outcome: 'completed' | 'refunded' }>()
+
+  const lnSend = tx?.lnSend
+  const fundedTxid = tx?.redeemTxid
+  const spend = lnSend?.spentTxid ? { spentTxid: lnSend.spentTxid, outcome: lnSend.outcome } : resolved
+  // Only a swap with no spend on record has anything left to look up.
+  const pending = lnSend && !spend ? { fundingTxid: fundedTxid, swapPkScript: lnSend.swapPkScript } : undefined
+
+  useEffect(() => {
+    const { fundingTxid, swapPkScript } = pending ?? {}
+    if (!fundingTxid || !swapPkScript || !svcWallet || !aspInfo.url) return
+    let live = true
+    lnSendSpender(new RestIndexerProvider(aspInfo.url), () => getTxHistory(svcWallet), { fundingTxid, swapPkScript })
+      .then((spender) => {
+        if (!live || !spender) return
+        // Persist so every later visit reads the answer instead of re-deriving
+        // it: the spend is terminal, and once the covenant vtxo is swept the
+        // indexer stops being able to answer at all.
+        saveTransactionActivityMetadata(fundingTxid, { lnSend: { swapPkScript, ...spender } })
+        setResolved(spender)
+      })
+      .catch(consoleError)
+    return () => {
+      live = false
+    }
+  }, [pending?.fundingTxid, pending?.swapPkScript, svcWallet, aspInfo.url])
+
+  if (!lnSend || !fundedTxid) return undefined
+  return {
+    fundedTxid,
+    spentTxid: spend?.spentTxid,
+    // "Refunded", not "Cancelled": nobody cancelled anything — the solver
+    // could not pay the invoice and the covenant returned the funds.
+    spendLabel: spend?.outcome === 'refunded' ? 'Refunded' : 'Completed',
+  }
+}

--- a/src/hooks/useLnSendReceipt.ts
+++ b/src/hooks/useLnSendReceipt.ts
@@ -2,11 +2,10 @@ import { useContext, useEffect, useState } from 'react'
 import { RestIndexerProvider } from '@arkade-os/sdk'
 import { AspContext } from '../providers/asp'
 import { WalletContext } from '../providers/wallet'
-import { getTxHistory } from '../lib/asp'
 import { lnSendSpender } from '../lib/lnSwap'
 import { consoleError } from '../lib/logs'
-import { saveTransactionActivityMetadata } from '../lib/storage'
-import { Tx } from '../lib/types'
+import { readTransactionActivityMetadata, saveTransactionActivityMetadata } from '../lib/storage'
+import { LnSendSpend, Tx } from '../lib/types'
 
 /** The two txids a Lightning-send receipt shows, and what to call the second. */
 export interface LnSendReceipt {
@@ -42,32 +41,44 @@ export interface LnSendReceipt {
 export function useLnSendReceipt(tx: Tx | undefined): LnSendReceipt | undefined {
   const { aspInfo } = useContext(AspContext)
   const { svcWallet } = useContext(WalletContext)
-  const [resolved, setResolved] = useState<{ spentTxid: string; outcome: 'completed' | 'refunded' }>()
+  // Seeded from storage because `tx` only carries the answer once a wallet
+  // reload has rebuilt history from it; without this, revisiting a resolved
+  // receipt in the same session would pay for the whole lookup again — and
+  // once the covenant is swept the indexer can no longer answer it at all.
+  const [resolved, setResolved] = useState<LnSendSpend | undefined>(
+    () => readTransactionActivityMetadata([tx?.redeemTxid])?.lnSend?.spend,
+  )
 
   const lnSend = tx?.lnSend
   const fundedTxid = tx?.redeemTxid
-  const spend = lnSend?.spentTxid ? { spentTxid: lnSend.spentTxid, outcome: lnSend.outcome } : resolved
-  // Only a swap with no spend on record has anything left to look up.
-  const pending = lnSend && !spend ? { fundingTxid: fundedTxid, swapPkScript: lnSend.swapPkScript } : undefined
+  const spend = lnSend?.spend ?? resolved
+  // The only thing left to look up: a covenant with no spend on record.
+  const unresolvedPkScript = spend ? undefined : lnSend?.swapPkScript
 
   useEffect(() => {
-    const { fundingTxid, swapPkScript } = pending ?? {}
-    if (!fundingTxid || !swapPkScript || !svcWallet || !aspInfo.url) return
+    if (!fundedTxid || !unresolvedPkScript || !svcWallet || !aspInfo.url) return
     let live = true
-    lnSendSpender(new RestIndexerProvider(aspInfo.url), () => getTxHistory(svcWallet), { fundingTxid, swapPkScript })
+    // Deliberately the raw SDK read, not getTxHistory: that one reports a
+    // failure as an empty history, which here would read as "no refund of
+    // ours" and persist a refunded swap as a completed payment.
+    const paidUs = async (txid: string) => {
+      const history = await svcWallet.getTransactionHistory()
+      return Boolean(history?.some(({ key }) => [key.arkTxid, key.boardingTxid, key.commitmentTxid].includes(txid)))
+    }
+    lnSendSpender(new RestIndexerProvider(aspInfo.url), paidUs, {
+      fundingTxid: fundedTxid,
+      swapPkScript: unresolvedPkScript,
+    })
       .then((spender) => {
         if (!live || !spender) return
-        // Persist so every later visit reads the answer instead of re-deriving
-        // it: the spend is terminal, and once the covenant vtxo is swept the
-        // indexer stops being able to answer at all.
-        saveTransactionActivityMetadata(fundingTxid, { lnSend: { swapPkScript, ...spender } })
+        saveTransactionActivityMetadata(fundedTxid, { lnSend: { swapPkScript: unresolvedPkScript, spend: spender } })
         setResolved(spender)
       })
       .catch(consoleError)
     return () => {
       live = false
     }
-  }, [pending?.fundingTxid, pending?.swapPkScript, svcWallet, aspInfo.url])
+  }, [fundedTxid, unresolvedPkScript, svcWallet, aspInfo.url])
 
   if (!lnSend || !fundedTxid) return undefined
   return {

--- a/src/hooks/useLnSendReceipt.ts
+++ b/src/hooks/useLnSendReceipt.ts
@@ -7,13 +7,20 @@ import { consoleError } from '../lib/logs'
 import { readTransactionActivityMetadata, saveTransactionActivityMetadata } from '../lib/storage'
 import { LnSendSpend, Tx } from '../lib/types'
 
-/** The two txids a Lightning-send receipt shows, and what to call the second. */
+/**
+ * The two txids a Lightning-send receipt shows, and what to call the second.
+ *
+ * Field names are `Details`' own, so a caller spreads this into `DetailsProps`
+ * rather than copying it across field by field — the rename in transit that
+ * `spentTxid` would force is a one-character trap between the only producer of
+ * this shape and its only consumer.
+ */
 export interface LnSendReceipt {
   /** The tx the wallet signed: it funded the lockup covenant. */
   fundedTxid: string
   /** The tx that spent that covenant — absent while the swap is in flight. */
-  spentTxid?: string
-  /** Row label for `spentTxid`, naming which spend it was. */
+  spendTxid?: string
+  /** Row label for `spendTxid`, naming which spend it was. */
   spendLabel: string
 }
 
@@ -45,8 +52,14 @@ export function useLnSendReceipt(tx: Tx | undefined): LnSendReceipt | undefined 
   // reload has rebuilt history from it; without this, revisiting a resolved
   // receipt in the same session would pay for the whole lookup again — and
   // once the covenant is swept the indexer can no longer answer it at all.
-  const [resolved, setResolved] = useState<LnSendSpend | undefined>(
-    () => readTransactionActivityMetadata([tx?.redeemTxid])?.lnSend?.spend,
+  //
+  // Gated on there being an unresolved send to seed: this hook runs for every
+  // transaction receipt in the app, and the read parses the whole activity
+  // blob. Mount-scoped, which is safe only because navigation unmounts the
+  // screen — a router that kept it mounted would show the previous receipt's
+  // spend.
+  const [resolved, setResolved] = useState<LnSendSpend | undefined>(() =>
+    tx?.lnSend && !tx.lnSend.spend ? readTransactionActivityMetadata([tx.redeemTxid])?.lnSend?.spend : undefined,
   )
 
   const lnSend = tx?.lnSend
@@ -57,7 +70,6 @@ export function useLnSendReceipt(tx: Tx | undefined): LnSendReceipt | undefined 
 
   useEffect(() => {
     if (!fundedTxid || !unresolvedPkScript || !svcWallet || !aspInfo.url) return
-    let live = true
     // Deliberately the raw SDK read, not getTxHistory: that one reports a
     // failure as an empty history, which here would read as "no refund of
     // ours" and persist a refunded swap as a completed payment.
@@ -65,25 +77,26 @@ export function useLnSendReceipt(tx: Tx | undefined): LnSendReceipt | undefined 
       const history = await svcWallet.getTransactionHistory()
       return Boolean(history?.some(({ key }) => [key.arkTxid, key.boardingTxid, key.commitmentTxid].includes(txid)))
     }
+    // No unmount guard: the answer is permanent and was already paid for, so
+    // it is written even if the user has navigated away — discarding it would
+    // make the next visit buy the same lookup again, which is the cost the
+    // seeding above exists to avoid. A setState after unmount is a no-op.
     lnSendSpender(new RestIndexerProvider(aspInfo.url), paidUs, {
       fundingTxid: fundedTxid,
       swapPkScript: unresolvedPkScript,
     })
       .then((spender) => {
-        if (!live || !spender) return
+        if (!spender) return
         saveTransactionActivityMetadata(fundedTxid, { lnSend: { swapPkScript: unresolvedPkScript, spend: spender } })
         setResolved(spender)
       })
       .catch(consoleError)
-    return () => {
-      live = false
-    }
   }, [fundedTxid, unresolvedPkScript, svcWallet, aspInfo.url])
 
   if (!lnSend || !fundedTxid) return undefined
   return {
     fundedTxid,
-    spentTxid: spend?.spentTxid,
+    spendTxid: spend?.spentTxid,
     // "Refunded", not "Cancelled": nobody cancelled anything — the solver
     // could not pay the invoice and the covenant returned the funds.
     spendLabel: spend?.outcome === 'refunded' ? 'Refunded' : 'Completed',

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -203,6 +203,7 @@ export const getTxHistory = async (wallet: IWallet): Promise<Tx[]> => {
         assets,
         boardingTxid: key.boardingTxid,
         destination: type === 'SENT' ? activityMetadata?.destination : undefined,
+        lnSend: type === 'SENT' ? activityMetadata?.lnSend : undefined,
         redeemTxid: key.arkTxid,
         roundTxid: key.commitmentTxid,
         createdAt: unix,

--- a/src/lib/lnSwap.ts
+++ b/src/lib/lnSwap.ts
@@ -22,11 +22,13 @@
  * The client comes from `@arkade-os/swap`, which this wallet takes straight
  * from the ts-sdk monorepo until that package is published to npm.
  */
+import { hex } from '@scure/base'
 import { sideLimits, type DiscoveredMarket } from '@arkade-os/solver-discovery'
-import type { NetworkName } from '@arkade-os/sdk'
+import type { NetworkName, RestIndexerProvider } from '@arkade-os/sdk'
 import { RFQ_TERMINAL_STATES, requestLightningSend, type InvoiceFacts, type RfqTransport } from '@arkade-os/swap'
 import { sleep as defaultSleep } from './sleep'
 import { decodeInvoice, invoiceMatchesNetwork, isInvoiceExpired, type DecodedInvoice } from './bolt11'
+import type { Tx } from './types'
 
 /** Why an invoice cannot start a swap. A closed set, so callers can branch. */
 export type InvoiceRejection = 'unparseable' | 'wrong_network' | 'expired' | 'zero_amount' | 'no_payment_hash'
@@ -148,6 +150,15 @@ export interface LnSendRequest {
   address: string
   /** Sats the lockup must carry. */
   fundAmount: number
+  /**
+   * Hex pkScript of that covenant.
+   *
+   * Kept because the funding txid is only half the story: the covenant's
+   * spender — the solver's claim or the refund — is a transaction the wallet
+   * never signs, so its own history cannot name it. This script is the
+   * indexer key that can. See `lnSendSpender`.
+   */
+  swapPkScript: string
   /** Unix seconds after which the quote is dead and must not be funded. */
   validUntil: number
   /**
@@ -199,9 +210,44 @@ export const requestLnSend = async (
     rfqId: result.rfqId,
     address: result.address,
     fundAmount: result.fundAmount,
+    swapPkScript: hex.encode(result.swapPkScript),
     validUntil: result.quote.valid_until,
     rendezvous: args.rendezvous,
   }
+}
+
+/**
+ * Find the transaction that spent a funded lockup, and say which spend it was.
+ *
+ * The two outcomes are told apart by who got paid, which the wallet can settle
+ * on its own: the refund path pays the refund address the client handed the
+ * solver — our address — so a refund lands in the wallet's own tx history,
+ * while the solver's claim pays the solver and never will. Asking the solver
+ * instead would make the receipt depend on a third party still being reachable
+ * and still remembering the negotiation.
+ *
+ * `history` is a thunk rather than a value so it is read AFTER the indexer has
+ * reported the spend, never from a copy taken before it. That ordering is what
+ * makes the absence of a matching tx mean something: a history read issued
+ * after the indexer saw the spend sees at least as much as it did. Deciding
+ * off an earlier snapshot could miss a refund and call it a paid invoice,
+ * which is the one error here that misreports money.
+ *
+ * Returns undefined while the lockup is unspent, and for a swept one: neither
+ * has a spender to name, and both are still the funding tx's story alone.
+ */
+export const lnSendSpender = async (
+  indexer: Pick<RestIndexerProvider, 'getVtxos'>,
+  history: () => Promise<Tx[]>,
+  lockup: { fundingTxid: string; swapPkScript: string },
+): Promise<{ spentTxid: string; outcome: 'completed' | 'refunded' } | undefined> => {
+  const { vtxos } = await indexer.getVtxos({ scripts: [lockup.swapPkScript] })
+  const funded = vtxos.find((v) => v.script === lockup.swapPkScript && v.txid === lockup.fundingTxid)
+  if (funded?.virtualStatus.state !== 'spent') return undefined
+  const spentTxid = funded.arkTxId ?? funded.spentBy
+  if (!spentTxid) return undefined
+  const ours = (await history()).some((tx) => [tx.boardingTxid, tx.redeemTxid, tx.roundTxid].includes(spentTxid))
+  return { spentTxid, outcome: ours ? 'refunded' : 'completed' }
 }
 
 /** How a funded Lightning send ended, from the wallet's point of view. */

--- a/src/lib/lnSwap.ts
+++ b/src/lib/lnSwap.ts
@@ -227,12 +227,19 @@ export const requestLnSend = async (
  * and still remembering the negotiation.
  *
  * `paidUs` is asked rather than handed a history so the read happens AFTER the
- * indexer has reported the spend, never from a copy taken before it. That
- * ordering is what makes a "no" mean something: a lookup issued after the
- * indexer saw the spend sees at least as much as it did. It must also FAIL
- * rather than answer "no" when it cannot tell — a `false` that really means
- * "could not check" would call a refund a paid invoice, which is the one error
- * here that misreports money.
+ * indexer has reported the spend, never from a copy taken before it, and it
+ * must FAIL rather than answer "no" when it cannot tell — a `false` that really
+ * means "could not check" would call a refund a paid invoice, which is the one
+ * error here that misreports money.
+ *
+ * Neither of those makes a "no" conclusive, and it is worth being exact about
+ * what is left. The wallet's own view and the indexer are separate stores, so
+ * asking second does not guarantee seeing as much: a wallet a sync cycle behind
+ * can still miss a refund that the indexer already knows about, and the answer
+ * persists. What the two rules buy is the removal of the avoidable half — a
+ * stale snapshot, and a failure disguised as a verdict. The residual is the
+ * trade-off `assetSwaps` already accepts for the same question, and it narrows
+ * on its own as the refund ages, which is when a receipt is usually read.
  *
  * Returns undefined while the lockup is unspent, and for a swept one: neither
  * has a spender to name, and both are still the funding tx's story alone.

--- a/src/lib/lnSwap.ts
+++ b/src/lib/lnSwap.ts
@@ -28,7 +28,7 @@ import type { NetworkName, RestIndexerProvider } from '@arkade-os/sdk'
 import { RFQ_TERMINAL_STATES, requestLightningSend, type InvoiceFacts, type RfqTransport } from '@arkade-os/swap'
 import { sleep as defaultSleep } from './sleep'
 import { decodeInvoice, invoiceMatchesNetwork, isInvoiceExpired, type DecodedInvoice } from './bolt11'
-import type { Tx } from './types'
+import type { LnSendSpend } from './types'
 
 /** Why an invoice cannot start a swap. A closed set, so callers can branch. */
 export type InvoiceRejection = 'unparseable' | 'wrong_network' | 'expired' | 'zero_amount' | 'no_payment_hash'
@@ -221,33 +221,33 @@ export const requestLnSend = async (
  *
  * The two outcomes are told apart by who got paid, which the wallet can settle
  * on its own: the refund path pays the refund address the client handed the
- * solver — our address — so a refund lands in the wallet's own tx history,
+ * solver — our address — so a refund is a transaction of the wallet's own,
  * while the solver's claim pays the solver and never will. Asking the solver
  * instead would make the receipt depend on a third party still being reachable
  * and still remembering the negotiation.
  *
- * `history` is a thunk rather than a value so it is read AFTER the indexer has
- * reported the spend, never from a copy taken before it. That ordering is what
- * makes the absence of a matching tx mean something: a history read issued
- * after the indexer saw the spend sees at least as much as it did. Deciding
- * off an earlier snapshot could miss a refund and call it a paid invoice,
- * which is the one error here that misreports money.
+ * `paidUs` is asked rather than handed a history so the read happens AFTER the
+ * indexer has reported the spend, never from a copy taken before it. That
+ * ordering is what makes a "no" mean something: a lookup issued after the
+ * indexer saw the spend sees at least as much as it did. It must also FAIL
+ * rather than answer "no" when it cannot tell — a `false` that really means
+ * "could not check" would call a refund a paid invoice, which is the one error
+ * here that misreports money.
  *
  * Returns undefined while the lockup is unspent, and for a swept one: neither
  * has a spender to name, and both are still the funding tx's story alone.
  */
 export const lnSendSpender = async (
   indexer: Pick<RestIndexerProvider, 'getVtxos'>,
-  history: () => Promise<Tx[]>,
+  paidUs: (txid: string) => Promise<boolean>,
   lockup: { fundingTxid: string; swapPkScript: string },
-): Promise<{ spentTxid: string; outcome: 'completed' | 'refunded' } | undefined> => {
+): Promise<LnSendSpend | undefined> => {
   const { vtxos } = await indexer.getVtxos({ scripts: [lockup.swapPkScript] })
   const funded = vtxos.find((v) => v.script === lockup.swapPkScript && v.txid === lockup.fundingTxid)
   if (funded?.virtualStatus.state !== 'spent') return undefined
   const spentTxid = funded.arkTxId ?? funded.spentBy
   if (!spentTxid) return undefined
-  const ours = (await history()).some((tx) => [tx.boardingTxid, tx.redeemTxid, tx.roundTxid].includes(spentTxid))
-  return { spentTxid, outcome: ours ? 'refunded' : 'completed' }
+  return { spentTxid, outcome: (await paidUs(spentTxid)) ? 'refunded' : 'completed' }
 }
 
 /** How a funded Lightning send ended, from the wallet's point of view. */

--- a/src/lib/lnSwap.ts
+++ b/src/lib/lnSwap.ts
@@ -250,7 +250,9 @@ export const lnSendSpender = async (
   lockup: { fundingTxid: string; swapPkScript: string },
 ): Promise<LnSendSpend | undefined> => {
   const { vtxos } = await indexer.getVtxos({ scripts: [lockup.swapPkScript] })
-  const funded = vtxos.find((v) => v.script === lockup.swapPkScript && v.txid === lockup.fundingTxid)
+  // The query is already scoped to the one script, so the funding txid is what
+  // distinguishes this deposit — identical quotes derive the same address.
+  const funded = vtxos.find((v) => v.txid === lockup.fundingTxid)
   if (funded?.virtualStatus.state !== 'spent') return undefined
   const spentTxid = funded.arkTxId ?? funded.spentBy
   if (!spentTxid) return undefined

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,5 @@
 import { AssetDetails } from '@arkade-os/sdk'
-import { Config, Wallet } from '../lib/types'
+import { Config, LnSendActivity, Wallet } from '../lib/types'
 import { consoleError } from './logs'
 import { LocalCardInput, validateCard } from '@arkade-os/solver-discovery'
 
@@ -56,6 +56,7 @@ export const readWalletFromStorage = (): Wallet | undefined => {
 export type TransactionActivityMetadata = {
   assetAction?: 'issued' | 'reissued' | 'burned'
   destination?: string
+  lnSend?: LnSendActivity
   networkFee?: number
   savedAt: number
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -100,10 +100,15 @@ export enum Themes {
 export type LnSendActivity = {
   /** Hex pkScript of the lockup covenant — the indexer's watch key. */
   swapPkScript: string
-  /** The tx that spent the lockup, once it has one. */
-  spentTxid?: string
-  /** What that spend was. Set together with `spentTxid`, never before it. */
-  outcome?: 'completed' | 'refunded'
+  /** The tx that ended the swap, absent until one exists. */
+  spend?: LnSendSpend
+}
+
+/** The tx that spent a lockup, and which of the two spends it was. One type
+ * because neither half means anything alone. */
+export type LnSendSpend = {
+  spentTxid: string
+  outcome: 'completed' | 'refunded'
 }
 
 export type Tx = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,6 +88,24 @@ export enum Themes {
   Light = 'Light',
 }
 
+/**
+ * The lockup leg of a Lightning send, recorded against its funding txid.
+ *
+ * A Lightning send is two transactions, not one: the tx the wallet signs funds
+ * the lockup covenant, and a second tx spends it — the solver's claim once it
+ * has paid the invoice, or the refund back to us when it could not. Only the
+ * first is the wallet's own, so nothing in tx history can name the second; the
+ * covenant's script is what lets the receipt find it.
+ */
+export type LnSendActivity = {
+  /** Hex pkScript of the lockup covenant — the indexer's watch key. */
+  swapPkScript: string
+  /** The tx that spent the lockup, once it has one. */
+  spentTxid?: string
+  /** What that spend was. Set together with `spentTxid`, never before it. */
+  outcome?: 'completed' | 'refunded'
+}
+
 export type Tx = {
   amount: number
   assetAction?: 'issued' | 'reissued' | 'burned'
@@ -96,6 +114,9 @@ export type Tx = {
   createdAt: number
   destination?: string
   explorable: string | undefined
+  /** Present only on a Lightning send: its lockup covenant and that
+   * covenant's spender, which is a second tx the wallet never signed. */
+  lnSend?: LnSendActivity
   networkFee?: number
   preconfirmed: boolean
   redeemTxid: string

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -23,6 +23,7 @@ import { buildTransactionAmountDisplay } from '../../../lib/transactionAmountDis
 import { useAmountDisplayContext } from '../../../hooks/useTransactionAmountDisplay'
 import TransactionAmountSummary from '../../../components/TransactionAmountSummary'
 import { saveTransactionActivityMetadata } from '../../../lib/storage'
+import type { LnSendActivity } from '../../../lib/types'
 
 export default function SendDetails() {
   const displayContext = useAmountDisplayContext()
@@ -111,10 +112,11 @@ export default function SendDetails() {
     }
   }, [sendInfo])
 
-  const handleTxid = (txid: string) => {
+  const handleTxid = (txid: string, lnSend?: LnSendActivity) => {
     if (!txid) return handleError('Error sending transaction')
     saveTransactionActivityMetadata(txid, {
       destination: details?.destination,
+      lnSend,
       networkFee: details?.fees,
     })
     setSendInfo({ ...sendInfo, total: details?.total, txid })
@@ -150,7 +152,10 @@ export default function SendDetails() {
   const payLightning = async (request: LnSendRequest) => {
     const txid = await sendOffChain(svcWallet!, request.fundAmount, request.address)
     if (!txid) return handleError('Error sending transaction')
-    handleTxid(txid)
+    // Record the covenant against the funding txid: it is the only handle on
+    // the spend that ends this swap, and it stops being derivable the moment
+    // this screen unmounts — the quote is gone and nothing else stores it.
+    handleTxid(txid, { swapPkScript: request.swapPkScript })
   }
 
   const handleContinue = async () => {

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -246,21 +246,19 @@ export default function Transaction() {
         date,
         destination: tx.type === 'sent' && !boardingTx && !issuanceTx && !burnTx ? tx.destination : undefined,
         fees,
-        // A Lightning send is two txs, so it gets the same pair of rows an
-        // asset swap does — funding, then the spend that ended it — instead of
-        // a lone "Transaction ID" that would name only the first and say
-        // nothing about whether the invoice was ever paid. Details drops that
-        // row on its own once a funding tx is named.
-        fundedTxid: lnSendReceipt?.fundedTxid,
         isOffchainTx: !tx.boardingTxid && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
         // Details' fallback row only (amountDisplay owns the rendered rows):
         // gross, matching the hook's convention
         satoshis: assetTransfer ? undefined : tx.amount,
-        spendLabel: lnSendReceipt?.spendLabel,
-        spendTxid: lnSendReceipt?.spentTxid,
         status,
         total: assetTransfer ? undefined : tx.amount,
-        txid,
+        // A Lightning send is two txs, so it gets the same pair of rows an
+        // asset swap does — funding, then the spend that ended it — in place
+        // of a lone "Transaction ID" that would name only the first and say
+        // nothing about whether the invoice was ever paid. Dropping txid is
+        // how the swap branch above expresses the same thing.
+        ...lnSendReceipt,
+        txid: lnSendReceipt ? undefined : txid,
         type: boardingTx ? 'Boarding' : undefined,
         wallet,
       }

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -247,9 +247,10 @@ export default function Transaction() {
         destination: tx.type === 'sent' && !boardingTx && !issuanceTx && !burnTx ? tx.destination : undefined,
         fees,
         // A Lightning send is two txs, so it gets the same pair of rows an
-        // asset swap does — funding, then the spend that ended it — in place
-        // of a lone "Transaction ID" that would name only the first and say
-        // nothing about whether the invoice was ever paid.
+        // asset swap does — funding, then the spend that ended it — instead of
+        // a lone "Transaction ID" that would name only the first and say
+        // nothing about whether the invoice was ever paid. Details drops that
+        // row on its own once a funding tx is named.
         fundedTxid: lnSendReceipt?.fundedTxid,
         isOffchainTx: !tx.boardingTxid && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
         // Details' fallback row only (amountDisplay owns the rendered rows):
@@ -259,7 +260,7 @@ export default function Transaction() {
         spendTxid: lnSendReceipt?.spentTxid,
         status,
         total: assetTransfer ? undefined : tx.amount,
-        txid: lnSendReceipt ? undefined : txid,
+        txid,
         type: boardingTx ? 'Boarding' : undefined,
         wallet,
       }

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -34,6 +34,7 @@ import {
 import { AssetSwapsContext } from '../../providers/assetSwaps'
 import { hapticTap } from '../../lib/haptics'
 import { useTransactionAmountDisplay } from '../../hooks/useTransactionAmountDisplay'
+import { useLnSendReceipt } from '../../hooks/useLnSendReceipt'
 import TransactionAmountSummary from '../../components/TransactionAmountSummary'
 import {
   AlertDialog,
@@ -82,6 +83,7 @@ export default function Transaction() {
       : txInfo
   const swapTx = tx?.type === 'swap'
   const amountDisplay = useTransactionAmountDisplay(tx)
+  const lnSendReceipt = useLnSendReceipt(tx)
   const issuanceTx = tx
     ? tx.assetAction === 'issued' || tx.assetAction === 'reissued' || (!tx.assetAction && isIssuance(tx))
     : false
@@ -244,13 +246,20 @@ export default function Transaction() {
         date,
         destination: tx.type === 'sent' && !boardingTx && !issuanceTx && !burnTx ? tx.destination : undefined,
         fees,
+        // A Lightning send is two txs, so it gets the same pair of rows an
+        // asset swap does — funding, then the spend that ended it — in place
+        // of a lone "Transaction ID" that would name only the first and say
+        // nothing about whether the invoice was ever paid.
+        fundedTxid: lnSendReceipt?.fundedTxid,
         isOffchainTx: !tx.boardingTxid && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
         // Details' fallback row only (amountDisplay owns the rendered rows):
         // gross, matching the hook's convention
         satoshis: assetTransfer ? undefined : tx.amount,
+        spendLabel: lnSendReceipt?.spendLabel,
+        spendTxid: lnSendReceipt?.spentTxid,
         status,
         total: assetTransfer ? undefined : tx.amount,
-        txid,
+        txid: lnSendReceipt ? undefined : txid,
         type: boardingTx ? 'Boarding' : undefined,
         wallet,
       }

--- a/src/test/lib/lnSwap.test.ts
+++ b/src/test/lib/lnSwap.test.ts
@@ -75,7 +75,8 @@ describe('lnSendSpender', () => {
   const swapPkScript = `5120${'ab'.repeat(32)}`
   const fundingTxid = 'funding-txid'
   const lockup = { fundingTxid, swapPkScript }
-  const asTx = (redeemTxid: string) => ({ boardingTxid: '', redeemTxid, roundTxid: '' }) as never
+  const theirs = async () => false
+  const ours = async () => true
   const indexer = (vtxos: unknown[]) => ({ getVtxos: async () => ({ vtxos }) }) as never
   const covenant = (state: string, spend?: Record<string, string>) => ({
     script: swapPkScript,
@@ -84,26 +85,22 @@ describe('lnSendSpender', () => {
     ...spend,
   })
 
-  it('reads a spend the wallet never signed as the solver claiming', async () => {
-    // The claim pays the solver, so it cannot appear in our history — that
-    // absence IS the evidence the invoice was paid.
-    const spender = await lnSendSpender(indexer([covenant('spent', { arkTxId: 'claim-txid' })]), async () => [], lockup)
+  it('reads a spend that is none of the wallet’s own txs as the solver claiming', async () => {
+    // The claim pays the solver, so it can never be a tx of ours — that is
+    // the evidence the invoice was paid.
+    const spender = await lnSendSpender(indexer([covenant('spent', { arkTxId: 'claim-txid' })]), theirs, lockup)
     expect(spender).toEqual({ spentTxid: 'claim-txid', outcome: 'completed' })
   })
 
   it('reads a spend that paid us as the refund', async () => {
-    const spender = await lnSendSpender(
-      indexer([covenant('spent', { arkTxId: 'refund-txid' })]),
-      async () => [asTx('refund-txid')],
-      lockup,
-    )
+    const spender = await lnSendSpender(indexer([covenant('spent', { arkTxId: 'refund-txid' })]), ours, lockup)
     expect(spender).toEqual({ spentTxid: 'refund-txid', outcome: 'refunded' })
   })
 
-  it('reads history only after the indexer has reported the spend', async () => {
-    // Ordering is the whole safeguard: a history read issued afterwards sees
-    // at least what the indexer just saw, so a refund cannot be missed and
-    // read as a completed payment. A snapshot taken earlier could be.
+  it('classifies only after the indexer has reported the spend', async () => {
+    // Ordering is the whole safeguard: a lookup issued afterwards sees at
+    // least what the indexer just saw, so a refund cannot be missed and read
+    // as a completed payment. A snapshot taken earlier could be.
     const seen: string[] = []
     await lnSendSpender(
       {
@@ -112,29 +109,37 @@ describe('lnSendSpender', () => {
           return { vtxos: [covenant('spent', { arkTxId: 'refund-txid' })] }
         },
       } as never,
-      async () => {
-        seen.push('history')
-        return [asTx('refund-txid')]
-      },
+      async () => (seen.push('classify'), true),
       lockup,
     )
-    expect(seen).toEqual(['indexer', 'history'])
+    expect(seen).toEqual(['indexer', 'classify'])
   })
 
-  it('does not ask for history at all while there is no spend to classify', async () => {
+  it('propagates a failed classification instead of reading it as "not ours"', async () => {
+    // A lookup that could not answer must not resolve to a completed payment
+    // and get persisted as one; the caller leaves the swap unresolved.
+    const failing = async () => {
+      throw new Error('history unavailable')
+    }
+    await expect(
+      lnSendSpender(indexer([covenant('spent', { arkTxId: 'refund-txid' })]), failing, lockup),
+    ).rejects.toThrow('history unavailable')
+  })
+
+  it('does not classify at all while there is no spend', async () => {
     let asked = false
-    await lnSendSpender(indexer([covenant('settled')]), async () => ((asked = true), []), lockup)
+    await lnSendSpender(indexer([covenant('settled')]), async () => ((asked = true), false), lockup)
     expect(asked).toBe(false)
   })
 
   it('falls back to spentBy when the indexer names no ark txid', async () => {
-    const spender = await lnSendSpender(indexer([covenant('spent', { spentBy: 'claim-txid' })]), async () => [], lockup)
+    const spender = await lnSendSpender(indexer([covenant('spent', { spentBy: 'claim-txid' })]), theirs, lockup)
     expect(spender?.spentTxid).toBe('claim-txid')
   })
 
   it('has no answer while the lockup is unspent, or once it is swept', async () => {
     for (const state of ['settled', 'preconfirmed', 'swept']) {
-      expect(await lnSendSpender(indexer([covenant(state)]), async () => [], lockup)).toBeUndefined()
+      expect(await lnSendSpender(indexer([covenant(state)]), theirs, lockup)).toBeUndefined()
     }
   })
 
@@ -142,7 +147,7 @@ describe('lnSendSpender', () => {
     // Identical quotes derive the same address, so the script alone does not
     // identify this swap's deposit — only the funding txid does.
     const other = { ...covenant('spent', { arkTxId: 'claim-txid' }), txid: 'another-funding-txid' }
-    expect(await lnSendSpender(indexer([other]), async () => [], lockup)).toBeUndefined()
+    expect(await lnSendSpender(indexer([other]), theirs, lockup)).toBeUndefined()
   })
 })
 

--- a/src/test/lib/lnSwap.test.ts
+++ b/src/test/lib/lnSwap.test.ts
@@ -1,6 +1,6 @@
 import { RFQ_TERMINAL_STATES } from '@arkade-os/swap'
 import { describe, it, expect } from 'vitest'
-import { InvoiceRejected, awaitLnSendOutcome, isRfqTerminal, toInvoiceFacts } from '../../lib/lnSwap'
+import { InvoiceRejected, awaitLnSendOutcome, isRfqTerminal, lnSendSpender, toInvoiceFacts } from '../../lib/lnSwap'
 import fixtures from '../fixtures.json'
 
 describe('lnSwap', () => {
@@ -68,6 +68,81 @@ describe('lnSwap', () => {
       for (const state of RFQ_TERMINAL_STATES) expect(isRfqTerminal(state)).toBe(true)
       for (const state of ['quoted', 'funded', 'paying', '']) expect(isRfqTerminal(state)).toBe(false)
     })
+  })
+})
+
+describe('lnSendSpender', () => {
+  const swapPkScript = `5120${'ab'.repeat(32)}`
+  const fundingTxid = 'funding-txid'
+  const lockup = { fundingTxid, swapPkScript }
+  const asTx = (redeemTxid: string) => ({ boardingTxid: '', redeemTxid, roundTxid: '' }) as never
+  const indexer = (vtxos: unknown[]) => ({ getVtxos: async () => ({ vtxos }) }) as never
+  const covenant = (state: string, spend?: Record<string, string>) => ({
+    script: swapPkScript,
+    txid: fundingTxid,
+    virtualStatus: { state },
+    ...spend,
+  })
+
+  it('reads a spend the wallet never signed as the solver claiming', async () => {
+    // The claim pays the solver, so it cannot appear in our history — that
+    // absence IS the evidence the invoice was paid.
+    const spender = await lnSendSpender(indexer([covenant('spent', { arkTxId: 'claim-txid' })]), async () => [], lockup)
+    expect(spender).toEqual({ spentTxid: 'claim-txid', outcome: 'completed' })
+  })
+
+  it('reads a spend that paid us as the refund', async () => {
+    const spender = await lnSendSpender(
+      indexer([covenant('spent', { arkTxId: 'refund-txid' })]),
+      async () => [asTx('refund-txid')],
+      lockup,
+    )
+    expect(spender).toEqual({ spentTxid: 'refund-txid', outcome: 'refunded' })
+  })
+
+  it('reads history only after the indexer has reported the spend', async () => {
+    // Ordering is the whole safeguard: a history read issued afterwards sees
+    // at least what the indexer just saw, so a refund cannot be missed and
+    // read as a completed payment. A snapshot taken earlier could be.
+    const seen: string[] = []
+    await lnSendSpender(
+      {
+        getVtxos: async () => {
+          seen.push('indexer')
+          return { vtxos: [covenant('spent', { arkTxId: 'refund-txid' })] }
+        },
+      } as never,
+      async () => {
+        seen.push('history')
+        return [asTx('refund-txid')]
+      },
+      lockup,
+    )
+    expect(seen).toEqual(['indexer', 'history'])
+  })
+
+  it('does not ask for history at all while there is no spend to classify', async () => {
+    let asked = false
+    await lnSendSpender(indexer([covenant('settled')]), async () => ((asked = true), []), lockup)
+    expect(asked).toBe(false)
+  })
+
+  it('falls back to spentBy when the indexer names no ark txid', async () => {
+    const spender = await lnSendSpender(indexer([covenant('spent', { spentBy: 'claim-txid' })]), async () => [], lockup)
+    expect(spender?.spentTxid).toBe('claim-txid')
+  })
+
+  it('has no answer while the lockup is unspent, or once it is swept', async () => {
+    for (const state of ['settled', 'preconfirmed', 'swept']) {
+      expect(await lnSendSpender(indexer([covenant(state)]), async () => [], lockup)).toBeUndefined()
+    }
+  })
+
+  it('ignores a covenant funded by some other transaction', async () => {
+    // Identical quotes derive the same address, so the script alone does not
+    // identify this swap's deposit — only the funding txid does.
+    const other = { ...covenant('spent', { arkTxId: 'claim-txid' }), txid: 'another-funding-txid' }
+    expect(await lnSendSpender(indexer([other]), async () => [], lockup)).toBeUndefined()
   })
 })
 

--- a/src/test/lib/lnSwap.test.ts
+++ b/src/test/lib/lnSwap.test.ts
@@ -126,12 +126,6 @@ describe('lnSendSpender', () => {
     ).rejects.toThrow('history unavailable')
   })
 
-  it('does not classify at all while there is no spend', async () => {
-    let asked = false
-    await lnSendSpender(indexer([covenant('settled')]), async () => ((asked = true), false), lockup)
-    expect(asked).toBe(false)
-  })
-
   it('falls back to spentBy when the indexer names no ark txid', async () => {
     const spender = await lnSendSpender(indexer([covenant('spent', { spentBy: 'claim-txid' })]), theirs, lockup)
     expect(spender?.spentTxid).toBe('claim-txid')

--- a/src/test/screens/wallet/transaction-ln-send.test.tsx
+++ b/src/test/screens/wallet/transaction-ln-send.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Transaction from '../../../screens/Wallet/Transaction'
+import { AspContext } from '../../../providers/asp'
+import { FlowContext } from '../../../providers/flow'
+import { LimitsContext } from '../../../providers/limits'
+import { NavigationContext } from '../../../providers/navigation'
+import { WalletContext } from '../../../providers/wallet'
+import { readTransactionActivityMetadata } from '../../../lib/storage'
+import type { LnSendActivity, Tx } from '../../../lib/types'
+import {
+  mockAspContextValue,
+  mockFlowContextValue,
+  mockLimitsContextValue,
+  mockNavigationContextValue,
+  mockTxInfo,
+  mockWalletContextValue,
+} from '../mocks'
+
+const getVtxos = vi.hoisted(() => vi.fn())
+const getTxHistory = vi.hoisted(() => vi.fn())
+
+vi.mock('@arkade-os/sdk', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@arkade-os/sdk')>()),
+  RestIndexerProvider: class {
+    getVtxos = getVtxos
+  },
+}))
+
+vi.mock('../../../lib/asp', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/asp')>()),
+  getTxHistory,
+  getInputsToSettle: async () => ({ inputs: [] }),
+}))
+
+const swapPkScript = `5120${'ab'.repeat(32)}`
+const fundingTxid = 'funding-txid'
+
+const sentTx: Tx = {
+  ...mockTxInfo,
+  amount: 5000,
+  boardingTxid: '',
+  destination: 'lnbc5u1p482...',
+  explorable: undefined,
+  redeemTxid: fundingTxid,
+  roundTxid: '',
+  type: 'sent',
+}
+
+const lnSendTx = (lnSend: LnSendActivity): Tx => ({ ...sentTx, lnSend })
+
+const renderReceipt = (tx: Tx, wallet = mockWalletContextValue) =>
+  render(
+    <NavigationContext.Provider value={mockNavigationContextValue}>
+      <AspContext.Provider value={mockAspContextValue}>
+        <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo: tx }}>
+          <WalletContext.Provider value={{ ...wallet, txs: [tx] }}>
+            <LimitsContext.Provider value={mockLimitsContextValue}>
+              <Transaction />
+            </LimitsContext.Provider>
+          </WalletContext.Provider>
+        </FlowContext.Provider>
+      </AspContext.Provider>
+    </NavigationContext.Provider>,
+  )
+
+/** A funded covenant the indexer reports as spent by `spentTxid`. */
+const spentCovenant = (spentTxid: string) => ({
+  vtxos: [{ script: swapPkScript, txid: fundingTxid, virtualStatus: { state: 'spent' }, arkTxId: spentTxid }],
+})
+
+describe('Lightning send receipt', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    getVtxos.mockReset()
+    getTxHistory.mockReset().mockResolvedValue([])
+  })
+
+  afterEach(() => vi.clearAllMocks())
+
+  it('names the funding tx rather than showing one anonymous transaction id', async () => {
+    // A wallet with no service worker cannot resolve the second leg, which is
+    // also what an in-flight send looks like: the funding row stands alone.
+    renderReceipt(lnSendTx({ swapPkScript }))
+
+    expect(await screen.findByText('Funded')).toBeInTheDocument()
+    expect(screen.getByTestId('Funded')).toHaveTextContent(fundingTxid)
+    expect(screen.queryByText('Transaction ID')).not.toBeInTheDocument()
+    // Nothing has spent the covenant, so claiming either outcome would be a lie.
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument()
+    expect(screen.queryByText('Refunded')).not.toBeInTheDocument()
+  })
+
+  it('shows both legs once the solver has claimed', async () => {
+    renderReceipt(lnSendTx({ swapPkScript, spentTxid: 'claim-txid', outcome: 'completed' }))
+
+    expect(await screen.findByText('Funded')).toBeInTheDocument()
+    expect(screen.getByTestId('Funded')).toHaveTextContent(fundingTxid)
+    expect(screen.getByTestId('Completed')).toHaveTextContent('claim-txid')
+  })
+
+  it('calls the second leg a refund, not a cancellation, when the funds came back', async () => {
+    // Nobody cancelled anything: the solver could not pay the invoice and the
+    // covenant returned the money on its own.
+    renderReceipt(lnSendTx({ swapPkScript, spentTxid: 'refund-txid', outcome: 'refunded' }))
+
+    expect(await screen.findByTestId('Refunded')).toHaveTextContent('refund-txid')
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cancelled')).not.toBeInTheDocument()
+  })
+
+  it('resolves the second leg on open and remembers it', async () => {
+    getVtxos.mockResolvedValue(spentCovenant('claim-txid'))
+    renderReceipt(lnSendTx({ swapPkScript }), { ...mockWalletContextValue, svcWallet: {} as never })
+
+    expect(await screen.findByTestId('Completed')).toHaveTextContent('claim-txid')
+    expect(getVtxos).toHaveBeenCalledWith({ scripts: [swapPkScript] })
+    // Persisted, so a later visit reads the answer instead of asking again —
+    // and still has it once the covenant is swept and the indexer forgets.
+    await waitFor(() =>
+      expect(readTransactionActivityMetadata([fundingTxid])?.lnSend).toEqual({
+        swapPkScript,
+        spentTxid: 'claim-txid',
+        outcome: 'completed',
+      }),
+    )
+  })
+
+  it('reads a spend that landed back in our own history as the refund', async () => {
+    getVtxos.mockResolvedValue(spentCovenant('refund-txid'))
+    getTxHistory.mockResolvedValue([{ boardingTxid: '', redeemTxid: 'refund-txid', roundTxid: '' }])
+    renderReceipt(lnSendTx({ swapPkScript }), { ...mockWalletContextValue, svcWallet: {} as never })
+
+    expect(await screen.findByTestId('Refunded')).toHaveTextContent('refund-txid')
+  })
+
+  it('leaves the funding row alone when the lookup fails', async () => {
+    getVtxos.mockRejectedValue(new Error('indexer unreachable'))
+    renderReceipt(lnSendTx({ swapPkScript }), { ...mockWalletContextValue, svcWallet: {} as never })
+
+    expect(await screen.findByTestId('Funded')).toHaveTextContent(fundingTxid)
+    await waitFor(() => expect(getVtxos).toHaveBeenCalled())
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument()
+    // A failed lookup must not be mistaken for an answer worth keeping.
+    expect(readTransactionActivityMetadata([fundingTxid])).toBeUndefined()
+  })
+
+  it('leaves an ordinary send showing its transaction id', async () => {
+    renderReceipt(sentTx)
+
+    expect(await screen.findByTestId('Transaction ID')).toHaveTextContent(fundingTxid)
+    expect(screen.queryByText('Funded')).not.toBeInTheDocument()
+    expect(getVtxos).not.toHaveBeenCalled()
+  })
+})

--- a/src/test/screens/wallet/transaction-ln-send.test.tsx
+++ b/src/test/screens/wallet/transaction-ln-send.test.tsx
@@ -13,6 +13,7 @@ import {
   mockFlowContextValue,
   mockLimitsContextValue,
   mockNavigationContextValue,
+  mockSvcWallet,
   mockTxInfo,
   mockWalletContextValue,
 } from '../mocks'
@@ -25,11 +26,6 @@ vi.mock('@arkade-os/sdk', async (importOriginal) => ({
   RestIndexerProvider: class {
     getVtxos = getVtxos
   },
-}))
-
-vi.mock('../../../lib/asp', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../../lib/asp')>()),
-  getInputsToSettle: async () => ({ inputs: [] }),
 }))
 
 const swapPkScript = `5120${'ab'.repeat(32)}`
@@ -48,21 +44,14 @@ const sentTx: Tx = {
 
 const lnSendTx = (lnSend: LnSendActivity): Tx => ({ ...sentTx, lnSend })
 
-const withSvcWallet = { ...mockWalletContextValue, svcWallet: { getTransactionHistory } as never }
-
-/** A wallet that can answer "is this one of my transactions?" */
-const walletWith = (ownTxids: string[] = []) => {
-  getTransactionHistory.mockResolvedValue(
-    ownTxids.map((arkTxid) => ({ key: { arkTxid, boardingTxid: '', commitmentTxid: '' } })),
-  )
-  return withSvcWallet
+/** A wallet whose history read is under the test's control. */
+const withSvcWallet = {
+  ...mockWalletContextValue,
+  svcWallet: { ...mockSvcWallet, getTransactionHistory } as never,
 }
 
-/** A wallet whose history read fails, so ownership cannot be determined. */
-const walletThatCannotAnswer = () => {
-  getTransactionHistory.mockRejectedValue(new Error('history unavailable'))
-  return withSvcWallet
-}
+/** One of the wallet's own transactions, as the raw SDK reports it. */
+const ownTx = (arkTxid: string) => ({ key: { arkTxid, boardingTxid: '', commitmentTxid: '' } })
 
 const renderReceipt = (tx: Tx, wallet = mockWalletContextValue) =>
   render(
@@ -122,7 +111,7 @@ describe('Lightning send receipt', () => {
 
   it('resolves the second leg on open and remembers it', async () => {
     getVtxos.mockResolvedValue(spentCovenant('claim-txid'))
-    renderReceipt(lnSendTx({ swapPkScript }), walletWith())
+    renderReceipt(lnSendTx({ swapPkScript }), withSvcWallet)
 
     expect(await screen.findByTestId('Completed')).toHaveTextContent('claim-txid')
     expect(getVtxos).toHaveBeenCalledWith({ scripts: [swapPkScript] })
@@ -140,7 +129,7 @@ describe('Lightning send receipt', () => {
     saveTransactionActivityMetadata(fundingTxid, {
       lnSend: { swapPkScript, spend: { spentTxid: 'claim-txid', outcome: 'completed' } },
     })
-    renderReceipt(lnSendTx({ swapPkScript }), walletWith())
+    renderReceipt(lnSendTx({ swapPkScript }), withSvcWallet)
 
     expect(await screen.findByTestId('Completed')).toHaveTextContent('claim-txid')
     expect(getVtxos).not.toHaveBeenCalled()
@@ -148,7 +137,8 @@ describe('Lightning send receipt', () => {
 
   it('reads a spend that is one of our own transactions as the refund', async () => {
     getVtxos.mockResolvedValue(spentCovenant('refund-txid'))
-    renderReceipt(lnSendTx({ swapPkScript }), walletWith(['refund-txid']))
+    getTransactionHistory.mockResolvedValue([ownTx('refund-txid')])
+    renderReceipt(lnSendTx({ swapPkScript }), withSvcWallet)
 
     expect(await screen.findByTestId('Refunded')).toHaveTextContent('refund-txid')
   })
@@ -157,7 +147,8 @@ describe('Lightning send receipt', () => {
     // A history read that failed must not read as "not ours" and be persisted
     // as a completed payment — that would report returned money as paid.
     getVtxos.mockResolvedValue(spentCovenant('refund-txid'))
-    renderReceipt(lnSendTx({ swapPkScript }), walletThatCannotAnswer())
+    getTransactionHistory.mockRejectedValue(new Error('history unavailable'))
+    renderReceipt(lnSendTx({ swapPkScript }), withSvcWallet)
 
     expect(await screen.findByTestId('Funded')).toHaveTextContent(fundingTxid)
     await waitFor(() => expect(getTransactionHistory).toHaveBeenCalled())
@@ -167,7 +158,7 @@ describe('Lightning send receipt', () => {
 
   it('leaves the funding row alone when the indexer lookup fails', async () => {
     getVtxos.mockRejectedValue(new Error('indexer unreachable'))
-    renderReceipt(lnSendTx({ swapPkScript }), walletWith())
+    renderReceipt(lnSendTx({ swapPkScript }), withSvcWallet)
 
     expect(await screen.findByTestId('Funded')).toHaveTextContent(fundingTxid)
     await waitFor(() => expect(getVtxos).toHaveBeenCalled())

--- a/src/test/screens/wallet/transaction-ln-send.test.tsx
+++ b/src/test/screens/wallet/transaction-ln-send.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Transaction from '../../../screens/Wallet/Transaction'
 import { AspContext } from '../../../providers/asp'
 import { FlowContext } from '../../../providers/flow'
 import { LimitsContext } from '../../../providers/limits'
 import { NavigationContext } from '../../../providers/navigation'
 import { WalletContext } from '../../../providers/wallet'
-import { readTransactionActivityMetadata } from '../../../lib/storage'
+import { readTransactionActivityMetadata, saveTransactionActivityMetadata } from '../../../lib/storage'
 import type { LnSendActivity, Tx } from '../../../lib/types'
 import {
   mockAspContextValue,
@@ -18,7 +18,7 @@ import {
 } from '../mocks'
 
 const getVtxos = vi.hoisted(() => vi.fn())
-const getTxHistory = vi.hoisted(() => vi.fn())
+const getTransactionHistory = vi.hoisted(() => vi.fn())
 
 vi.mock('@arkade-os/sdk', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@arkade-os/sdk')>()),
@@ -29,7 +29,6 @@ vi.mock('@arkade-os/sdk', async (importOriginal) => ({
 
 vi.mock('../../../lib/asp', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../lib/asp')>()),
-  getTxHistory,
   getInputsToSettle: async () => ({ inputs: [] }),
 }))
 
@@ -48,6 +47,22 @@ const sentTx: Tx = {
 }
 
 const lnSendTx = (lnSend: LnSendActivity): Tx => ({ ...sentTx, lnSend })
+
+const withSvcWallet = { ...mockWalletContextValue, svcWallet: { getTransactionHistory } as never }
+
+/** A wallet that can answer "is this one of my transactions?" */
+const walletWith = (ownTxids: string[] = []) => {
+  getTransactionHistory.mockResolvedValue(
+    ownTxids.map((arkTxid) => ({ key: { arkTxid, boardingTxid: '', commitmentTxid: '' } })),
+  )
+  return withSvcWallet
+}
+
+/** A wallet whose history read fails, so ownership cannot be determined. */
+const walletThatCannotAnswer = () => {
+  getTransactionHistory.mockRejectedValue(new Error('history unavailable'))
+  return withSvcWallet
+}
 
 const renderReceipt = (tx: Tx, wallet = mockWalletContextValue) =>
   render(
@@ -73,18 +88,15 @@ describe('Lightning send receipt', () => {
   beforeEach(() => {
     localStorage.clear()
     getVtxos.mockReset()
-    getTxHistory.mockReset().mockResolvedValue([])
+    getTransactionHistory.mockReset().mockResolvedValue([])
   })
-
-  afterEach(() => vi.clearAllMocks())
 
   it('names the funding tx rather than showing one anonymous transaction id', async () => {
     // A wallet with no service worker cannot resolve the second leg, which is
     // also what an in-flight send looks like: the funding row stands alone.
     renderReceipt(lnSendTx({ swapPkScript }))
 
-    expect(await screen.findByText('Funded')).toBeInTheDocument()
-    expect(screen.getByTestId('Funded')).toHaveTextContent(fundingTxid)
+    expect(await screen.findByTestId('Funded')).toHaveTextContent(fundingTxid)
     expect(screen.queryByText('Transaction ID')).not.toBeInTheDocument()
     // Nothing has spent the covenant, so claiming either outcome would be a lie.
     expect(screen.queryByText('Completed')).not.toBeInTheDocument()
@@ -92,17 +104,16 @@ describe('Lightning send receipt', () => {
   })
 
   it('shows both legs once the solver has claimed', async () => {
-    renderReceipt(lnSendTx({ swapPkScript, spentTxid: 'claim-txid', outcome: 'completed' }))
+    renderReceipt(lnSendTx({ swapPkScript, spend: { spentTxid: 'claim-txid', outcome: 'completed' } }))
 
-    expect(await screen.findByText('Funded')).toBeInTheDocument()
-    expect(screen.getByTestId('Funded')).toHaveTextContent(fundingTxid)
+    expect(await screen.findByTestId('Funded')).toHaveTextContent(fundingTxid)
     expect(screen.getByTestId('Completed')).toHaveTextContent('claim-txid')
   })
 
   it('calls the second leg a refund, not a cancellation, when the funds came back', async () => {
     // Nobody cancelled anything: the solver could not pay the invoice and the
     // covenant returned the money on its own.
-    renderReceipt(lnSendTx({ swapPkScript, spentTxid: 'refund-txid', outcome: 'refunded' }))
+    renderReceipt(lnSendTx({ swapPkScript, spend: { spentTxid: 'refund-txid', outcome: 'refunded' } }))
 
     expect(await screen.findByTestId('Refunded')).toHaveTextContent('refund-txid')
     expect(screen.queryByText('Completed')).not.toBeInTheDocument()
@@ -111,32 +122,52 @@ describe('Lightning send receipt', () => {
 
   it('resolves the second leg on open and remembers it', async () => {
     getVtxos.mockResolvedValue(spentCovenant('claim-txid'))
-    renderReceipt(lnSendTx({ swapPkScript }), { ...mockWalletContextValue, svcWallet: {} as never })
+    renderReceipt(lnSendTx({ swapPkScript }), walletWith())
 
     expect(await screen.findByTestId('Completed')).toHaveTextContent('claim-txid')
     expect(getVtxos).toHaveBeenCalledWith({ scripts: [swapPkScript] })
-    // Persisted, so a later visit reads the answer instead of asking again —
-    // and still has it once the covenant is swept and the indexer forgets.
-    await waitFor(() =>
-      expect(readTransactionActivityMetadata([fundingTxid])?.lnSend).toEqual({
-        swapPkScript,
-        spentTxid: 'claim-txid',
-        outcome: 'completed',
-      }),
-    )
+    expect(readTransactionActivityMetadata([fundingTxid])?.lnSend).toEqual({
+      swapPkScript,
+      spend: { spentTxid: 'claim-txid', outcome: 'completed' },
+    })
   })
 
-  it('reads a spend that landed back in our own history as the refund', async () => {
+  it('reads the remembered answer instead of asking again', async () => {
+    // The tx itself only carries the answer after a wallet reload has rebuilt
+    // history from storage, so without this a revisit re-pays for the lookup —
+    // and a swept covenant, which the indexer can no longer answer for, would
+    // lose its outcome entirely.
+    saveTransactionActivityMetadata(fundingTxid, {
+      lnSend: { swapPkScript, spend: { spentTxid: 'claim-txid', outcome: 'completed' } },
+    })
+    renderReceipt(lnSendTx({ swapPkScript }), walletWith())
+
+    expect(await screen.findByTestId('Completed')).toHaveTextContent('claim-txid')
+    expect(getVtxos).not.toHaveBeenCalled()
+  })
+
+  it('reads a spend that is one of our own transactions as the refund', async () => {
     getVtxos.mockResolvedValue(spentCovenant('refund-txid'))
-    getTxHistory.mockResolvedValue([{ boardingTxid: '', redeemTxid: 'refund-txid', roundTxid: '' }])
-    renderReceipt(lnSendTx({ swapPkScript }), { ...mockWalletContextValue, svcWallet: {} as never })
+    renderReceipt(lnSendTx({ swapPkScript }), walletWith(['refund-txid']))
 
     expect(await screen.findByTestId('Refunded')).toHaveTextContent('refund-txid')
   })
 
-  it('leaves the funding row alone when the lookup fails', async () => {
+  it('leaves the swap unresolved when the wallet cannot say whose the spend was', async () => {
+    // A history read that failed must not read as "not ours" and be persisted
+    // as a completed payment — that would report returned money as paid.
+    getVtxos.mockResolvedValue(spentCovenant('refund-txid'))
+    renderReceipt(lnSendTx({ swapPkScript }), walletThatCannotAnswer())
+
+    expect(await screen.findByTestId('Funded')).toHaveTextContent(fundingTxid)
+    await waitFor(() => expect(getTransactionHistory).toHaveBeenCalled())
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument()
+    expect(readTransactionActivityMetadata([fundingTxid])).toBeUndefined()
+  })
+
+  it('leaves the funding row alone when the indexer lookup fails', async () => {
     getVtxos.mockRejectedValue(new Error('indexer unreachable'))
-    renderReceipt(lnSendTx({ swapPkScript }), { ...mockWalletContextValue, svcWallet: {} as never })
+    renderReceipt(lnSendTx({ swapPkScript }), walletWith())
 
     expect(await screen.findByTestId('Funded')).toHaveTextContent(fundingTxid)
     await waitFor(() => expect(getVtxos).toHaveBeenCalled())


### PR DESCRIPTION
Stacked on #876 — base is that PR's head.

The Lightning-send receipt showed a single **Transaction ID**. It now shows the pair an asset swap shows:

- **Funded** — the tx that funded the lockup covenant
- **Completed** / **Refunded** — the tx that spent it

## Why this needed more than a UI edit

A Lightning send is two transactions and the wallet only signs the first. The second — the solver's claim after it pays the invoice, or the covenant refund — is not a transaction of ours unless it *is* the refund, so there was nothing to render. Three pieces:

1. `requestLnSend` carries the covenant's `swapPkScript` through. The swap client already returned it (*"for watching the lockup and its spend"*); `lnSwap.ts` was dropping it.
2. `Send/Details.tsx` records it against the funding txid at funding time — the only moment it exists, since the quote is gone once that screen unmounts.
3. `useLnSendReceipt` resolves the spender from the indexer when the receipt is opened, persists the answer, and seeds from that store on later visits — which also matters because a swept covenant stops being answerable at all.

## Telling a claim from a refund

The refund path pays the refund address the client handed the solver, so a refund is a transaction of the wallet's own and a claim never can be.

The failure mode that matters is reporting returned money as a paid invoice. Two rules narrow it:

- **Ordering.** The ownership check runs *after* the indexer reports the spend, never from a copy taken before it.
- **Failing loudly.** The check must fail rather than answer "not ours" when it cannot tell. This is why it uses the raw SDK history read rather than `getTxHistory`, which reports failure as an empty history — that would have read as "no refund of ours" and persisted a refunded swap as completed. A lookup that cannot answer leaves the swap unresolved and retries on the next visit.

Both are pinned by tests.

**What that still does not buy**, stated plainly: the wallet's own view and the indexer are separate stores, so asking second gives sequencing, not currency. A wallet a sync cycle behind can miss a refund the indexer already knows about, and that answer persists. The two rules remove the avoidable half — a stale snapshot, and a failure disguised as a verdict — and the residual is the same trade-off `assetSwaps` already accepts for the same question. It also narrows as the refund ages, which is when a receipt is usually read.

Asking the solver instead was the alternative, and was rejected: `RfqStatus.profile` is `Record<string, unknown>` with no guaranteed claim txid, and it would make the receipt depend on a third party still being reachable and still remembering the negotiation.

## Two deliberate deviations

- **"Refunded", not the asset swap's "Cancelled"** — nobody cancelled anything, and no cancel action exists on this path.
- **The Status row still reads "Settled"**, referring to the Ark funding tx. Next to this branch's "sent means paid" stance that is arguably worth revisiting, but changing status semantics is beyond showing the two txids, so it is left alone here.

## Known scope limits

Lightning sends are tracked on `TransactionActivityMetadata` and resolved lazily on the receipt, rather than getting the dedicated store + monitor + chain-restore that asset swaps have. That is deliberate for a two-row receipt change with one consumer and no user action to perform, but it means: no activity-list merge of the send/refund pair, no restore after wallet recovery, and the covenant handle lives in a 250-entry LRU. When the M3 receive leg lands, that is the thing to build rather than extend.

## Verification

629 tests across 75 files, plus `tsc --noEmit`, eslint and prettier clean. `vite build` is covered by the Cloudflare Pages checks on this PR.

Note that `ci.yml` and `playwright.yml` are filtered to PRs targeting `master`/`next`, so neither runs here — the above was verified locally.

Reproducing locally needs one workaround: `pnpm install` cannot fetch `@arkade-os/swap` from a restricted network (`codeload.github.com` 403s), so it was built from ts-sdk at the pinned commit and placed in `node_modules` by hand. None of that scaffolding is committed.