### PR TITLE
show toasts on notification settings

### DIFF
--- a/src/screens/Settings/Notifications.tsx
+++ b/src/screens/Settings/Notifications.tsx
@@ -20,7 +20,7 @@ export default function Notifications() {
       return
     }
     if (!config.notifications) {
-      requestPermission().then(async (notifications) => {
+      requestPermission().then((notifications) => {
         if (notifications) sendTestNotification()
         else toast('Notifications permission denied')
         backupAndUpdateConfig({ ...config, notifications })

--- a/src/screens/Settings/Notifications.tsx
+++ b/src/screens/Settings/Notifications.tsx
@@ -15,19 +15,21 @@ export default function Notifications() {
   const { toast } = useToast()
 
   const handleChange = async () => {
+    if (config.notifications) {
+      backupAndUpdateConfig({ ...config, notifications: false })
+      return
+    }
+
     if (!notificationApiSupport) {
       toast('Notifications API not supported')
       return
     }
-    if (!config.notifications) {
-      requestPermission().then((notifications) => {
-        if (notifications) sendTestNotification()
-        else toast('Notifications permission denied')
-        backupAndUpdateConfig({ ...config, notifications })
-      })
-    } else {
-      backupAndUpdateConfig({ ...config, notifications: false })
-    }
+
+    requestPermission().then((notifications) => {
+      if (notifications) sendTestNotification()
+      else toast('Notifications permission denied')
+      backupAndUpdateConfig({ ...config, notifications })
+    })
   }
 
   const subText = notificationApiSupport

--- a/src/screens/Settings/Notifications.tsx
+++ b/src/screens/Settings/Notifications.tsx
@@ -6,16 +6,23 @@ import { notificationApiSupport, requestPermission, sendTestNotification } from 
 import Header from './Header'
 import Content from '../../components/Content'
 import Toggle from '../../components/Toggle'
+import { useToast } from '../../components/Toast'
 
 export default function Notifications() {
   const { backupAndUpdateConfig } = useContext(BackupContext)
   const { config } = useContext(ConfigContext)
 
+  const { toast } = useToast()
+
   const handleChange = async () => {
-    if (!notificationApiSupport) return
+    if (!notificationApiSupport) {
+      toast('Notifications API not supported')
+      return
+    }
     if (!config.notifications) {
       requestPermission().then(async (notifications) => {
         if (notifications) sendTestNotification()
+        else toast('Notifications permission denied')
         backupAndUpdateConfig({ ...config, notifications })
       })
     } else {

--- a/src/test/screens/settings/notifications.test.tsx
+++ b/src/test/screens/settings/notifications.test.tsx
@@ -81,10 +81,11 @@ describe('Notifications screen', () => {
   it('shows a toast when the browser does not support notifications', () => {
     const backupAndUpdateConfig = vi.fn()
     notificationsMock.notificationApiSupport = false
+    const mockConfig = { ...mockConfigContextValue, config: { ...mockConfigContextValue.config, notifications: false } }
 
     render(
       <BackupContext.Provider value={{ backupAndUpdateConfig } as any}>
-        <ConfigContext.Provider value={mockConfigContextValue as any}>
+        <ConfigContext.Provider value={mockConfig as any}>
           <Notifications />
         </ConfigContext.Provider>
       </BackupContext.Provider>,

--- a/src/test/screens/settings/notifications.test.tsx
+++ b/src/test/screens/settings/notifications.test.tsx
@@ -1,28 +1,126 @@
-import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
 import Notifications from '../../../screens/Settings/Notifications'
 import { ConfigContext } from '../../../providers/config'
+import { BackupContext } from '../../../providers/backup'
 import { mockConfigContextValue } from '../mocks'
 
+if (!window.PointerEvent) {
+  Object.defineProperty(window, 'PointerEvent', {
+    writable: true,
+    configurable: true,
+    value: MouseEvent,
+  })
+}
+
+const toast = vi.fn()
+const notificationsMock = vi.hoisted(() => ({
+  notificationApiSupport: true,
+  requestPermission: vi.fn().mockResolvedValue(true),
+  sendTestNotification: vi.fn(),
+}))
+
+vi.mock('../../../components/Toast', () => ({
+  useToast: () => ({ toast }),
+}))
+
+vi.mock('../../../lib/notifications', () => ({
+  get notificationApiSupport() {
+    return notificationsMock.notificationApiSupport
+  },
+  requestPermission: notificationsMock.requestPermission,
+  sendTestNotification: notificationsMock.sendTestNotification,
+}))
+
 describe('Notifications screen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    notificationsMock.notificationApiSupport = true
+    notificationsMock.requestPermission.mockResolvedValue(true)
+  })
+
   it('renders the notifications screen with the correct elements', () => {
     render(
-      <ConfigContext.Provider value={mockConfigContextValue as any}>
-        <Notifications />
-      </ConfigContext.Provider>,
+      <BackupContext.Provider value={{ backupAndUpdateConfig: vi.fn() } as any}>
+        <ConfigContext.Provider value={mockConfigContextValue as any}>
+          <Notifications />
+        </ConfigContext.Provider>
+      </BackupContext.Provider>,
     )
+
     expect(screen.getByText('Allow notifications')).toBeInTheDocument()
     expect(screen.getByTestId('toggle-notifications')).toBeInTheDocument()
     expect(screen.getByTestId('toggle-notifications').getAttribute('data-checked')).toBe('true')
   })
 
-  it('renders the notifications screen with the correct toggle', () => {
+  it('updates config when the notifications toggle is clicked', async () => {
+    const backupAndUpdateConfig = vi.fn()
+
     render(
-      <ConfigContext.Provider value={mockConfigContextValue as any}>
-        <Notifications />
-      </ConfigContext.Provider>,
+      <BackupContext.Provider value={{ backupAndUpdateConfig } as any}>
+        <ConfigContext.Provider
+          value={
+            { ...mockConfigContextValue, config: { ...mockConfigContextValue.config, notifications: true } } as any
+          }
+        >
+          <Notifications />
+        </ConfigContext.Provider>
+      </BackupContext.Provider>,
     )
-    expect(screen.getByTestId('toggle-notifications')).toBeInTheDocument()
-    expect(screen.getByTestId('toggle-notifications').getAttribute('data-checked')).toBe('true')
+
+    fireEvent.click(screen.getByTestId('toggle-notifications'))
+
+    await vi.waitFor(() => {
+      expect(backupAndUpdateConfig).toHaveBeenCalledWith({
+        ...mockConfigContextValue.config,
+        notifications: false,
+      })
+    })
+  })
+
+  it('shows a toast when the browser does not support notifications', () => {
+    const backupAndUpdateConfig = vi.fn()
+    notificationsMock.notificationApiSupport = false
+
+    render(
+      <BackupContext.Provider value={{ backupAndUpdateConfig } as any}>
+        <ConfigContext.Provider value={mockConfigContextValue as any}>
+          <Notifications />
+        </ConfigContext.Provider>
+      </BackupContext.Provider>,
+    )
+
+    fireEvent.click(screen.getByTestId('toggle-notifications'))
+
+    expect(toast).toHaveBeenCalledWith('Notifications API not supported')
+    expect(backupAndUpdateConfig).not.toHaveBeenCalled()
+  })
+
+  it('shows a toast when notification permission is denied', async () => {
+    const backupAndUpdateConfig = vi.fn()
+    notificationsMock.requestPermission.mockResolvedValue(false)
+
+    render(
+      <BackupContext.Provider value={{ backupAndUpdateConfig } as any}>
+        <ConfigContext.Provider
+          value={
+            { ...mockConfigContextValue, config: { ...mockConfigContextValue.config, notifications: false } } as any
+          }
+        >
+          <Notifications />
+        </ConfigContext.Provider>
+      </BackupContext.Provider>,
+    )
+
+    fireEvent.click(screen.getByTestId('toggle-notifications'))
+
+    await vi.waitFor(() => {
+      expect(notificationsMock.requestPermission).toHaveBeenCalledOnce()
+      expect(toast).toHaveBeenCalledWith('Notifications permission denied')
+      expect(backupAndUpdateConfig).toHaveBeenCalledWith({
+        ...mockConfigContextValue.config,
+        notifications: false,
+      })
+    })
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear error notifications when browser notification APIs are unavailable.
  * Added feedback when notification permission is denied.
  * Prevented notification setup from continuing in unsupported environments.

* **Tests**
  * Expanded coverage for notification settings, browser support, permissions, toast messages, and configuration toggles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->