### PR TITLE
Improve QR scanner camera error handling and UX

### DIFF
--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -7,6 +7,7 @@ import Padded from './Padded'
 import { QRCanvas, frameLoop, frontalCamera } from 'qr/dom.js'
 import { useRef, useEffect, useState } from 'react'
 import { extractError } from '../lib/error'
+import { cameraErrorText, queryCameraPermission } from '../lib/camera'
 import QrScanner from 'qr-scanner'
 
 const videoStyle: React.CSSProperties = {
@@ -105,41 +106,37 @@ function ScannerMills({ close, label, onData, onError, onSwitch }: ScannerProps)
 }
 
 function ScannerQr({ calculateScanRegion, close, label, onData, onError, onSwitch }: ScannerProps) {
-  const [error, setError] = useState(false)
-  const [hasCamera, setHasCamera] = useState(false)
+  const [error, setError] = useState('')
+  const [attempt, setAttempt] = useState(0)
 
   const videoRef = useRef<HTMLVideoElement>(null)
   const qrScanner = useRef<QrScanner | null>(null)
 
   useEffect(() => {
-    QrScanner.hasCamera().then(setHasCamera)
-  }, [])
-
-  useEffect(() => {
-    if (!hasCamera) return
     if (!videoRef.current) return
-    if (!qrScanner.current) {
-      qrScanner.current = new QrScanner(
-        videoRef.current,
-        (result) => {
-          onData(result.data)
-          handleClose()
-        },
-        {
-          maxScansPerSecond: 100,
-          highlightScanRegion: true,
-          highlightCodeOutline: true,
-          onDecodeError: () => {},
-          calculateScanRegion,
-        },
-      )
-    }
-    qrScanner.current.start().catch((err) => {
-      onError(extractError(err))
-      setError(true)
+    qrScanner.current = new QrScanner(
+      videoRef.current,
+      (result) => {
+        onData(result.data)
+        handleClose()
+      },
+      {
+        maxScansPerSecond: 100,
+        highlightScanRegion: true,
+        highlightCodeOutline: true,
+        onDecodeError: () => {},
+        calculateScanRegion,
+      },
+    )
+    qrScanner.current.start().catch(async () => {
+      // qr-scanner throws the same 'Camera not found.' whatever went wrong,
+      // so the permission is what tells us if the user blocked the camera
+      const text = cameraErrorText(await queryCameraPermission())
+      onError(text)
+      setError(text)
     })
     return () => stopScan()
-  }, [hasCamera])
+  }, [attempt])
 
   const stopScan = () => {
     qrScanner.current?.destroy()
@@ -149,6 +146,14 @@ function ScannerQr({ calculateScanRegion, close, label, onData, onError, onSwitc
   const handleClose = () => {
     stopScan()
     close()
+  }
+
+  // re-prompts if the prompt was only dismissed, and picks up a permission
+  // the user has just unblocked in the browser settings
+  const handleRetry = () => {
+    onError('')
+    setError('')
+    setAttempt(attempt + 1)
   }
 
   const handleSwitch = () => {
@@ -161,14 +166,13 @@ function ScannerQr({ calculateScanRegion, close, label, onData, onError, onSwitc
       <Header auxFunc={handleSwitch} auxText={calculateScanRegion ? 'q' : 'Q'} text={label} back={handleClose} />
       <Content>
         <Padded>
-          <ErrorMessage error={error} text='Camera not available' />
-          <div id='video-wrapper'>
-            <video id='qr-scanner' ref={videoRef} style={videoStyle} />
-          </div>
+          <ErrorMessage error={Boolean(error)} text={error} />
+          <div id='video-wrapper'>{error ? null : <video id='qr-scanner' ref={videoRef} style={videoStyle} />}</div>
         </Padded>
       </Content>
       <ButtonsOnBottom>
-        <Button onClick={handleClose} label='Cancel' />
+        {error ? <Button onClick={handleRetry} label='Try again' /> : null}
+        <Button onClick={handleClose} label='Cancel' secondary={Boolean(error)} />
       </ButtonsOnBottom>
     </>
   )

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -128,14 +128,19 @@ function ScannerQr({ calculateScanRegion, close, label, onData, onError, onSwitc
         calculateScanRegion,
       },
     )
+    let cancelled = false
     qrScanner.current.start().catch(async () => {
       // qr-scanner throws the same 'Camera not found.' whatever went wrong,
       // so the permission is what tells us if the user blocked the camera
       const text = cameraErrorText(await queryCameraPermission())
+      if (cancelled) return
       onError(text)
       setError(text)
     })
-    return () => stopScan()
+    return () => {
+      cancelled = true
+      stopScan()
+    }
   }, [attempt])
 
   const stopScan = () => {

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -153,7 +153,7 @@ function ScannerQr({ calculateScanRegion, close, label, onData, onError, onSwitc
   const handleRetry = () => {
     onError('')
     setError('')
-    setAttempt(attempt + 1)
+    setAttempt((n) => n + 1)
   }
 
   const handleSwitch = () => {

--- a/src/lib/camera.ts
+++ b/src/lib/camera.ts
@@ -1,5 +1,3 @@
-import { consoleError } from './logs'
-
 /**
  * qr-scanner reports every start failure as 'Camera not found.', so a camera the
  * user blocked is indistinguishable from a missing one unless we ask the permission.
@@ -8,10 +6,9 @@ export const queryCameraPermission = async (): Promise<PermissionState> => {
   try {
     // Chromium browsers and Safari answer this
     return (await navigator.permissions.query({ name: 'camera' as PermissionName })).state
-  } catch (err) {
-    // Firefox lands here because 'camera' is unsupported in query()
-    consoleError(err, 'error querying camera permission')
-    // we assume 'prompt' status, we only know the camera did not start
+  } catch {
+    // Firefox lands here because 'camera' is unsupported in query(), which is
+    // routine and not worth logging: we assume 'prompt' and say the less of the two
     return 'prompt'
   }
 }

--- a/src/lib/camera.ts
+++ b/src/lib/camera.ts
@@ -1,0 +1,22 @@
+import { consoleError } from './logs'
+
+/**
+ * qr-scanner reports every start failure as 'Camera not found.', so a camera the
+ * user blocked is indistinguishable from a missing one unless we ask the permission.
+ */
+export const queryCameraPermission = async (): Promise<PermissionState> => {
+  try {
+    // Chromium browsers and Safari answer this
+    return (await navigator.permissions.query({ name: 'camera' as PermissionName })).state
+  } catch (err) {
+    // Firefox lands here because 'camera' is unsupported in query()
+    consoleError(err, 'error querying camera permission')
+    // we assume 'prompt' status, we only know the camera did not start
+    return 'prompt'
+  }
+}
+
+export const cameraErrorText = (permission: PermissionState): string =>
+  permission === 'denied'
+    ? 'Camera access is blocked. Allow it for this site in your browser settings, then try again.'
+    : 'Camera not available'

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -946,23 +946,19 @@ export default function SendForm() {
     )
   }
 
-  const Scan = () => (
-    <Scanner
-      close={() => setScan(false)}
-      label='Recipient address'
-      onData={(data) => {
-        setRecipient(data)
-        setRawScanData(data)
-        setReadyToParse(true)
-      }}
-      onError={smartSetError}
-    />
-  )
-
   if (scan) {
     return prefersReducedMotion ? (
       <div style={sendOverlayStyle}>
-        <Scan />
+        <Scanner
+          close={() => setScan(false)}
+          label='Recipient address'
+          onData={(data) => {
+            setRecipient(data)
+            setRawScanData(data)
+            setReadyToParse(true)
+          }}
+          onError={smartSetError}
+        />
       </div>
     ) : (
       <AnimatePresence>
@@ -974,7 +970,16 @@ export default function SendForm() {
           exit='exit'
           style={sendOverlayStyle}
         >
-          <Scan />
+          <Scanner
+            close={() => setScan(false)}
+            label='Recipient address'
+            onData={(data) => {
+              setRecipient(data)
+              setRawScanData(data)
+              setReadyToParse(true)
+            }}
+            onError={smartSetError}
+          />
         </motion.div>{' '}
       </AnimatePresence>
     )

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -947,19 +947,22 @@ export default function SendForm() {
   }
 
   if (scan) {
+    // an element, never a component defined here: a fresh component type on
+    // every render remounts the scanner, and each remount asks for the camera
+    const scanner = (
+      <Scanner
+        close={() => setScan(false)}
+        label='Recipient address'
+        onData={(data) => {
+          setRecipient(data)
+          setRawScanData(data)
+          setReadyToParse(true)
+        }}
+        onError={smartSetError}
+      />
+    )
     return prefersReducedMotion ? (
-      <div style={sendOverlayStyle}>
-        <Scanner
-          close={() => setScan(false)}
-          label='Recipient address'
-          onData={(data) => {
-            setRecipient(data)
-            setRawScanData(data)
-            setReadyToParse(true)
-          }}
-          onError={smartSetError}
-        />
-      </div>
+      <div style={sendOverlayStyle}>{scanner}</div>
     ) : (
       <AnimatePresence>
         <motion.div
@@ -970,16 +973,7 @@ export default function SendForm() {
           exit='exit'
           style={sendOverlayStyle}
         >
-          <Scanner
-            close={() => setScan(false)}
-            label='Recipient address'
-            onData={(data) => {
-              setRecipient(data)
-              setRawScanData(data)
-              setReadyToParse(true)
-            }}
-            onError={smartSetError}
-          />
+          {scanner}
         </motion.div>{' '}
       </AnimatePresence>
     )

--- a/src/test/components/Scanner.test.tsx
+++ b/src/test/components/Scanner.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ToastProvider } from '../../components/Toast'
 import Scanner from '../../components/Scanner'
@@ -26,12 +26,19 @@ vi.mock('../../lib/haptics', () => ({
   setHapticsEnabled: vi.fn(),
 }))
 
+const realPermissions = Object.getOwnPropertyDescriptor(navigator, 'permissions')
+
 const mockCameraPermission = (state: PermissionState) => {
   Object.defineProperty(navigator, 'permissions', {
     configurable: true,
     value: { query: async () => ({ state }) },
   })
 }
+
+afterEach(() => {
+  if (realPermissions) Object.defineProperty(navigator, 'permissions', realPermissions)
+  else delete (navigator as any).permissions
+})
 
 const renderScanner = (onError = vi.fn()) => {
   render(

--- a/src/test/components/Scanner.test.tsx
+++ b/src/test/components/Scanner.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ToastProvider } from '../../components/Toast'
+import Scanner from '../../components/Scanner'
+
+const start = vi.fn()
+
+vi.mock('qr-scanner', () => ({
+  default: class {
+    start = start
+    destroy = vi.fn()
+  },
+}))
+
+// alternative implementation behind the header switch, never reached here
+vi.mock('qr/dom.js', () => ({
+  QRCanvas: class {},
+  frameLoop: () => () => {},
+  frontalCamera: async () => ({}),
+}))
+
+vi.mock('../../lib/haptics', () => ({
+  hapticLight: vi.fn(),
+  hapticSubtle: vi.fn(),
+  hapticTap: vi.fn(),
+  setHapticsEnabled: vi.fn(),
+}))
+
+const mockCameraPermission = (state: PermissionState) => {
+  Object.defineProperty(navigator, 'permissions', {
+    configurable: true,
+    value: { query: async () => ({ state }) },
+  })
+}
+
+const renderScanner = (onError = vi.fn()) => {
+  render(
+    <ToastProvider>
+      <Scanner close={vi.fn()} label='Recipient address' onData={vi.fn()} onError={onError} />
+    </ToastProvider>,
+  )
+  return onError
+}
+
+describe('Scanner', () => {
+  beforeEach(() => {
+    start.mockReset()
+    // whatever the reason, qr-scanner fails with this
+    start.mockRejectedValue('Camera not found.')
+  })
+
+  it('tells the user the camera is blocked and offers a way back in', async () => {
+    mockCameraPermission('denied')
+    const onError = renderScanner()
+
+    expect(await screen.findByTestId('error-message')).toHaveTextContent(/blocked/i)
+    expect(onError).toHaveBeenCalledWith(expect.stringMatching(/blocked/i))
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('does not blame the permission when the camera is merely unavailable', async () => {
+    mockCameraPermission('granted')
+    renderScanner()
+
+    expect(await screen.findByTestId('error-message')).toHaveTextContent('Camera not available')
+  })
+
+  it('starts the camera again when the user retries', async () => {
+    mockCameraPermission('denied')
+    renderScanner()
+
+    const retry = await screen.findByRole('button', { name: 'Try again' })
+    start.mockResolvedValue(undefined)
+    fireEvent.click(retry)
+
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(2))
+    expect(screen.queryByTestId('error-message')).not.toBeInTheDocument()
+  })
+})

--- a/src/test/components/Scanner.test.tsx
+++ b/src/test/components/Scanner.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ToastProvider } from '../../components/Toast'
 import Scanner from '../../components/Scanner'
 
@@ -40,13 +40,14 @@ afterEach(() => {
   else delete (navigator as any).permissions
 })
 
-const renderScanner = (onError = vi.fn()) => {
-  render(
+const renderScanner = () => {
+  const onError = vi.fn()
+  const { unmount } = render(
     <ToastProvider>
       <Scanner close={vi.fn()} label='Recipient address' onData={vi.fn()} onError={onError} />
     </ToastProvider>,
   )
-  return onError
+  return { onError, unmount }
 }
 
 describe('Scanner', () => {
@@ -58,7 +59,7 @@ describe('Scanner', () => {
 
   it('tells the user the camera is blocked and offers a way back in', async () => {
     mockCameraPermission('denied')
-    const onError = renderScanner()
+    const { onError } = renderScanner()
 
     expect(await screen.findByTestId('error-message')).toHaveTextContent(/blocked/i)
     expect(onError).toHaveBeenCalledWith(expect.stringMatching(/blocked/i))
@@ -82,5 +83,22 @@ describe('Scanner', () => {
 
     await waitFor(() => expect(start).toHaveBeenCalledTimes(2))
     expect(screen.queryByTestId('error-message')).not.toBeInTheDocument()
+  })
+
+  it('says nothing to a screen the user has already left', async () => {
+    // the permission answer arrives after the user gives up and closes the scanner
+    let answer: (result: { state: PermissionState }) => void = () => {}
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: { query: () => new Promise((resolve) => (answer = resolve)) },
+    })
+    const { onError, unmount } = renderScanner()
+
+    await waitFor(() => expect(start).toHaveBeenCalled())
+    unmount()
+    answer({ state: 'denied' })
+    await act(async () => {})
+
+    expect(onError).not.toHaveBeenCalled()
   })
 })

--- a/src/test/lib/camera.test.ts
+++ b/src/test/lib/camera.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { cameraErrorText, queryCameraPermission } from '../../lib/camera'
+
+const realPermissions = Object.getOwnPropertyDescriptor(navigator, 'permissions')
 
 const mockPermissions = (query: () => Promise<{ state: PermissionState }>) => {
   Object.defineProperty(navigator, 'permissions', { configurable: true, value: { query } })
 }
+
+afterEach(() => {
+  if (realPermissions) Object.defineProperty(navigator, 'permissions', realPermissions)
+  else delete (navigator as any).permissions
+})
 
 describe('camera permission', () => {
   it('reports the state the browser gives us', async () => {

--- a/src/test/lib/camera.test.ts
+++ b/src/test/lib/camera.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { cameraErrorText, queryCameraPermission } from '../../lib/camera'
+
+const mockPermissions = (query: () => Promise<{ state: PermissionState }>) => {
+  Object.defineProperty(navigator, 'permissions', { configurable: true, value: { query } })
+}
+
+describe('camera permission', () => {
+  it('reports the state the browser gives us', async () => {
+    mockPermissions(async () => ({ state: 'denied' }))
+    expect(await queryCameraPermission()).toBe('denied')
+  })
+
+  it('assumes prompt where the camera permission cannot be queried', async () => {
+    mockPermissions(async () => {
+      throw new TypeError("'camera' is not a valid permission name")
+    })
+    expect(await queryCameraPermission()).toBe('prompt')
+  })
+
+  it('tells a user who blocked the camera how to unblock it', () => {
+    expect(cameraErrorText('denied')).toMatch(/browser settings/)
+  })
+
+  it('does not blame the permission when the camera is merely unavailable', () => {
+    expect(cameraErrorText('prompt')).toBe('Camera not available')
+    expect(cameraErrorText('granted')).toBe('Camera not available')
+  })
+})


### PR DESCRIPTION
## Summary
Enhanced the QR scanner's camera error handling to distinguish between blocked camera permissions and unavailable cameras, providing users with more helpful error messages and recovery options.

## Key Changes
- **New camera permission utilities** (`src/lib/camera.ts`): Added `queryCameraPermission()` to detect the actual camera permission state and `cameraErrorText()` to generate appropriate error messages based on permission status
- **Improved error state management**: Changed error state from boolean to string to display contextual error messages
- **Better user recovery flow**: 
  - Added "Try again" button when camera access fails, allowing users to retry after unblocking permissions
  - Hides video element when error occurs
  - Clears error state on retry attempt
- **Smarter error detection**: Since qr-scanner reports all failures as "Camera not found.", the code now queries the Permissions API to determine if the user blocked access vs. the camera being unavailable
- **Comprehensive test coverage**: Added unit tests for camera permission detection and integration tests for Scanner component error scenarios

## Implementation Details
- The `queryCameraPermission()` function gracefully handles browsers that don't support camera permission queries (like Firefox) by defaulting to 'prompt' status
- Error retry logic uses an `attempt` counter to trigger re-initialization of the QR scanner
- Button layout adapts based on error state: shows "Try again" when error occurs, "Cancel" becomes secondary
- Tests mock the qr-scanner library and camera permissions API to verify error handling paths

https://claude.ai/code/session_01RJPVarPXaWDBNU8paKJazx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved QR scanner recovery when camera access fails.
  - Added clearer messages for blocked permissions versus unavailable cameras.
  - Prevented unnecessary scanner resets while sending.
  - Added “Try again” and “Cancel” actions when scanning errors occur.
  - Scanner now hides the camera view while displaying an error and can recover successfully after retrying.

- **Tests**
  - Added coverage for camera permissions, error states, retry behavior, and successful recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->