### PR TITLE
feat(lnswap): persist the refund-signer record with the funding tx

### DIFF
--- a/src/lib/lnSwap.ts
+++ b/src/lib/lnSwap.ts
@@ -25,10 +25,10 @@
 import { hex } from '@scure/base'
 import { sideLimits, type DiscoveredMarket, type Side } from '@arkade-os/solver-discovery'
 import type { NetworkName, RestIndexerProvider } from '@arkade-os/sdk'
-import { isRfqTerminal, requestLightningSend, type InvoiceFacts, type RfqTransport } from '@arkade-os/swap'
+import { isRfqTerminal, requestLightningSend, rfqSecretsToRecord, type InvoiceFacts, type RfqTransport } from '@arkade-os/swap'
 import { sleep as defaultSleep } from './sleep'
 import { decodeInvoice, invoiceMatchesNetwork, isInvoiceExpired, type DecodedInvoice } from './bolt11'
-import type { LnSendSpend } from './types'
+import type { LnSendSecretsRecord, LnSendSpend } from './types'
 
 /** Why an invoice cannot start a swap. A closed set, so callers can branch. */
 export type InvoiceRejection = 'unparseable' | 'wrong_network' | 'expired' | 'zero_amount' | 'no_payment_hash'
@@ -255,6 +255,9 @@ export interface LnSendRequest {
   swapPkScript: string
   /** Unix seconds after which the quote is dead and must not be funded. */
   validUntil: number
+  /** How the refund signer is recovered after a restart — see
+   * `LnSendSecretsRecord`. */
+  secretsRecord: LnSendSecretsRecord
   /**
    * Where to reach the solver again after funding.
    *
@@ -310,6 +313,10 @@ export const requestLnSend = async (
     swapPkScript: hex.encode(result.swapPkScript),
     validUntil: result.quote.valid_until,
     rendezvous: args.rendezvous,
+    // JSON-safe by construction: a public descriptor on the HD arm, the raw
+    // sender key when the wallet cannot allocate one. The pay screen persists
+    // it with the funding tx — losing it there loses the interactive refund.
+    secretsRecord: rfqSecretsToRecord(result.secrets),
   }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,4 @@
+import type { rfqSecretsToRecord } from '@arkade-os/swap'
 import { Asset, NetworkName, type ExtendedVirtualCoin, type ServiceWorkerWalletMode } from '@arkade-os/sdk'
 
 export type Addresses = {
@@ -97,9 +98,20 @@ export enum Themes {
  * first is the wallet's own, so nothing in tx history can name the second; the
  * covenant's script is what lets the receipt find it.
  */
+/**
+ * The swap package's JSON-safe secrets record (`rfqSecretsToRecord`). On an
+ * HD wallet it holds only a public signing descriptor; when the wallet
+ * cannot allocate one, it holds the raw sender key — the material every
+ * interactive refund leaf needs, existing nowhere else. Same trust domain
+ * as the rest of this storage, same precedent as the Boltz swap records.
+ */
+export type LnSendSecretsRecord = ReturnType<typeof rfqSecretsToRecord>
+
 export type LnSendActivity = {
   /** Hex pkScript of the lockup covenant — the indexer's watch key. */
   swapPkScript: string
+  /** How the refund signer is recovered after a restart. */
+  secretsRecord?: LnSendSecretsRecord
   /** The tx that ended the swap, absent until one exists. */
   spend?: LnSendSpend
 }

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -155,7 +155,7 @@ export default function SendDetails() {
     // Record the covenant against the funding txid: it is the only handle on
     // the spend that ends this swap, and it stops being derivable the moment
     // this screen unmounts — the quote is gone and nothing else stores it.
-    handleTxid(txid, { swapPkScript: request.swapPkScript })
+    handleTxid(txid, { swapPkScript: request.swapPkScript, secretsRecord: request.secretsRecord })
   }
 
   const handleContinue = async () => {


### PR DESCRIPTION
Interim fix for the console warning `[swap] wallet cannot allocate an HD descriptor: the sender key is random and MUST be persisted before funding` — which was accurate: the wallet dropped the secrets, so on every send the key behind the interactive refund leaves existed only until the screen unmounted. A stalled swap then needed the solver's cooperation (non-interactive path) instead of the wallet's own refund.

Three small changes:

- `requestLnSend` carries the package's JSON-safe secrets record (`rfqSecretsToRecord`) on `LnSendRequest` — a public signing descriptor on the HD arm, the raw sender key hex on the fallback arm.
- The pay screen persists it in the transaction activity metadata beside `swapPkScript` at funding time.
- `LnSendActivity` gains the optional `secretsRecord`, restorable later via `rfqSecretsOfRecord`.

Trust domain unchanged: this is the same localStorage the activity metadata already lives in, and the Boltz-era swap records stored their claim/refund keys the same way. **Interim by design** — the right home is the contract-manager row itself (SDK proposal coming separately), and the real fix for the warning is the HD surface through `ServiceWorkerWallet`.

`tsc` clean, 654 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyyk1wuSFmcVXYz2aLeJqx)_