### PR TITLE
fix(pwa): keep bottom actions in the visible viewport

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -82,18 +82,13 @@ body,
   background-color: var(--background-color, #fff);
 }
 
-/* Installed-PWA only: iOS standalone can letterbox the bottom home-indicator
-   zone out of the containing block that the absolute .page sizes against,
-   leaving a dead band under the content. Pin the shell to the full dynamic
-   viewport and make #root the containing block so .page reaches the physical
-   bottom. Inert in browsers (100dvh == 100% there). */
+/* Installed-PWA only: size the shell to the currently visible viewport so
+   bottom actions stay above standalone browser chrome and OS gesture areas. */
 @media (display-mode: standalone) {
   html,
   body,
   #root {
-    /* lvh, not dvh: the large viewport includes the home-indicator zone the
-       letterboxed containing block excludes */
-    height: 100lvh;
+    height: 100dvh;
   }
   #root {
     position: relative;


### PR DESCRIPTION
## Summary

- Size the installed-PWA shell with the dynamic viewport instead of the large viewport.
- Keep shared bottom actions reachable in standalone apps, including Send Continue and amount-keypad Save.
- Preserve regular browser-tab sizing and the existing visual design.

## Scope

- `src/index.css`: change the standalone shell from `100lvh` to `100dvh` and update the explanatory comment.
- User-visible behavior: bottom action buttons remain inside the visible installed-app viewport.
- No unrelated files or behavior changed.

## Verification

- Focused `ButtonsOnBottom` tests: 2 passed.
- Prettier check: passed.
- ESLint pre-commit hook: passed.
- Production Vite build: passed.
- Responsive checks at 393×852, 375×667, and 768×1024 kept the shared footer fully visible.
- The temporary HTTPS phone-testing origin loaded the actual Arkade Wallet app.
- Installed standalone-device verification was skipped at the requester's direction; reviewer/device confirmation remains recommended.

## Visual proof

Post-change Send screen at 393×852, showing the shared Continue action fully inside the viewport:

<img width="393" height="852" alt="Post-change Send screen with Continue button visible" src="https://github.com/user-attachments/assets/bcd3ec66-1ac4-4b52-8e01-c93bdc9dbb4a" />
