### PR TITLE
fix(lnswap): match @arkade-os/swap 0.0.3 signatures

### DIFF
--- a/src/lib/lnReceive.ts
+++ b/src/lib/lnReceive.ts
@@ -27,7 +27,6 @@ import {
   type SwapSecrets,
 } from '@arkade-os/swap'
 import { secp256k1 } from '@noble/curves/secp256k1.js'
-import { hex } from '@scure/base'
 import { toInvoiceFacts, type LnSendRendezvous } from './lnSwap'
 
 /**
@@ -95,10 +94,11 @@ export const requestLnReceive = async (args: {
   network: NetworkName
   amountSats: number
 }): Promise<LnReceiveRequest> => {
+  // 0.0.3: the co-signer key resolves inside the package (per-network pin);
+  // the positional argument is gone.
   const result = await requestLightningReceive(
     args.wallet,
     args.arkServerUrl,
-    hex.decode(args.rendezvous.emulatorPubkey),
     args.transport,
     {
       amount: args.amountSats,

--- a/src/lib/lnSwap.ts
+++ b/src/lib/lnSwap.ts
@@ -296,18 +296,13 @@ export const requestLnSend = async (
   nowSeconds = Math.floor(Date.now() / 1000),
 ): Promise<LnSendRequest> => {
   const invoice = toInvoiceFacts(args.invoice, args.network, nowSeconds)
-  // The emulator's x-only KEY, not the emulator's URL. The client has no
-  // network path to that service and never dials it — the key is a covenant
-  // parameter, one of the eight leaves' inputs. It is taken from the rendezvous
-  // rather than accepted as a separate argument so no call site can pair one
-  // solver's card with another's co-signer.
-  const result = await requestLightningSend(
-    args.wallet,
-    args.arkServerUrl,
-    hex.decode(args.rendezvous.emulatorPubkey),
-    args.transport,
-    { invoice },
-  )
+  // Since @arkade-os/swap 0.0.3 the covenant co-signer key resolves inside
+  // the package from its per-network pin — there is no positional argument.
+  // Passing the old five-argument shape shifted every parameter one slot and
+  // died reading `params.invoice.raw` off the transport.
+  const result = await requestLightningSend(args.wallet, args.arkServerUrl, args.transport, {
+    invoice,
+  })
   return {
     rfqId: result.rfqId,
     address: result.address,


### PR DESCRIPTION
Fixes the live send crash `error sending payment: Cannot read properties of undefined (reading 'raw')`.

`@arkade-os/swap@0.0.3` resolves the covenant co-signer key inside the package (per-network pin) and **drops the positional `emulatorPubkey` argument** from `requestLightningSend` and `requestLightningReceive`. The wallet still passed the old five-argument shape, shifting every parameter one slot: the key Uint8Array landed in the `transport` slot, the real transport landed in `params`, and the package's first property read — `params.invoice.raw` — died with exactly the reported error, on every send.

Both call sites now use the 4-argument shape (`lnSwap.ts`, `lnReceive.ts`); the card's `emulator_pubkey` plumbing is untouched — it still validates cards, it's just no longer forwarded positionally. `tsc` clean, eslint clean, 654 tests green.

Worth knowing: this class of bug is invisible to tests that mock the package boundary — a smoke test that calls the real `requestLightningSend` against a fake transport would have caught the slot shift at the first property read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyyk1wuSFmcVXYz2aLeJqx)_