### PR TITLE
Run unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,14 @@ jobs:
     - name: Run linter
       run: pnpm lint
 
+    # src/_gitCommit.ts is gitignored and generated; the unit tests import it
+    # transitively, so it must exist before vitest runs (pnpm build does this
+    # itself, but the tests run first).
+    - name: Generate git commit info
+      run: pnpm git-info
+
+    - name: Run unit tests
+      run: pnpm test:unit
+
     - name: Run build
       run: pnpm build 


### PR DESCRIPTION
## The gap

The CI job is named `test`, but its steps are `pnpm install`, `format:check`, `lint`, `build`. Nothing ever invokes vitest. The job has been reporting green without executing a single test, which is worse than having no job at all — the name says tests ran, so people trust it.

`package.json` already has the right script: `test:unit` (`vitest run --exclude '**/e2e/**'`). `test:e2e` is deliberately left out — it needs browsers and a regtest stack and already has its own workflow in `playwright.yml`.

## The change

Adds `pnpm test:unit` after the linter and before the build, so the cheap checks still fail fast.

It also hoists out a `pnpm git-info` step, which is the non-obvious part. `src/_gitCommit.ts` is gitignored and generated. `LoadingLogo.tsx` and `Settings/About.tsx` import it, and enough of the tree pulls those in that **34 of the 72 test files fail to collect** without it, all with `Failed to resolve import "../_gitCommit"`. `pnpm build` generates it via `pnpm git-info`, but the tests now run before the build, so the generation has to happen explicitly first.

This is the one real trap in the change: dropping `pnpm test:unit` in after `lint` without the `git-info` step turns the job red immediately on a fresh checkout. Confirmed by deleting `src/_gitCommit.ts` and running the sequence both ways.

## What the tests actually do on CI

10 runs of this branch on `ubuntu-latest` — 1 from the PR trigger, 9 via `workflow_dispatch` — all green, all identical:

```
Test Files  72 passed (72)
     Tests  580 passed | 3 skipped (583)
```

## Follow-up worth filing separately: two timing-sensitive tests

Not blocking, and not touched here, but worth recording. The same suite is unreliable on a slower machine. On Windows locally it went red in 3 of 6 runs on `master` at `142e778d`, with no code change:

1. **`src/test/lib/format.test.ts > prettyAgo`** — captures `const now = Date.now()` once in the `describe` body, then asserts `prettyAgo(now - 30 * 1000)` equals `'30s ago'` inside the `it`. If more than a second passes between collection and execution it reads `'31s ago'`. Locally, collect alone took ~250s versus ~42s on the runner, so the gap is wide enough to trip it.
2. **`src/test/screens/wallet/swap.test.tsx > swaps in asset units without currency prices in either direction`** — hits the default 5000ms timeout. The file passes 39/39 run on its own; it only fails inside the full parallel suite.

Neither reproduced on the runner in 10 attempts, so this PR is safe to merge as-is. But both are latent — a slow or noisy runner can hit them, and `prettyAgo` in particular is a genuine landmine (the fix is to compute `now` inside each test, or use fake timers). Better to know about them now that the tests actually run than to discover them as a mystery red build later.

## Separate issue: feature branches get no CI at all

Not changed here, since it is a repo-policy call rather than a bug.

The triggers are `push`/`pull_request` on `branches: [master, next]` only. Any PR targeting a feature branch — `feat/arkade-swap` being the live example — gets zero GitHub Actions CI. Those PRs show only Cloudflare Pages and CodeRabbit, which reads as green even though nothing was built, linted or tested. Work there has had to be manually dispatched via `workflow_dispatch`, or it shipped unverified.

Two ways to close it, both fine:

- Add the long-lived feature branch(es) to the `pull_request` trigger list, so PRs into them run the same job.
- Leave the triggers alone and make "dispatch CI manually on this branch" an explicit review-checklist item.

Worth an explicit decision either way, because the current state is silent.

## Verification

- `pnpm install --frozen-lockfile` then `pnpm test:unit` on `origin/master` @ `142e778d` in a clean worktree, to get a baseline before changing anything: 72/72 files, 580 passed, 3 skipped.
- Reproduced the exact step sequence this PR adds — `lint`, `git-info`, `test:unit` — from a fresh checkout with `src/_gitCommit.ts` deleted, to confirm the generation step is both necessary and sufficient. `test:unit` needs `git-info` only; it does not need `build:worker` or `vite build`.
- 10 green runs on `ubuntu-latest`, as above.

No test was skipped, disabled, or filtered to get here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Unit tests now run as part of the continuous integration workflow before builds.
* **Chores**
  * Build metadata is generated automatically during continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->