### PR TITLE
fix(assets): cap selectable amounts at spendable, not owned

### DIFF
--- a/src/hooks/usePortfolioFiat.ts
+++ b/src/hooks/usePortfolioFiat.ts
@@ -14,8 +14,14 @@ export interface PortfolioRow {
   ticker: string
   icon?: string
   decimals: number
-  /** Raw balance in the asset's smallest unit (sats for BTC, minor units otherwise). */
+  /** Raw balance in the asset's smallest unit (sats for BTC, minor units otherwise).
+   * Everything the wallet owns, escrow and awaiting-recovery included — this is
+   * the reporting figure, not a spending limit. */
   balance: number | bigint
+  /** The spendable subset of {@link balance}, same denomination. Funds locked in
+   * a swap covenant, intent-locked or awaiting recovery are excluded, so this is
+   * what any selectable amount must be capped at. */
+  spendableBalance: number | bigint
   /** Fiat value in the user's selected currency (0 if no price feed). */
   fiatAmount: number
   /** Equivalent value in satoshis, computed via the live BTC price feed. */
@@ -41,7 +47,8 @@ export interface PortfolioFiat {
  */
 export function usePortfolioFiat(): PortfolioFiat {
   const { aspInfo } = useContext(AspContext)
-  const { balance, assetBalances, assetMetadataCache, isVerifiedAsset } = useContext(WalletContext)
+  const { balance, availableBalance, assetBalances, availableAssetBalances, assetMetadataCache, isVerifiedAsset } =
+    useContext(WalletContext)
   const { fromFiatAmount, toFiat } = useContext(FiatContext)
   const convertToSelectedFiat = (amount: number, from: Currencies) => toFiat(fromFiatAmount(amount, from))
 
@@ -56,6 +63,7 @@ export function usePortfolioFiat(): PortfolioFiat {
     ticker: 'BTC',
     decimals: 8,
     balance,
+    spendableBalance: availableBalance,
     fiatAmount: toFiat(balance),
     satsEquivalent: balance,
     hasFiatPrice: true,
@@ -65,17 +73,23 @@ export function usePortfolioFiat(): PortfolioFiat {
   for (const ab of assetBalances) {
     const meta = assetMetadataCache.get(ab.assetId)?.metadata
     const assetDecimals = meta?.decimals ?? 8
+    // absent from availableAssets means every unit of it is escrowed, locked or
+    // awaiting recovery — owned, but nothing of it is selectable
+    const spendableAmount = availableAssetBalances.find((a) => a.assetId === ab.assetId)?.amount ?? BigInt(0)
     // only verified asset IDs may claim currency-account treatment
     const sourceFiat = isVerifiedAsset(ab.assetId) ? designatedAccountCurrency(aspInfo.network, ab.assetId) : undefined
 
     if (sourceFiat) {
       const accountDecimals = fiatDecimalsFor(sourceFiat)
+      // the backing asset fulfills sends, so it carries the spendable amount;
+      // the row's own `balance` stays owned for display and the fiat total
       const sourceAsset: FiatAccountSourceAsset = {
         assetId: ab.assetId,
-        balance: BigInt(ab.amount),
+        balance: BigInt(spendableAmount),
         decimals: assetDecimals,
       }
-      const minorUnits = normalizeAssetMinorUnits(sourceAsset.balance, assetDecimals, accountDecimals)
+      const minorUnits = normalizeAssetMinorUnits(BigInt(ab.amount), assetDecimals, accountDecimals)
+      const spendableMinorUnits = normalizeAssetMinorUnits(sourceAsset.balance, assetDecimals, accountDecimals)
       const amount = Decimal.div(minorUnits.toString(), Decimal.pow(10, accountDecimals)).toNumber()
       const fiatAmount = convertToSelectedFiat(amount, sourceFiat)
       const satsEquivalent = fromFiatAmount(amount, sourceFiat)
@@ -86,6 +100,7 @@ export function usePortfolioFiat(): PortfolioFiat {
         ticker: sourceFiat,
         decimals: accountDecimals,
         balance: minorUnits,
+        spendableBalance: spendableMinorUnits,
         fiatAmount,
         satsEquivalent,
         hasFiatPrice: true,
@@ -102,6 +117,7 @@ export function usePortfolioFiat(): PortfolioFiat {
       icon: meta?.icon,
       decimals: assetDecimals,
       balance: ab.amount,
+      spendableBalance: spendableAmount,
       fiatAmount: 0,
       satsEquivalent: 0,
       hasFiatPrice: false,

--- a/src/lib/accountAssets.ts
+++ b/src/lib/accountAssets.ts
@@ -17,6 +17,8 @@ const DESIGNATED_ACCOUNT_ASSETS: Record<string, Partial<Record<string, Currencie
 
 export interface FiatAccountSourceAsset {
   assetId: string
+  /** Spendable amount, not the owned total — this asset fulfills the send, so
+   * escrowed and locked units must not reach it. */
   balance: bigint
   decimals: number
 }
@@ -24,6 +26,7 @@ export interface FiatAccountSourceAsset {
 export interface FiatAccountSend {
   assetId: string
   ticker: WalletAccountTicker
+  /** Spendable amount in account minor units; caps what the composer accepts. */
   balance: bigint
   decimals: number
   amount: bigint

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -110,7 +110,12 @@ interface WalletContextProps {
   vtxos: { spendable: Vtxo[]; spent: Vtxo[] }
   balance: WalletBalance['total']
   availableBalance: WalletBalance['available']
+  /** Everything the wallet owns, including assets escrowed in a swap covenant,
+   * intent-locked or awaiting recovery. Reporting only. */
   assetBalances: WalletBalance['assets']
+  /** The subset generic spending will accept — the asset analogue of
+   * `availableBalance`. Any selectable amount must come from here. */
+  availableAssetBalances: WalletBalance['availableAssets']
   assetMetadataCache: Map<string, CachedAssetDetails>
   setCacheEntry: (assetId: string, details: AssetDetails) => CachedAssetDetails
   iconApprovalManager: AssetIconApprovalManager
@@ -140,6 +145,7 @@ export const WalletContext = createContext<WalletContextProps>({
   balance: 0,
   availableBalance: 0,
   assetBalances: [],
+  availableAssetBalances: [],
   assetMetadataCache: new Map(),
   setCacheEntry: () => ({ cachedAt: 0 }) as CachedAssetDetails,
   iconApprovalManager: new AssetIconApprovalManager(),
@@ -176,6 +182,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   const [authState, setAuthState] = useState<WalletAuthState>('unknown')
   const [vtxos, setVtxos] = useState<{ spendable: Vtxo[]; spent: Vtxo[] }>({ spendable: [], spent: [] })
   const [assetBalances, setAssetBalances] = useState<WalletBalance['assets']>([])
+  const [availableAssetBalances, setAvailableAssetBalances] = useState<WalletBalance['availableAssets']>([])
 
   const [vtxoManager, setVtxoManager] = useState<IVtxoManager>()
 
@@ -463,7 +470,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       if (isFirstLoad) setLoadingStatus('Fetching transactions...')
       const txs = await getTxHistory(swWallet)
       if (isFirstLoad) setLoadingStatus('Updating balance...')
-      const { total, available, assets } = await getBalance(swWallet)
+      const { total, available, assets, availableAssets } = await getBalance(swWallet)
       // prefetch asset metadata before triggering re-renders
       if (isFirstLoad && assets.length > 0) setLoadingStatus('Loading asset metadata...')
       for (const ab of assets) {
@@ -479,6 +486,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       setBalance(total)
       setAvailableBalance(available)
       setAssetBalances(assets)
+      setAvailableAssetBalances(availableAssets)
       if (assets.length > 0 && !configRef.current.apps.assets.enabled) {
         const live = configRef.current
         updateConfig({ ...live, apps: { ...live.apps, assets: { enabled: true } } })
@@ -938,6 +946,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         balance,
         availableBalance,
         assetBalances,
+        availableAssetBalances,
         assetMetadataCache: assetMetadataCache.current,
         setCacheEntry,
         iconApprovalManager,

--- a/src/screens/Wallet/BitcoinDetail.tsx
+++ b/src/screens/Wallet/BitcoinDetail.tsx
@@ -59,6 +59,7 @@ const unavailableRow: PortfolioRow = {
   ticker: 'TKN',
   decimals: 0,
   balance: BigInt(0),
+  spendableBalance: BigInt(0),
   fiatAmount: 0,
   satsEquivalent: 0,
   hasFiatPrice: false,
@@ -116,6 +117,10 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
           minimumFractionDigits: marketDecimals,
         })
   const rawBalance = typeof row.balance === 'bigint' ? row.balance : BigInt(Math.max(0, Math.floor(row.balance)))
+  const rawSpendableBalance =
+    typeof row.spendableBalance === 'bigint'
+      ? row.spendableBalance
+      : BigInt(Math.max(0, Math.floor(row.spendableBalance)))
   const formattedBalance = isBitcoin
     ? prettyBitcoinAmount(safeBitcoinBalance, bitcoinUnit)
     : `${prettyCurrencyAssetAmount(rawBalance, row.decimals, row.ticker)} ${row.ticker}`
@@ -140,7 +145,9 @@ export default function BitcoinDetail({ assetId = 'btc' }: { assetId?: string })
       ? {
           assetId: row.assetId,
           ticker: accountTicker,
-          balance: rawBalance,
+          // the composer caps at this, so it is the spendable amount; the header
+          // above keeps showing the owned total
+          balance: rawSpendableBalance,
           decimals: row.decimals,
           amount: BigInt(0),
           source: row.sourceAsset,

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -131,8 +131,16 @@ export default function SendForm() {
   const { amountIsAboveMaxLimit, amountIsBelowMinLimit, utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { setOption } = useContext(OptionsContext)
   const { navigate } = useContext(NavigationContext)
-  const { assetBalances, assetMetadataCache, availableBalance, balance, isVerifiedAsset, setCacheEntry, svcWallet } =
-    useContext(WalletContext)
+  const {
+    assetBalances,
+    availableAssetBalances,
+    assetMetadataCache,
+    availableBalance,
+    balance,
+    isVerifiedAsset,
+    setCacheEntry,
+    svcWallet,
+  } = useContext(WalletContext)
 
   const [amount, setAmount] = useState<number>()
   const [amountTextValue, setAmountTextValue] = useState('')
@@ -275,7 +283,9 @@ export default function SendForm() {
         const presentation = rawAssetPresentation(meta?.metadata, `${ab.assetId.slice(0, 8)}...`)
         options.push({
           assetId: ab.assetId,
-          balance: ab.amount,
+          // list membership follows owned assets so one fully in escrow still
+          // appears, but the amount offered is only ever the spendable part
+          balance: availableAssetBalances.find((a) => a.assetId === ab.assetId)?.amount ?? BigInt(0),
           name: presentation.name,
           ticker: presentation.ticker,
           icon: presentation.icon,
@@ -286,7 +296,7 @@ export default function SendForm() {
       setAssetOptions(options)
     }
     loadOptions()
-  }, [svcWallet, assetBalances, config.apps.assets.enabled])
+  }, [svcWallet, assetBalances, availableAssetBalances, config.apps.assets.enabled])
 
   // initialize selected asset from pre-set sendInfo.assets (e.g. from Asset Detail page)
   useEffect(() => {

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -96,7 +96,7 @@ export default function WalletSwap() {
   const { fiatDecimals, fromFiatAmount, toFiat, toFiatAmount } = useContext(FiatContext)
   const { swapFromAssetId, setSwapFromAssetId } = useContext(FlowContext)
   const { goBack, navigate } = useContext(NavigationContext)
-  const { assetBalances, assetMetadataCache, availableBalance, isVerifiedAsset } = useContext(WalletContext)
+  const { assetMetadataCache, availableAssetBalances, availableBalance, isVerifiedAsset } = useContext(WalletContext)
   const { rows } = usePortfolioFiat()
   const prefersReduced = useReducedMotion()
 
@@ -133,7 +133,8 @@ export default function WalletSwap() {
       }
 
       const row = rows.find((candidate) => candidate.assetId === asset.id)
-      const owned = assetBalances.find((balance) => balance.assetId === asset.id)
+      // spendable, not owned: the composer offers this as a max
+      const spendable = availableAssetBalances.find((balance) => balance.assetId === asset.id)
       const designatedCurrency = verifiedDesignatedCurrency(aspInfo.network, asset.id, isVerifiedAsset)
       return {
         assetId: asset.id,
@@ -141,7 +142,7 @@ export default function WalletSwap() {
         ticker: row?.ticker ?? designatedCurrency ?? asset.ticker,
         currency: designatedCurrency,
         decimals: asset.decimals,
-        balance: BigInt(owned?.amount ?? 0),
+        balance: BigInt(spendable?.amount ?? 0),
         fiatText: row?.hasFiatPrice
           ? prettyFiatAmount(row.fiatAmount, config.currency, { bitcoinUnit: config.unit })
           : undefined,
@@ -150,9 +151,9 @@ export default function WalletSwap() {
       }
     })
   }, [
-    assetBalances,
     assetMetadataCache,
     aspInfo.network,
+    availableAssetBalances,
     availableBalance,
     btcUnit,
     config.currency,

--- a/src/test/hooks/usePortfolioFiat.test.tsx
+++ b/src/test/hooks/usePortfolioFiat.test.tsx
@@ -50,7 +50,9 @@ function wrapper({
             {
               ...mockWalletContextValue,
               balance: 500,
+              availableBalance: 500,
               assetBalances,
+              availableAssetBalances: assetBalances,
               assetMetadataCache,
               isVerifiedAsset: () => verified,
             } as any
@@ -81,7 +83,9 @@ const makeChfWrapper = (isVerifiedAsset: (assetId: string) => boolean) => {
             {
               ...mockWalletContextValue,
               balance: 1000,
+              availableBalance: 1000,
               assetBalances: [{ assetId: 'chf-asset', amount: BigInt(2000) }],
+              availableAssetBalances: [{ assetId: 'chf-asset', amount: BigInt(2000) }],
               assetMetadataCache: new Map([['chf-asset', assetDetails('chf-asset', 'CHF')]]),
               isVerifiedAsset,
             } as any
@@ -94,7 +98,85 @@ const makeChfWrapper = (isVerifiedAsset: (assetId: string) => boolean) => {
   )
 }
 
+/** Owned exceeds spendable — the shape a swap covenant produces, where the
+ * escrowed VTXO is still the wallet's but generic spending refuses it. */
+function escrowWrapper({ children }: { children: ReactNode }) {
+  return (
+    <AspContext.Provider
+      value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' } } as any}
+    >
+      <FiatContext.Provider
+        value={{
+          ...mockFiatContextValue,
+          fromFiatAmount: (amount: number, currency: Currencies) => (currency === Currencies.USD ? amount * 1_000 : 0),
+          toFiat: (sats?: number) => sats ?? 0,
+        }}
+      >
+        <WalletContext.Provider
+          value={
+            {
+              ...mockWalletContextValue,
+              balance: 500,
+              availableBalance: 200,
+              assetBalances: [{ assetId: MUTINYNET_USDT_ASSET_ID, amount: BigInt(1_234) }],
+              availableAssetBalances: [{ assetId: MUTINYNET_USDT_ASSET_ID, amount: BigInt(1_000) }],
+              assetMetadataCache: new Map([[MUTINYNET_USDT_ASSET_ID, assetDetails(MUTINYNET_USDT_ASSET_ID, 'USDT')]]),
+              isVerifiedAsset: () => true,
+            } as any
+          }
+        >
+          {children}
+        </WalletContext.Provider>
+      </FiatContext.Provider>
+    </AspContext.Provider>
+  )
+}
+
 describe('usePortfolioFiat', () => {
+  it('reports owned holdings but caps the spendable figure at what generic spending accepts', () => {
+    const { result } = renderHook(() => usePortfolioFiat(), { wrapper: escrowWrapper })
+
+    const btcRow = result.current.rows.find((row) => row.assetId === 'btc')
+    expect(btcRow?.balance).toBe(500)
+    expect(btcRow?.spendableBalance).toBe(200)
+
+    // the account's backing asset fulfills sends, so it carries the spendable
+    // amount; the row keeps reporting the full holding
+    expect(result.current.rows.find((row) => row.assetId === MUTINYNET_USDT_ASSET_ID)).toMatchObject({
+      balance: BigInt(1_234),
+      spendableBalance: BigInt(1_000),
+      sourceAsset: { assetId: MUTINYNET_USDT_ASSET_ID, balance: BigInt(1_000), decimals: 2 },
+    })
+
+    // escrow is still the wallet's money, so the portfolio total keeps it
+    expect(result.current.totalSats).toBe(500 + 12_340)
+  })
+
+  it('treats an asset absent from availableAssets as entirely unspendable', () => {
+    const lockedWrapper = ({ children }: { children: ReactNode }) => (
+      <WalletContext.Provider
+        value={
+          {
+            ...mockWalletContextValue,
+            balance: 500,
+            availableBalance: 500,
+            assetBalances: [{ assetId: 'locked-asset', amount: BigInt(9_000) }],
+            availableAssetBalances: [],
+            assetMetadataCache: new Map([['locked-asset', assetDetails('locked-asset', 'LOCK')]]),
+            isVerifiedAsset: () => true,
+          } as any
+        }
+      >
+        {children}
+      </WalletContext.Provider>
+    )
+    const { result } = renderHook(() => usePortfolioFiat(), { wrapper: lockedWrapper })
+    const row = result.current.rows.find((candidate) => candidate.assetId === 'locked-asset')
+
+    expect(row?.balance).toBe(BigInt(9_000))
+    expect(row?.spendableBalance).toBe(BigInt(0))
+  })
+
   it('creates separate verified Mutinynet USD and BRL accounts and includes both in the total', () => {
     const { result } = renderHook(() => usePortfolioFiat(), { wrapper })
 

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -133,6 +133,7 @@ export const mockWalletContextValue = {
   balance: 0,
   availableBalance: 0,
   assetBalances: [],
+  availableAssetBalances: [],
   assetMetadataCache: new Map(),
   setCacheEntry: () => ({ cachedAt: 0 }) as any,
   txs: [mockTxInfo],

--- a/src/test/screens/wallet/account-detail.test.tsx
+++ b/src/test/screens/wallet/account-detail.test.tsx
@@ -66,6 +66,7 @@ describe('Account detail screen', () => {
                         ...mockWalletContextValue,
                         isVerifiedAsset: (assetId: string) => assetId === sourceAssetId,
                         assetBalances: [{ assetId: sourceAssetId, amount: BigInt(200_000_000_000) }],
+                        availableAssetBalances: [{ assetId: sourceAssetId, amount: BigInt(200_000_000_000) }],
                         assetMetadataCache: new Map([
                           [
                             sourceAssetId,
@@ -144,6 +145,7 @@ describe('Account detail screen', () => {
                         ...mockWalletContextValue,
                         isVerifiedAsset: (assetId: string) => assetId === sourceAssetId,
                         assetBalances: [{ assetId: sourceAssetId, amount: BigInt(10_000) }],
+                        availableAssetBalances: [{ assetId: sourceAssetId, amount: BigInt(10_000) }],
                         assetMetadataCache: new Map([
                           [
                             sourceAssetId,

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -72,6 +72,20 @@ function renderSwap({
     [USDT_ID, { metadata: { name: 'USDT', ticker: 'USDT', decimals: 2 } }],
     [DEPIX_ID, { metadata: { name: 'Decentralized Pix', ticker: 'DEPIX', decimals: 8 } }],
   ])
+  const walletValue: Record<string, unknown> = {
+    ...mockWalletContextValue,
+    isVerifiedAsset: () => true,
+    balance: 250_000,
+    assetBalances: [
+      { assetId: USDT_ID, amount: BigInt(15_000) },
+      { assetId: DEPIX_ID, amount: BigInt(2_000_000_000) },
+    ],
+    assetMetadataCache,
+    availableBalance: 100_000,
+    ...wallet,
+  }
+  // nothing escrowed unless a test says so, so every owned unit is spendable
+  if (!('availableAssetBalances' in wallet)) walletValue.availableAssetBalances = walletValue.assetBalances
 
   const view = render(
     <AspContext.Provider
@@ -94,22 +108,7 @@ function renderSwap({
               }
             >
               <FlowContext.Provider value={{ ...mockFlowContextValue, ...flow } as any}>
-                <WalletContext.Provider
-                  value={
-                    {
-                      ...mockWalletContextValue,
-                      isVerifiedAsset: () => true,
-                      balance: 250_000,
-                      assetBalances: [
-                        { assetId: USDT_ID, amount: BigInt(15_000) },
-                        { assetId: DEPIX_ID, amount: BigInt(2_000_000_000) },
-                      ],
-                      assetMetadataCache,
-                      availableBalance: 100_000,
-                      ...wallet,
-                    } as any
-                  }
-                >
+                <WalletContext.Provider value={walletValue as any}>
                   <AssetSwapsContext.Provider
                     value={
                       {
@@ -635,6 +634,34 @@ describe('Wallet swap flow', () => {
 
     await waitFor(() => expect(createSwap).toHaveBeenCalledOnce())
     expect(createSwap.mock.calls[0][0].deposit.atomic).toBe(BigInt(100_000))
+  })
+
+  it('offers only the spendable part of an asset held partly in swap escrow', async () => {
+    // a covenant VTXO stays owned but generic spending refuses it, so the
+    // composer must cap at availableAssets — offering the owned total builds a
+    // swap coin selection cannot fund
+    renderSwap({
+      config: { unit: Unit.SATS },
+      flow: { swapFromAssetId: USDT_ID, setSwapFromAssetId: vi.fn() },
+      wallet: {
+        assetBalances: [{ assetId: USDT_ID, amount: BigInt(15_000) }],
+        availableAssetBalances: [{ assetId: USDT_ID, amount: BigInt(10_000) }],
+      },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /Bitcoin/i }))
+
+    await userEvent.click(await screen.findByRole('button', { name: '100.00 USD' }))
+    expect(screen.queryByRole('button', { name: '150.00 USD' })).not.toBeInTheDocument()
+
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    await waitFor(() => expect(continueButton).toBeEnabled(), { timeout: 3_000 })
+    fireEvent.click(continueButton)
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm swap' }))
+
+    await waitFor(() => expect(createSwap).toHaveBeenCalledOnce())
+    expect(createSwap.mock.calls[0][0].deposit.atomic).toBe(BigInt(10_000))
   })
 
   it('hides Use max when the selected asset has no balance', () => {


### PR DESCRIPTION
Addresses the asset half of the balance bug reported in https://github.com/arkade-os/wallet/pull/908#issuecomment-5278434021.

## Root cause

`@arkade-os/swap`'s `registerLockupContract` writes the swap covenant into the wallet's own ContractManager with `metadata.genericallySpendable: false`. That puts the covenant's VTXOs into the wallet's snapshot.

The SDK's `computeOffchainBalance` applies the `genericallySpendable` gate only to `available` and `availableAssets`:

```js
if (vtxo.isPreconfirmed) preconfirmed += vtxo.value; else settled += vtxo.value;   // no gate
if (isGenericallySpendable(vtxo) && isUnlocked(vtxo)) {                            // gate here only
  available += vtxo.value;
  addAssets(spendable, vtxo);
}
```

So an escrowed asset stays in `assets` (owned) while dropping out of `availableAssets`.

## Why this is more than a display bug

Every selectable asset amount read `assetBalances`, i.e. owned:

- `Send/Form.tsx` asset options
- `Swap/Index.tsx` composer max
- `BitcoinDetail.tsx` → `sendAccount.balance`, and `sourceAsset.balance`, which `Send/Form.tsx:817` spends verbatim on "use all"

With an offer in flight the composer offered a maximum coin selection cannot fund. The send failed at spend time rather than being blocked at entry.

## Change

`availableAssets` is threaded through `WalletProvider` as `availableAssetBalances` and used wherever an amount is selectable. `PortfolioRow` gains `spendableBalance` alongside `balance`, and `sourceAsset.balance` now carries the spendable amount since it fulfills the send.

Reporting surfaces keep showing owned — portfolio rows, the fiat total, the asset screens. Escrow is still the wallet's money.

Send-form list membership still follows owned assets, so an asset held entirely in escrow appears with nothing selectable rather than disappearing from the picker.

## Tests

Three regression cases; all 616 unit tests pass.

- `usePortfolioFiat.test.tsx` — owned/spendable divergence propagating to `sourceAsset`, and an asset absent from `availableAssets` reading as entirely unspendable
- `swap.test.tsx` — end to end: an asset held partly in escrow offers only the spendable part through to `createSwap`

I verified the swap test fails against pre-fix code rather than passing vacuously. Existing helpers now mirror owned → spendable by default, so prior tests keep their original meaning.

## Deliberately not in scope

**The BTC home-screen total is still wrong**, for the same root cause. It cannot be fixed cleanly at the display layer today: `total - available` also folds in `recoverable`, `pendingRecovery` and intent-locked funds, and `WalletBalance` has no bucket isolating escrow. Showing `available` instead would erase swept and awaiting-recovery funds from the hero — a regression in the opposite direction. This wants an escrow bucket on `WalletBalance` upstream; `computeOffchainBalance` already has `isGenericallySpendable` in hand.

**`BitcoinDetail.tsx:316`** still gates the Send button on the owned balance, so an account entirely in escrow reaches a form capped at zero rather than a disabled button. Fixing that means deciding what to tell the user, which belongs with the in-flight presentation question above.