### PR TITLE
fix(pwa): cover success splash safe areas

### DIFF
--- a/src/components/WalletSuccessSplash.tsx
+++ b/src/components/WalletSuccessSplash.tsx
@@ -1,9 +1,14 @@
 import { AnimatePresence, motion } from 'framer-motion'
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import SuccessIcon from '../icons/Success'
 import { EASE_OUT_QUINT_TUPLE } from '../lib/animations'
+import { activateDocumentSurface } from '../lib/documentSurface'
 import { hapticLight } from '../lib/haptics'
 import { useReducedMotion } from '../hooks/useReducedMotion'
+
+const SUCCESS_SURFACE_CLASS = 'wallet-success-surface-active'
+const SUCCESS_THEME_COLOR = '#5528d4'
 
 interface WalletSuccessSplashProps {
   show?: boolean
@@ -21,32 +26,40 @@ export default function WalletSuccessSplash({
   onDone,
 }: WalletSuccessSplashProps) {
   const prefersReduced = useReducedMotion()
+  const releaseSurfaceRef = useRef<(() => void) | undefined>()
+
   useEffect(() => {
     if (show) hapticLight()
   }, [show])
 
-  // The splash must read full-bleed: the OS bars around it (Android PWA
-  // status/nav bars, iOS status-bar backdrop) are painted from the
-  // theme-color meta, which is white in light mode — leaving white bands
-  // above and below the purple. Match it to the splash while shown.
-  useEffect(() => {
-    if (!show) return
-    const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
-    if (!meta) return
-    const previous = meta.getAttribute('content')
-    meta.setAttribute('content', '#5528d4') // --purple-600, the gradient's top
-    return () => {
-      if (previous) meta.setAttribute('content', previous)
-    }
+  useLayoutEffect(() => {
+    if (!show || releaseSurfaceRef.current) return
+    releaseSurfaceRef.current = activateDocumentSurface({
+      className: SUCCESS_SURFACE_CLASS,
+      themeColor: SUCCESS_THEME_COLOR,
+    })
   }, [show])
+
+  useLayoutEffect(
+    () => () => {
+      releaseSurfaceRef.current?.()
+      releaseSurfaceRef.current = undefined
+    },
+    [],
+  )
+
+  const releaseSurface = () => {
+    releaseSurfaceRef.current?.()
+    releaseSurfaceRef.current = undefined
+  }
 
   const handleDone = () => {
     hapticLight()
     onDone()
   }
 
-  return (
-    <AnimatePresence>
+  return createPortal(
+    <AnimatePresence onExitComplete={releaseSurface}>
       {show ? (
         <motion.button
           type='button'
@@ -79,6 +92,7 @@ export default function WalletSuccessSplash({
           </motion.span>
         </motion.button>
       ) : null}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,18 @@ body::before {
   pointer-events: none;
 }
 
+/* Full-bleed success surfaces are portaled to body, outside the safe-area page
+   shell. Paint the document canvas as a fallback for PWA system areas that sit
+   beyond the dynamic viewport. */
+html.wallet-success-surface-active,
+html.wallet-success-surface-active body {
+  background-color: var(--purple-800);
+}
+
+html.wallet-success-surface-active body::before {
+  background-color: var(--purple-600);
+}
+
 body {
   margin: 0;
   font-family:
@@ -3927,14 +3939,16 @@ html.palette-dark .settings-row--danger .settings-row__chevron {
 .wallet-success-splash {
   position: fixed;
   inset: 0;
-  /* above the body::before status-bar backdrop strip (99999), which would
-   * otherwise paint a theme-colored band over the splash's safe-area top */
+  /* Portaled to body so fixed positioning resolves against the viewport and
+   * this root-level z-index sits above the status-bar backdrop strip. */
   z-index: 100000;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 1.25rem;
+  padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px)
+    env(safe-area-inset-left, 0px);
   border: 0;
   background:
     radial-gradient(circle at 50% 34%, color-mix(in srgb, var(--purple-500) 28%, transparent), transparent 32%),

--- a/src/lib/documentSurface.ts
+++ b/src/lib/documentSurface.ts
@@ -1,0 +1,62 @@
+interface DocumentSurfaceOptions {
+  className?: string
+  themeColor?: string
+}
+
+interface ActiveDocumentSurface extends DocumentSurfaceOptions {
+  id: symbol
+}
+
+const activeSurfaces: ActiveDocumentSurface[] = []
+let baseThemeColor: string | null | undefined
+let initialThemeColor: string | null | undefined
+
+const getThemeColorMeta = () =>
+  typeof document === 'undefined' ? null : document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+
+const captureInitialThemeColor = () => {
+  if (initialThemeColor !== undefined) return
+  initialThemeColor = getThemeColorMeta()?.getAttribute('content') ?? null
+}
+
+const applyThemeColor = () => {
+  const meta = getThemeColorMeta()
+  if (!meta) return
+
+  const override = [...activeSurfaces].reverse().find((surface) => surface.themeColor)?.themeColor
+  const nextThemeColor = override ?? baseThemeColor ?? initialThemeColor
+
+  if (nextThemeColor === null) meta.removeAttribute('content')
+  else if (nextThemeColor !== undefined) meta.setAttribute('content', nextThemeColor)
+}
+
+export const setDocumentThemeColor = (themeColor: string) => {
+  captureInitialThemeColor()
+  baseThemeColor = themeColor
+  applyThemeColor()
+}
+
+export const activateDocumentSurface = ({ className, themeColor }: DocumentSurfaceOptions) => {
+  if (typeof document === 'undefined') return () => {}
+
+  captureInitialThemeColor()
+  const surface: ActiveDocumentSurface = { id: Symbol('document-surface'), className, themeColor }
+  activeSurfaces.push(surface)
+
+  if (className) document.documentElement.classList.add(className)
+  applyThemeColor()
+
+  let active = true
+  return () => {
+    if (!active) return
+    active = false
+
+    const index = activeSurfaces.findIndex(({ id }) => id === surface.id)
+    if (index !== -1) activeSurfaces.splice(index, 1)
+
+    if (className && !activeSurfaces.some((entry) => entry.className === className)) {
+      document.documentElement.classList.remove(className)
+    }
+    applyThemeColor()
+  }
+}

--- a/src/providers/config.tsx
+++ b/src/providers/config.tsx
@@ -5,6 +5,7 @@ import { Config, Currencies, Themes, Unit } from '../lib/types'
 import { normalizeBitcoinUnit } from '../lib/format'
 import { setHapticsEnabled } from '../lib/haptics'
 import { getCurrency } from '@/lib/language'
+import { setDocumentThemeColor } from '../lib/documentSurface'
 
 const defaultConfig: Config = {
   announcementsSeen: [],
@@ -103,7 +104,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
     else root.classList.remove(darkPalette)
 
     const themeColor = resolved === Themes.Dark ? '#101010' : '#fff'
-    document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')?.setAttribute('content', themeColor)
+    setDocumentThemeColor(themeColor)
   }
 
   // TODO: the full-object contract is a stale-closure hazard — a caller that

--- a/src/test/components/WalletSuccessSplash.test.tsx
+++ b/src/test/components/WalletSuccessSplash.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import WalletSuccessSplash from '../../components/WalletSuccessSplash'
+import { setDocumentThemeColor } from '../../lib/documentSurface'
+import { hapticLight } from '../../lib/haptics'
+
+vi.mock('../../lib/haptics', () => ({
+  hapticLight: vi.fn(),
+}))
+
+const reducedMotionMatchMedia = (query: string): MediaQueryList =>
+  ({
+    matches: query === '(prefers-reduced-motion: reduce)',
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }) as unknown as MediaQueryList
+
+const regularMotionMatchMedia = (query: string): MediaQueryList =>
+  ({
+    ...reducedMotionMatchMedia(query),
+    matches: false,
+  }) as MediaQueryList
+
+describe('WalletSuccessSplash', () => {
+  let themeColorMeta: HTMLMetaElement
+
+  beforeEach(() => {
+    window.matchMedia = vi.fn(reducedMotionMatchMedia)
+    vi.mocked(hapticLight).mockClear()
+    themeColorMeta = document.createElement('meta')
+    themeColorMeta.name = 'theme-color'
+    document.head.append(themeColorMeta)
+    setDocumentThemeColor('#fff')
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.documentElement.classList.remove('wallet-success-surface-active')
+    themeColorMeta.remove()
+  })
+
+  it('portals the splash outside the page container and owns the document surface', () => {
+    const pageContainer = document.createElement('div')
+    document.body.append(pageContainer)
+
+    const { unmount } = render(
+      <WalletSuccessSplash
+        headline='Payment sent'
+        text='1,000 sats sent successfully'
+        ariaLabel='Payment sent successfully. Tap to go home.'
+        onDone={vi.fn()}
+      />,
+      { container: pageContainer },
+    )
+
+    const splash = screen.getByRole('button', { name: 'Payment sent successfully. Tap to go home.' })
+    expect(splash.parentElement).toBe(document.body)
+    expect(pageContainer).not.toContainElement(splash)
+    expect(document.documentElement).toHaveClass('wallet-success-surface-active')
+    expect(themeColorMeta).toHaveAttribute('content', '#5528d4')
+
+    unmount()
+    expect(document.documentElement).not.toHaveClass('wallet-success-surface-active')
+    expect(themeColorMeta).toHaveAttribute('content', '#fff')
+    pageContainer.remove()
+  })
+
+  it('keeps the document surface active through exit and releases it afterwards', async () => {
+    window.matchMedia = vi.fn(regularMotionMatchMedia)
+    const { rerender } = render(
+      <WalletSuccessSplash
+        show
+        headline='Payment received'
+        ariaLabel='Payment received successfully. Tap to go home.'
+        onDone={vi.fn()}
+      />,
+    )
+
+    rerender(
+      <WalletSuccessSplash
+        show={false}
+        headline='Payment received'
+        ariaLabel='Payment received successfully. Tap to go home.'
+        onDone={vi.fn()}
+      />,
+    )
+
+    expect(document.documentElement).toHaveClass('wallet-success-surface-active')
+    await waitFor(() => expect(document.documentElement).not.toHaveClass('wallet-success-surface-active'))
+    expect(themeColorMeta).toHaveAttribute('content', '#fff')
+  })
+
+  it('dismisses from the portaled button', () => {
+    const onDone = vi.fn()
+    render(<WalletSuccessSplash headline='Swap created' ariaLabel='Swap created. Tap to go home.' onDone={onDone} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Swap created. Tap to go home.' }))
+
+    expect(onDone).toHaveBeenCalledOnce()
+    expect(hapticLight).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/test/lib/documentSurface.test.ts
+++ b/src/test/lib/documentSurface.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { activateDocumentSurface, setDocumentThemeColor } from '../../lib/documentSurface'
+
+describe('document surface', () => {
+  let themeColorMeta: HTMLMetaElement
+
+  beforeEach(() => {
+    themeColorMeta = document.createElement('meta')
+    themeColorMeta.name = 'theme-color'
+    themeColorMeta.content = '#fff'
+    document.head.append(themeColorMeta)
+    setDocumentThemeColor('#fff')
+  })
+
+  afterEach(() => {
+    document.documentElement.classList.remove('test-surface', 'first-surface', 'second-surface')
+    themeColorMeta.remove()
+  })
+
+  it('keeps an active surface override when the base theme changes', () => {
+    const release = activateDocumentSurface({ className: 'test-surface', themeColor: '#5528d4' })
+
+    expect(document.documentElement).toHaveClass('test-surface')
+    expect(themeColorMeta).toHaveAttribute('content', '#5528d4')
+
+    setDocumentThemeColor('#101010')
+    expect(themeColorMeta).toHaveAttribute('content', '#5528d4')
+
+    release()
+    expect(document.documentElement).not.toHaveClass('test-surface')
+    expect(themeColorMeta).toHaveAttribute('content', '#101010')
+  })
+
+  it('supports nested surfaces and cleanup in any order', () => {
+    const releaseFirst = activateDocumentSurface({ className: 'first-surface', themeColor: '#111111' })
+    const releaseSecond = activateDocumentSurface({ className: 'second-surface', themeColor: '#222222' })
+
+    expect(themeColorMeta).toHaveAttribute('content', '#222222')
+    expect(document.documentElement).toHaveClass('first-surface', 'second-surface')
+
+    releaseFirst()
+    expect(document.documentElement).not.toHaveClass('first-surface')
+    expect(document.documentElement).toHaveClass('second-surface')
+    expect(themeColorMeta).toHaveAttribute('content', '#222222')
+
+    releaseSecond()
+    expect(document.documentElement).not.toHaveClass('second-surface')
+    expect(themeColorMeta).toHaveAttribute('content', '#fff')
+  })
+})


### PR DESCRIPTION
## What changed

- Render the shared wallet success splash through a `document.body` portal so its fixed positioning and z-index resolve at the document root.
- Add document-surface ownership for temporary HTML classes and theme-color overrides, including nested surfaces and out-of-order cleanup.
- Paint the document canvas and iOS status-bar backdrop while the splash is active, with safe-area insets applied as internal content padding.
- Keep the surface active through the exit animation, then restore the current light or dark theme.
- Add regression coverage for portal placement, cleanup, theme changes, nested ownership, exit behavior, and dismissal.

## Root cause

`WalletSuccessSplash` was fixed-positioned inside `.page` and `PageTransition`. Their containment and transform-related styles create a bounded containing/stacking context, so the splash covered the page rather than the viewport and could not escape the page's root-level z-index. The page also begins below the top safe-area inset, while the document canvas and status-bar backdrop retained the normal light background.

Changing only `theme-color` could influence browser chrome, but it could not move the overlay out of that containing block or paint the HTML/body canvas. It could also be overwritten by a concurrent application-theme update.

Because send, receive, and swap success states share this component, correcting the shared document surface fixes all three flows without per-screen offsets.

## Validation

- `pnpm test:unit` — 78 files passed; 621 tests passed, 1 existing skip
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`
- Mobile Chrome PWA smoke test against the local Vite server

Manual verification in an installed iOS PWA remains pending.