### PR TITLE
Activity Phase 4: group every RFQ swap, and call a lost receive lost

### DIFF
--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -57,7 +57,13 @@ const TransactionLine = ({
   const iconTone =
     tx.preconfirmed && tx.boardingTxid
       ? 'pending'
-      : burn || swapStatus === 'failed' || swapStatus === 'cancelled' || lnSwapOutcome === 'failed'
+      : // `lost` earns the same tone as `failed`: on a receive leg the covenant
+        // going back means the payment never arrived, so it is money gone.
+        burn ||
+          swapStatus === 'failed' ||
+          swapStatus === 'cancelled' ||
+          lnSwapOutcome === 'failed' ||
+          lnSwapOutcome === 'lost'
         ? 'burn'
         : swapStatus === 'pending' || lnSwapOutcome === 'pending'
           ? 'pending'

--- a/src/lib/activityHistory.ts
+++ b/src/lib/activityHistory.ts
@@ -1,4 +1,5 @@
 import type { Activity } from '@arkade-os/sdk'
+import { isRfqSwapTerminal } from '@arkade-os/swap'
 import { ASSET_SWAP_ACTIVITY_KIND } from './activity/assetSwapResolver'
 import { consoleError } from './logs'
 import type { TransactionActivityMetadata } from './storage'
@@ -13,7 +14,9 @@ export interface ActivityHistoryOptions {
   swaps: WalletAssetSwap[]
   /** The Lightning sends, as stored. `RfqSwapManager` owns their state; this
    * is the read side of it, and the only source of a row's outcome detail and
-   * of the receipt's second txid. */
+   * of the receipt's second txid — and, for a send Arkade's history does not
+   * report at all, the only source of the row itself. See
+   * `ungroupedLnSendTx`. */
   lnSends?: LnSendView[]
   /** Snapshot taken alongside the activity fetch. Never read in here: this
    * runs in a `useMemo`, so a `localStorage` read would be an undeclared dep. */
@@ -47,6 +50,11 @@ const swapIdOf = (activity: Activity): string | undefined =>
  * is `swapKind`, never the group id, since both namespaces are `swap:`. */
 const rfqSwapKindOf = (activity: Activity): string | undefined =>
   activity.intent?.metadata?.swapKind as string | undefined
+
+/** Which swap a group belongs to, by the resolver's own metadata. The group id
+ * says the same thing, but only by string surgery on a namespace the package
+ * owns. */
+const rfqIdOf = (activity: Activity): string | undefined => activity.intent?.metadata?.rfqId as string | undefined
 
 /**
  * One row for a Lightning send: its funding tx, plus the refund when the swap
@@ -122,6 +130,68 @@ const lightningReceiveTx = (
   }
 }
 
+/**
+ * One row for a Lightning send Arkade's own history does not report.
+ *
+ * **Why any send is missing at all.** Funding the lockup is an ordinary Arkade
+ * transaction, but the covenant it pays is a contract THIS wallet registered
+ * (`registerLockupContract`), so `buildTransactionHistory` sees the lockup
+ * output among the wallet's own outputs and counts it as change. Funding minus
+ * change is then zero on a corridor with no fee, and a zero-amount movement is
+ * not emitted — so the transaction that committed the money produces no row,
+ * and nothing appears until a SECOND transaction spends the lockup. That second
+ * transaction is the solver's claim, which lands only once the invoice is
+ * actually paid — a wait the payer does not control and that can outlast the
+ * app being open. The payment was in flight the whole time with nothing on
+ * screen to say so.
+ *
+ * So the record answers for it. It holds what history has lost — the amount,
+ * the funding txid, the time, the state — and it is written before the refresh
+ * that rebuilds this list, so the row is there on the first render after
+ * signing.
+ *
+ * Emitted only for a send no group covers. Once the lockup is spent the group
+ * exists and `lightningSendTx` builds the real row from the transactions
+ * themselves, under this same key, so the row is replaced rather than doubled.
+ * Terminal sends are kept for the same reason they are worth showing at all: a
+ * refund returns the money through a transaction that nets to zero the same
+ * way, so dropping them here would make a payment vanish from the list at the
+ * moment it came back.
+ */
+const ungroupedLnSendTx = (send: LnSendView, metadata: Record<string, TransactionActivityMetadata>): Tx =>
+  graftMetadata(
+    {
+      amount: send.amount,
+      boardingTxid: '',
+      createdAt: send.createdAt,
+      // Offchain: there is no on-chain transaction to open in an explorer.
+      explorable: undefined,
+      // The wallet's own send convention (see `arkTransactionToTx`): an
+      // outgoing Arkade transaction is final as soon as it is signed. What is
+      // pending here is the swap, and `outcome` is what says so.
+      preconfirmed: false,
+      redeemTxid: send.fundingTxid,
+      roundTxid: '',
+      settled: true,
+      type: 'sent',
+      lnSwap: {
+        // The same copy the package's resolver emits for this corridor, so a
+        // row does not rename itself when the group finally arrives.
+        label: 'Lightning send',
+        // `RFQ_SWAP_TERMINAL_STATES` and the resolver's outcome tokens are the
+        // same three words, which is what lets the state stand in for the
+        // token: everything short of an ending reads as pending.
+        outcome: isRfqSwapTerminal(send.state) ? send.state : 'pending',
+        fundingTxid: send.fundingTxid,
+        spendTxid: send.spendTxid,
+      },
+      // The group id the resolver would give this swap, so the key survives the
+      // handover to the real row.
+      historyKey: `swap:${send.rfqId}`,
+    },
+    metadata[send.fundingTxid],
+  )
+
 /** `Activity[]` -> the `Tx[]` the UI already reads. Pure and synchronous.
  *
  * Only groups we know how to collapse become a single row; everything else
@@ -170,6 +240,14 @@ export const activitiesToTxs = (activities: Activity[], options: ActivityHistory
       const txid = txidOfArkTransaction(tx)
       rows.push({ ...arkTransactionToTx(tx, metadata[txid]), historyKey: `${activity.id}:${txid}` })
     }
+  }
+  // The sends history cannot see, from the store that can — see
+  // `ungroupedLnSendTx`. Keyed on the rfq id rather than the funding txid: that
+  // is what the group carries, and a send whose funding tx IS in history is
+  // grouped by it.
+  const grouped = new Set(activities.flatMap((activity) => rfqIdOf(activity) ?? []))
+  for (const send of lnSends) {
+    if (!grouped.has(send.rfqId)) rows.push(ungroupedLnSendTx(send, metadata))
   }
   return sortLocalTxs(rows)
 }

--- a/src/lib/activityHistory.ts
+++ b/src/lib/activityHistory.ts
@@ -90,6 +90,38 @@ const lightningSendTx = (
   }
 }
 
+/**
+ * One row for a Lightning receive: the claim that paid us.
+ *
+ * The mirror of the send, minus the funding leg — on this corridor the SOLVER
+ * funds the lockup, so the only transaction of ours is the claim. That has a
+ * consequence worth stating: a receive that ended `refunded` has no transaction
+ * in this wallet's history at all, so it produces no group and therefore no
+ * row. The `lost` copy below is reachable only for a receive that got some of
+ * its money — a piecemeal funding we partly claimed — not for one that never
+ * arrived. Surfacing those is an activity-model question, not a row-builder
+ * one.
+ *
+ * No `fundingTxid` is set, deliberately: `useLnSendReceipt` keys the send
+ * receipt off exactly that field and returns undefined without it, which is
+ * what keeps a receive row from opening a receipt built for the other leg.
+ */
+const lightningReceiveTx = (
+  activity: Activity,
+  metadata: Record<string, TransactionActivityMetadata>,
+): Tx | undefined => {
+  const claim = activity.txs.find((tx) => tx.type === 'RECEIVED')
+  if (!claim) return undefined
+  const claimTxid = txidOfArkTransaction(claim)
+  return {
+    ...arkTransactionToTx(claim, metadata[claimTxid]),
+    amount: Math.abs(activity.amount),
+    type: activity.amount < 0 ? 'sent' : 'received',
+    lnSwap: { label: activity.intent?.label, outcome: activity.intent?.outcome },
+    historyKey: activity.id,
+  }
+}
+
 /** `Activity[]` -> the `Tx[]` the UI already reads. Pure and synchronous.
  *
  * Only groups we know how to collapse become a single row; everything else
@@ -99,7 +131,8 @@ export const activitiesToTxs = (activities: Activity[], options: ActivityHistory
   const { swaps, metadata, network, assetDisplay, lnSends = [] } = options
   const rows: Tx[] = []
   for (const activity of activities) {
-    if (rfqSwapKindOf(activity) === 'lightning_send') {
+    const swapKind = rfqSwapKindOf(activity)
+    if (swapKind === 'lightning_send') {
       const row = lightningSendTx(activity, metadata, lnSends)
       if (row) {
         rows.push(row)
@@ -108,6 +141,13 @@ export const activitiesToTxs = (activities: Activity[], options: ActivityHistory
       // No sent member means the record named a txid this history does not
       // have. Fall through rather than drop the group: whatever IS here is
       // still the user's money moving.
+    }
+    if (swapKind === 'lightning_receive') {
+      const row = lightningReceiveTx(activity, metadata)
+      if (row) {
+        rows.push(row)
+        continue
+      }
     }
     const swapId = swapIdOf(activity)
     const swap = swapId ? swaps.find((record) => record.id === swapId) : undefined

--- a/src/lib/lnSendRecords.ts
+++ b/src/lib/lnSendRecords.ts
@@ -242,6 +242,13 @@ export interface LnSendView {
   rfqId: string
   fundingTxid: string
   state: RfqSwapRecord['state']
+  /** Sats the lockup was funded with. The record is the only place this
+   * survives for a send Arkade's own history cannot see — see
+   * `ungroupedLnSendTx` in `activityHistory.ts`. */
+  amount: number
+  /** When the send was made, unix seconds — the same clock `Tx.createdAt` uses,
+   * so a row built from the record sorts beside rows built from history. */
+  createdAt: number
   /** The tx that ended it, when that tx is one of ours. */
   spendTxid?: string
 }
@@ -249,7 +256,14 @@ export interface LnSendView {
 const viewOf = (record: RfqSwapRecord): LnSendView | undefined => {
   const fundingTxid = fundingTxidOf(record)
   if (!fundingTxid) return undefined
-  return { rfqId: record.rfqId, fundingTxid, state: record.state, spendTxid: spendTxidOf(record) }
+  return {
+    rfqId: record.rfqId,
+    fundingTxid,
+    state: record.state,
+    amount: record.amount ?? 0,
+    createdAt: record.createdAt,
+    spendTxid: spendTxidOf(record),
+  }
 }
 
 /** The sends, for the row builder. */

--- a/src/lib/lnSendRecords.ts
+++ b/src/lib/lnSendRecords.ts
@@ -6,22 +6,29 @@
  * state on it — it reads the lockup's fate off the chain, pushes the refund
  * when the solver never acts, and calls back to persist — and everything the
  * wallet shows is derived from that: the activity grouping, the row's label,
- * the receipt's two txids. Anything this file adds is what the manager has no
- * field for, and there are exactly two of those, both under `profile`, which is
- * the corridor's own opaque half:
+ * the receipt's two txids.
  *
- * - `funding_txid`. The manager watches a lockup by its script and never needs
- *   to name the transaction that filled it; grouping correlates by txid and can
- *   do nothing else.
- * - `spend_txid`. `readLockupFate` answers `returned` without naming the
- *   transaction, and `refundArkTxid` is set only for a refund the wallet itself
- *   pushed — but the ordinary failure is the solver's own
- *   `nonInteractiveRefund`, which is neither, and whose row in our history is
- *   precisely what has to group with the funding tx.
+ * **This file used to add two keys of its own**, `funding_txid` and
+ * `spend_txid`, both under `profile`, because the manager had no field for
+ * either. ts-sdk#773 gave it both, so they are gone as things we WRITE:
  *
- * Safe keys to add: the lightning-send corridor handler's `project()` returns
- * `{}`, so nothing overwrites them, and its `hydrate` ignores what it does not
- * know.
+ * - `fundingArkTxid` is on the origin. The manager watches a lockup by its
+ *   script and still never needs the transaction that filled it, but the record
+ *   carries it now — and it has to, because grouping correlates by txid and
+ *   `rfqSwapActivityInputs` reads the record's own fields. The lightning-send
+ *   corridor has no `activityTxids`, so a funding txid under a wallet-private
+ *   profile key is a txid the resolver cannot see.
+ * - `lockupSpendArkTxids` is stamped by the manager at finalization, from the
+ *   chain read that ended the swap. That covers the ordinary failure — the
+ *   solver's own `nonInteractiveRefund`, which is neither a refund the wallet
+ *   pushed nor something `readLockupFate` named — which is exactly the gap
+ *   `spend_txid` existed to fill.
+ *
+ * Both old keys are still READ, so a store written by an earlier preview deploy
+ * keeps its receipts and its grouping. `funding_txid` is no longer written at
+ * all. `spend_txid` still is, but only as the fallback for a record the manager
+ * has not stamped — see `recordEnding` in `providers/lnSwaps.tsx`, which now
+ * checks the stamp before paying for an indexer lookup.
  */
 import type { IWallet, ProvisionedKey, VHTLC } from '@arkade-os/sdk'
 import {
@@ -36,6 +43,8 @@ import {
   updateRfqSwapRecord,
   type LockupContractReader,
   type PersistableRfqSwap,
+  rfqSwapActivityInputs,
+  type LockupSpendIndexer,
   type RfqSwapRecord,
   type SwapActivityInput,
 } from '@arkade-os/swap'
@@ -92,8 +101,13 @@ export const lnSendSwapRecord = (input: LnSendRecordInput, nowSeconds?: number):
     {
       kind: 'lightning_send',
       lockupAddress: input.lockupAddress,
-      profile: { ...rfqSecretsProfile(input.secrets, input.paymentHash), [FUNDING_TXID]: input.fundingTxid },
+      profile: rfqSecretsProfile(input.secrets, input.paymentHash),
       amount: input.amount,
+      // The record's OWN field, not a profile key of ours. `rfqSwapActivityInputs`
+      // reads this and never looks at `profile` for a send — the corridor handler
+      // has no `activityTxids` — so a funding txid parked under a wallet-private
+      // key groups nothing at all.
+      fundingArkTxid: input.fundingTxid,
     },
     lnSendSwap(input, nowSeconds),
   )
@@ -125,17 +139,28 @@ const profileTxid = (record: RfqSwapRecord, key: string): string | undefined => 
   return typeof txid === 'string' && txid ? txid : undefined
 }
 
-export const fundingTxidOf = (record: RfqSwapRecord): string | undefined => profileTxid(record, FUNDING_TXID)
+/**
+ * The tx that filled the lockup.
+ *
+ * `fundingArkTxid` is where it lives now. `funding_txid` is read only for
+ * records written before it moved there — a preview deploy's store, not a
+ * shape anything still writes.
+ */
+export const fundingTxidOf = (record: RfqSwapRecord): string | undefined =>
+  record.fundingArkTxid ?? profileTxid(record, FUNDING_TXID)
 
 /**
  * The tx that ended the swap, when it is one of ours.
  *
  * `refundArkTxid` first: a refund the wallet pushed is the manager's own fact,
- * written as the push lands. `spend_txid` is the fallback for the solver-pushed
- * refund the manager never names.
+ * written as the push lands. Then `lockupSpendArkTxids`, which the manager now
+ * stamps at finalization from the chain read that ended the swap — that is the
+ * ordinary case, the solver's own `nonInteractiveRefund`, which the wallet used
+ * to have to observe for itself. `spend_txid` survives as the back-compat read
+ * for records written before the manager stamped anything.
  */
 export const spendTxidOf = (record: RfqSwapRecord): string | undefined =>
-  record.refundArkTxid ?? profileTxid(record, SPEND_TXID)
+  record.refundArkTxid ?? record.lockupSpendArkTxids?.[0] ?? profileTxid(record, SPEND_TXID)
 
 /** Note the transaction that spent a lockup. A swap already carrying one is
  * left alone, so a re-observation cannot rewrite what was recorded first. */
@@ -238,29 +263,43 @@ export const lnSendViews = async (): Promise<LnSendView[]> => {
 }
 
 /**
- * The sends, as `swapActivityResolver` wants them.
+ * Every stored RFQ swap, as `swapActivityResolver` wants them.
  *
- * The spend is named only for a swap that came BACK. A settled send's spend is
- * the solver's claim: it pays the solver, so it is not in this wallet's history
- * and grouping against it would group nothing.
+ * `rfqSwapActivityInputs` does the work: the record's own `fundingArkTxid` and
+ * `refundArkTxid`, the corridor handler's `activityTxids` — so no corridor
+ * knowledge lives here — the manager's stamped `lockupSpendArkTxids`, and one
+ * lockup read only for what none of those can answer.
+ *
+ * **One txid it cannot see, and the reason it stays here.** `spend_txid` is the
+ * solver-pushed refund this wallet observed for itself, and it cannot move onto
+ * the record's `lockupSpendArkTxids` where the reader would find it:
+ * `updateRfqSwapRecord` strips that field and refills it from the live swap, so
+ * a value written here would survive exactly until the manager's next pass.
+ * `profile` is the half that survives, which is why the key was put there.
+ *
+ * So it is merged in afterwards — for `lightning_send` only, which is this
+ * file's own corridor, reading this file's own key. Nothing here interprets a
+ * profile it does not own, which is the rule `rfqCorridors.ts` exists to keep.
+ *
+ * Named only for a swap that came BACK. A settled send's spend is the solver's
+ * claim: it pays the solver, so it is not in this wallet's history and grouping
+ * against it would group nothing.
  */
-export const lnSendActivityInputs = async (): Promise<SwapActivityInput[]> => {
+export const swapActivityInputs = async (indexer?: LockupSpendIndexer): Promise<SwapActivityInput[]> => {
   try {
-    return (await lightningSends()).flatMap((record) => {
-      const view = viewOf(record)
-      if (!view) return []
-      const refundTxid = record.state === 'refunded' ? view.spendTxid : undefined
-      return [
-        {
-          rfqId: record.rfqId,
-          kind: 'lightning_send' as const,
-          state: record.state,
-          txids: [view.fundingTxid, ...(refundTxid ? [refundTxid] : [])],
-        },
-      ]
+    const [inputs, records] = await Promise.all([
+      rfqSwapActivityInputs({ repository: assetSwapRepository, indexer }),
+      assetSwapRepository.getAllRfqSwaps(),
+    ])
+    return inputs.map((input) => {
+      if (input.kind !== 'lightning_send' || input.state !== 'refunded') return input
+      const record = records.find((stored) => stored.rfqId === input.rfqId)
+      const spendTxid = record && profileTxid(record, SPEND_TXID)
+      if (!spendTxid || input.txids.includes(spendTxid)) return input
+      return { ...input, txids: [...input.txids, spendTxid] }
     })
   } catch (err) {
-    consoleError(err, 'error reading lightning send swap records')
+    consoleError(err, 'error reading swap records for activity grouping')
     return []
   }
 }

--- a/src/lib/swapDisplay.ts
+++ b/src/lib/swapDisplay.ts
@@ -35,15 +35,30 @@ export function swapStatusLabel(tx: Tx): string {
 /**
  * How a grouped RFQ swap row reads.
  *
- * The resolver's `outcome` is an opaque machine token, so the mapping to copy
- * belongs here rather than in the row. "Refunded", not "Failed": nothing broke
- * from the user's side — the solver could not pay the invoice and the covenant
- * returned the funds, which is the same word the receipt already uses.
+ * The resolver's `outcome` is an opaque machine token — the package emits
+ * `pending`, `settled`, `refunded`, `failed` and `lost`, and says nothing about
+ * wording — so the mapping to copy belongs here rather than in the row.
+ *
+ * Two of the five need care:
+ *
+ * - **`refunded`** is "Refunded", not "Failed". Nothing broke from the user's
+ *   side: the solver could not pay the invoice and the covenant returned the
+ *   funds, which is the same word the receipt already uses.
+ * - **`lost`** is a `lightning_receive` that ended `refunded`, and it is the
+ *   opposite of the above. On the receive leg every non-claim leaf of the
+ *   covenant is the SOLVER's, so a lockup that went back is a payment that
+ *   never arrived — money gone, not money returned. Calling it "refunded" here
+ *   would tell the user the exact opposite of what happened, and would also
+ *   disagree with the receive screen, which already renders this as a loss.
+ *
+ * `settled` adds no word: a send that went through is just "Lightning send",
+ * the way a plain payment row carries no adverb.
  */
 export function lnSwapLabel(tx: Tx): string | undefined {
   const swap = tx.lnSwap
   if (!swap) return undefined
   const stem = swap.label ?? 'Lightning send'
+  if (swap.outcome === 'lost') return `${stem} lost`
   if (swap.outcome === 'refunded') return `${stem} refunded`
   if (swap.outcome === 'failed') return `${stem} failed`
   if (swap.outcome === 'pending') return `${stem} pending`

--- a/src/providers/lnSwaps.tsx
+++ b/src/providers/lnSwaps.tsx
@@ -34,6 +34,7 @@ import {
   lnSendSwapRecord,
   readRecord,
   recordSpendTxid,
+  spendTxidOf,
   restoreLnSendSwaps,
   saveRecord,
   saveSwapUpdate,
@@ -150,7 +151,15 @@ const recordEnding = async (
   swap: RfqSwap,
 ): Promise<string | undefined> => {
   const record = await readRecord(swap.rfqId)
-  const fundingTxid = record && fundingTxidOf(record)
+  if (!record) return undefined
+  // The manager stamps `lockupSpendArkTxids` at finalization, from the chain
+  // read that ended the swap, so a terminal record usually answers for itself —
+  // and this whole lookup is a network round trip for a permanent fact someone
+  // already fetched. The indexer path stays for the record that has no stamp:
+  // one written before #773, or a swap whose end we saw some other way.
+  const stamped = spendTxidOf(record)
+  if (stamped) return stamped
+  const fundingTxid = fundingTxidOf(record)
   if (!fundingTxid) return undefined
   const spendTxid = await lockupSpenderTxid(indexer, {
     fundingTxid,

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -13,6 +13,7 @@ import {
   rollbackMigration,
   IndexedDBWalletRepository,
   IndexedDBContractRepository,
+  RestIndexerProvider,
   type Activity,
   type Identity,
   type ServiceWorkerWalletMode,
@@ -40,7 +41,8 @@ import { deepLinkInUrl } from '../lib/deepLink'
 import { consoleError } from '../lib/logs'
 import { Tx, Vtxo, Wallet } from '../lib/types'
 import { activitiesToTxs, getActivities } from '../lib/activityHistory'
-import { lnSendActivityInputs, lnSendViews, type LnSendView } from '../lib/lnSendRecords'
+import { Indexer } from '../lib/indexer'
+import { lnSendViews, swapActivityInputs, type LnSendView } from '../lib/lnSendRecords'
 import { assetSwapResolver } from '../lib/activity/assetSwapResolver'
 import { swapActivityResolver } from '@arkade-os/swap'
 import { assetSwapRepository, type WalletAssetSwap } from '../lib/swapRepository'
@@ -61,7 +63,6 @@ import {
 } from '../lib/constants'
 import { AssetIconApprovalManager } from '../lib/assetIconApproval'
 import { IndexedDBStorageAdapter } from '@arkade-os/sdk/adapters/indexedDB'
-import { Indexer } from '../lib/indexer'
 import { BackupContext } from './backup'
 
 const SERVICE_WORKER_ACTIVATION_TIMEOUT_MS = 5_000
@@ -613,10 +614,25 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       // The registry ships with the SDK built-ins already in it; only ours has
       // to be added, and `use()` is idempotent by id across reinit paths.
       svcWallet.activity.use(assetSwapResolver())
-      // The package's own resolver for the RFQ corridors, fed from the records
-      // the send flow writes: it is what turns a Lightning send's funding tx —
-      // and the refund that may follow it — into one labelled activity.
-      svcWallet.activity.use(swapActivityResolver({ listSwaps: lnSendActivityInputs }))
+      // The package's own resolver for the RFQ corridors, fed by the package's
+      // own reader over the records `RfqSwapManager` writes. It is what turns a
+      // swap's funding tx — and the claim or refund that follows it — into one
+      // labelled activity instead of two unrelated rows.
+      //
+      // `rfqSwapActivityInputs` rather than a mapping of ours, because the
+      // per-corridor txids come from the corridor's handler
+      // (`activityTxids(profile)`): reading profile keys by name here would put
+      // corridor knowledge in the wallet, which is what adding a corridor would
+      // then have to come back and edit. It also drains the manager's stamped
+      // `lockupSpendArkTxids` before any network read, so a terminal swap
+      // answers for its own counterparty spend.
+      //
+      // The indexer covers only what a record cannot: one written before
+      // `fundingArkTxid` existed, and a terminal swap no refund of ours ended.
+      // It is optional and failure-isolated — one that throws costs that record
+      // its extra txids, never the whole list.
+      const activityIndexer = new RestIndexerProvider(arkServerUrl)
+      svcWallet.activity.use(swapActivityResolver({ listSwaps: () => swapActivityInputs(activityIndexer) }))
 
       if (!skipMigration) {
         setLoadingStatus('Migrating data...')

--- a/src/test/lib/activityHistory.test.ts
+++ b/src/test/lib/activityHistory.test.ts
@@ -5,6 +5,7 @@ import { activitiesToTxs, getActivityTxHistory } from '../../lib/activityHistory
 import { swapActivityResolver } from '@arkade-os/swap'
 import { ASSET_SWAP_ACTIVITY_KIND, assetSwapResolver } from '../../lib/activity/assetSwapResolver'
 import { readAllTransactionActivityMetadata, saveTransactionActivityMetadata } from '../../lib/storage'
+import type { LnSendView } from '../../lib/lnSendRecords'
 import type { WalletAssetSwap } from '../../lib/swapRepository'
 
 beforeEach(() => localStorage.clear())
@@ -275,6 +276,72 @@ describe('lightning send activities', () => {
     })
 
     expect(row).toMatchObject({ destination: 'lnbc10u1p...', networkFee: 30 })
+  })
+
+  const view = (over: Partial<LnSendView> = {}): LnSendView => ({
+    rfqId: RFQ_ID,
+    fundingTxid: 'funding-txid',
+    state: 'pending',
+    amount: 1_030,
+    createdAt: 4_000,
+    ...over,
+  })
+
+  it('shows a send in flight from its record, before any tx of it reaches history', () => {
+    // The funding tx pays a covenant this wallet registered, so Arkade counts
+    // the lockup as change and reports no movement at all. Nothing appears
+    // until the solver spends the lockup — which is the wait the payer cannot
+    // see and cannot control.
+    const [row, ...rest] = activitiesToTxs([], { ...empty, lnSends: [view()] })
+
+    expect(rest).toEqual([])
+    expect(row).toMatchObject({
+      amount: 1_030,
+      type: 'sent',
+      createdAt: 4_000,
+      redeemTxid: 'funding-txid',
+      settled: true,
+      historyKey: `swap:${RFQ_ID}`,
+      lnSwap: { label: 'Lightning send', outcome: 'pending', fundingTxid: 'funding-txid' },
+    })
+    expect(lnSwapLabel(row)).toBe('Lightning send pending')
+  })
+
+  it('gives that row the invoice and fee saved against the funding tx', () => {
+    saveTransactionActivityMetadata('funding-txid', { destination: 'lnbc10u1p...', networkFee: 30 })
+
+    const [row] = activitiesToTxs([], {
+      ...empty,
+      lnSends: [view()],
+      metadata: readAllTransactionActivityMetadata(),
+    })
+
+    expect(row).toMatchObject({ destination: 'lnbc10u1p...', networkFee: 30 })
+  })
+
+  it('keeps naming a refunded send, whose refund tx history reports no better', () => {
+    // A refund returns the money through a tx that nets to zero the same way
+    // the funding did. Dropping the record's row on a terminal state would make
+    // the payment vanish from the list at the moment it came back.
+    const [row] = activitiesToTxs([], {
+      ...empty,
+      lnSends: [view({ state: 'refunded', spendTxid: 'refund-txid' })],
+    })
+
+    expect(row.lnSwap).toMatchObject({ outcome: 'refunded', spendTxid: 'refund-txid' })
+    expect(lnSwapLabel(row)).toBe('Lightning send refunded')
+  })
+
+  it('yields to the group once one exists, under the same key', () => {
+    // The lockup spend is a tx of ours, so the group finally forms — and the
+    // real row replaces the record's rather than doubling it.
+    const rows = activitiesToTxs([{ ...activity(`swap:${RFQ_ID}`, [funding], lnIntent('pending')), amount: -1_030 }], {
+      ...empty,
+      lnSends: [view()],
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].historyKey).toBe(`swap:${RFQ_ID}`)
   })
 
   it('groups the refund with its funding tx end to end, through the package resolver', async () => {

--- a/src/test/lib/activityHistory.test.ts
+++ b/src/test/lib/activityHistory.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, it, expect } from 'vitest'
+import { lnSwapLabel } from '../../lib/swapDisplay'
 import { createDefaultActivityRegistry, ServiceWorkerWallet, type Activity, type ArkTransaction } from '@arkade-os/sdk'
 import { activitiesToTxs, getActivityTxHistory } from '../../lib/activityHistory'
 import { swapActivityResolver } from '@arkade-os/swap'
@@ -301,4 +302,77 @@ describe('lightning send activities', () => {
     ])
     expect(txs[1]).toMatchObject({ amount: 30, lnSwap: { label: 'Lightning send', outcome: 'refunded' } })
   })
+})
+
+describe('lightning receive activities', () => {
+  const RFQ_ID = 'c'.repeat(64)
+
+  const recvIntent = (outcome: string): Activity['intent'] => ({
+    kind: 'swap',
+    label: 'Lightning receive',
+    outcome,
+    metadata: { rfqId: RFQ_ID, swapKind: 'lightning_receive' },
+  })
+
+  // The only transaction of ours on this leg: the SOLVER funds the lockup, we
+  // claim it. There is no funding member to anchor on.
+  const claim = arkTx('claim-txid', { amount: 10_000, createdAt: 7_000 })
+
+  it('shows a settled receive as one labelled row, not a bare incoming tx', () => {
+    const [row, ...rest] = activitiesToTxs(
+      [{ ...activity(`swap:${RFQ_ID}`, [claim], recvIntent('settled')), amount: 10_000 }],
+      empty,
+    )
+
+    expect(rest).toEqual([])
+    expect(row).toMatchObject({
+      amount: 10_000,
+      type: 'received',
+      historyKey: `swap:${RFQ_ID}`,
+      lnSwap: { label: 'Lightning receive', outcome: 'settled' },
+    })
+  })
+
+  it('carries no fundingTxid, so it cannot open the send leg’s receipt', () => {
+    const [row] = activitiesToTxs(
+      [{ ...activity(`swap:${RFQ_ID}`, [claim], recvIntent('settled')), amount: 10_000 }],
+      empty,
+    )
+
+    // `useLnSendReceipt` keys off exactly this field and returns undefined
+    // without it — which is what keeps a receive out of a receipt built for a
+    // send.
+    expect(row.lnSwap?.fundingTxid).toBeUndefined()
+  })
+
+  it('renders a lost receive as lost, never as refunded', () => {
+    // The resolver emits `lost` for a `lightning_receive` that ended
+    // `refunded`, because on this leg the lockup going back means the payment
+    // never arrived. Reachable in history only for a receive that got SOME of
+    // its money — one that got none contributes no tx of ours, so it forms no
+    // group at all.
+    const [row] = activitiesToTxs(
+      [{ ...activity(`swap:${RFQ_ID}`, [claim], recvIntent('lost')), amount: 4_000 }],
+      empty,
+    )
+
+    expect(row.lnSwap?.outcome).toBe('lost')
+    expect(lnSwapLabel(row)).toBe('Lightning receive lost')
+  })
+
+  it('falls back to plain member rows rather than dropping a group it cannot anchor', () => {
+    // No RECEIVED member means the record named a txid this history does not
+    // have. Whatever IS here is still the user's money moving, so it is emitted
+    // rather than swallowed — the same rule the send builder follows.
+    const stray = arkTx('stray-txid', { type: 'SENT' as ArkTransaction['type'], amount: 500, createdAt: 8_000 })
+
+    const rows = activitiesToTxs([{ ...activity(`swap:${RFQ_ID}`, [stray], recvIntent('lost')), amount: -500 }], empty)
+
+    expect(rows.map((tx) => tx.historyKey)).toEqual([`swap:${RFQ_ID}:stray-txid`])
+    expect(rows[0].lnSwap).toBeUndefined()
+  })
+
+  // A receive that never arrived at all contributes no transaction of ours, so
+  // it forms no activity and reaches this function not at all. That absence is
+  // upstream of the row builder and cannot be asserted here.
 })

--- a/src/test/lib/lnSendRecords.test.ts
+++ b/src/test/lib/lnSendRecords.test.ts
@@ -221,6 +221,26 @@ describe('swapActivityInputs', () => {
   })
 })
 
+describe('lnSendViews', () => {
+  it('carries what a row needs when history reports no transaction at all', async () => {
+    // The funding tx nets to zero against the lockup output the wallet also
+    // owns, so Arkade's history emits nothing for it and the row is built from
+    // this view instead — see `ungroupedLnSendTx`.
+    await store()
+
+    expect(await lnSendViews()).toEqual([
+      {
+        rfqId: RFQ_ID,
+        fundingTxid: 'funding-txid',
+        state: 'pending',
+        amount: 1_030,
+        createdAt: 1_700_000_000,
+        spendTxid: undefined,
+      },
+    ])
+  })
+})
+
 describe('restoreLnSendSwaps', () => {
   // Every rebuild needs the lockup's contract row; a wallet without one is the
   // case these tests are about, so the reader answers with none.

--- a/src/test/lib/lnSendRecords.test.ts
+++ b/src/test/lib/lnSendRecords.test.ts
@@ -3,7 +3,6 @@ import { ArkAddress, type ProvisionedKey } from '@arkade-os/sdk'
 import { RFQ_SWAP_RETENTION_SECONDS, type LockupContractReader } from '@arkade-os/swap'
 import {
   fundingTxidOf,
-  lnSendActivityInputs,
   lnSendSwapRecord,
   lnSendViews,
   recordSpendTxid,
@@ -11,6 +10,7 @@ import {
   saveRecord,
   saveSwapUpdate,
   spendTxidOf,
+  swapActivityInputs,
   type LnSendRecordInput,
 } from '../../lib/lnSendRecords'
 import { assetSwapRepository as repository } from '../../lib/swapRepository'
@@ -144,31 +144,80 @@ describe('the spend that ended a swap', () => {
   })
 })
 
-describe('lnSendActivityInputs', () => {
-  it('names the refund only for a swap that came back', async () => {
+/**
+ * The hand-rolled `lnSendActivityInputs` is gone; `rfqSwapActivityInputs` reads
+ * the store instead. That only works if the txids are on the record's OWN
+ * fields — the lightning-send corridor has no `activityTxids`, so a funding
+ * txid parked under a wallet-private profile key would group nothing.
+ */
+describe('swapActivityInputs', () => {
+  const inputs = () => swapActivityInputs()
+
+  it('finds the funding txid on the record, not under a profile key of ours', async () => {
+    await store()
+
+    expect(await inputs()).toEqual([
+      { rfqId: RFQ_ID, kind: 'lightning_send', state: 'pending', txids: ['funding-txid'] },
+    ])
+  })
+
+  it('merges in the solver-pushed refund the package reader cannot see', async () => {
+    // `spend_txid` is this file's own key and stays there: the record's
+    // `lockupSpendArkTxids` is stripped and refilled from the live swap on
+    // every manager pass, so a value written to it would not survive.
     await store({}, { state: 'refunded' })
     await recordSpendTxid(RFQ_ID, 'refund-txid')
 
-    expect(await lnSendActivityInputs()).toEqual([
-      { rfqId: RFQ_ID, kind: 'lightning_send', state: 'refunded', txids: ['funding-txid', 'refund-txid'] },
-    ])
+    const [input] = await inputs()
+    expect(input.state).toBe('refunded')
+    expect([...input.txids].sort()).toEqual(['funding-txid', 'refund-txid'])
+  })
+
+  it('gives the row builder nothing for a record with no funding txid', async () => {
+    // Neither the record's own field nor the legacy profile key. There is no
+    // transaction to anchor a row on, and a view without one would name a
+    // lockup that does not exist.
+    const record = await store()
+    await saveRecord({ ...record, fundingArkTxid: undefined, profile: { ...record.profile, funding_txid: undefined } })
+
+    expect(await lnSendViews()).toEqual([])
   })
 
   it('leaves a settled send’s spend out — it pays the solver, not us', async () => {
     await store({}, { state: 'settled' })
     await recordSpendTxid(RFQ_ID, 'solver-claim-txid')
 
-    expect(await lnSendActivityInputs()).toEqual([
-      { rfqId: RFQ_ID, kind: 'lightning_send', state: 'settled', txids: ['funding-txid'] },
-    ])
+    const [input] = await inputs()
+    expect(input.txids).not.toContain('solver-claim-txid')
   })
 
-  it('drops a record with no funding txid rather than grouping nothing', async () => {
-    const record = await store()
-    await saveRecord({ ...record, profile: { ...record.profile, funding_txid: undefined } })
+  it('costs no indexer call once the manager has stamped the spend', async () => {
+    const record = await store({}, { state: 'settled' })
+    await saveRecord({ ...record, lockupSpendArkTxids: ['solver-claim-txid'] })
+    let asked = false
+    const indexer = { getVtxos: async () => ((asked = true), { vtxos: [] }) }
 
-    expect(await lnSendActivityInputs()).toEqual([])
-    expect(await lnSendViews()).toEqual([])
+    const [input] = await swapActivityInputs(indexer as never)
+
+    // Funding on the record, spend stamped by the manager from the chain read
+    // that ended the swap — nothing left to ask for. Without the stamp a
+    // terminal swap pays a lockup read for a permanent fact.
+    expect(asked).toBe(false)
+    expect([...input.txids].sort()).toEqual(['funding-txid', 'solver-claim-txid'])
+  })
+
+  it('survives an indexer that throws, rather than losing every row to it', async () => {
+    // The lookup is a backfill for what a record cannot answer. One that fails
+    // costs that record its extra txids and nothing else.
+    const record = await store({}, { state: 'settled' })
+    await saveRecord({ ...record, fundingArkTxid: undefined })
+    const indexer = {
+      getVtxos: async () => {
+        throw new Error('indexer down')
+      },
+    }
+
+    await expect(swapActivityInputs(indexer as never)).resolves.toHaveLength(1)
   })
 })
 

--- a/src/test/lib/swapDisplay.test.ts
+++ b/src/test/lib/swapDisplay.test.ts
@@ -221,8 +221,25 @@ describe('lnSwapLabel', () => {
     expect(lnSwapLabel(row({ label: 'Lightning send', outcome: 'failed' }))).toBe('Lightning send failed')
   })
 
+  it('calls a lost receive lost, which is the opposite of a refund', () => {
+    // The resolver emits `lost` for a `lightning_receive` that ended
+    // `refunded`. On that leg every non-claim leaf of the covenant is the
+    // SOLVER's, so the lockup going back means the payment never arrived —
+    // money gone, not money returned. Reading it as "refunded" would tell the
+    // user the exact opposite of what happened.
+    expect(lnSwapLabel(row({ label: 'Lightning receive', outcome: 'lost' }))).toBe('Lightning receive lost')
+    expect(lnSwapLabel(row({ label: 'Lightning receive', outcome: 'lost' }))).not.toContain('refunded')
+  })
+
+  it('still calls a SEND that came back refunded, on the same token set', () => {
+    // The two legs read `refunded` in opposite directions, and the package is
+    // what tells them apart — the wallet must not collapse the distinction.
+    expect(lnSwapLabel(row({ label: 'Lightning send', outcome: 'refunded' }))).toBe('Lightning send refunded')
+  })
+
   it('says nothing extra once the payment simply went through', () => {
     expect(lnSwapLabel(row({ label: 'Lightning send', outcome: 'settled' }))).toBe('Lightning send')
+    expect(lnSwapLabel(row({ label: 'Lightning receive', outcome: 'settled' }))).toBe('Lightning receive')
   })
 
   it('falls back to the corridor name for an outcome token it does not know', () => {


### PR DESCRIPTION
Phase 4 of `plans/adopt-activity-history.md`, executed as Phase C of `plans/rfq-persistence-and-activity.md`. **Stacked on [#927](https://github.com/arkade-os/wallet/pull/927)**, which is itself stacked on [#918](https://github.com/arkade-os/wallet/pull/918).

Every RFQ swap now groups into one activity through the package's own reader, and a Lightning receive that came back reads as **lost** rather than as a refund.

## What was blocked, and why it is not any more

Phase 4 needed two things pointing in opposite directions along the stack: records to group (#918 wired the manager's repository) and a resolver registry to attach to (`svcWallet.activity.use`, which is #927's). Both are now below this branch.

## C1 — the package reader replaces the hand-rolled mapping

`lnSendActivityInputs` is deleted. `rfqSwapActivityInputs({ repository, indexer })` does the work, and does strictly more:

- **Corridor txids come from the corridor.** `activityTxids(profile)` is the handler's, so no corridor knowledge lives in the wallet. The old mapping read profile keys by name — which `rfqCorridors.ts` forbids on purpose, since adding a corridor would then mean coming back to edit the wallet.
- **The manager's stamped `lockupSpendArkTxids` is drained before any network read**, so a terminal swap answers for its own counterparty spend instead of paying for a lockup lookup.
- **The indexer is optional and failure-isolated** — it covers only what a record cannot answer, and one that throws costs that record its extra txids rather than sinking the list.

### The bug this nearly shipped, and the fix

Swapping the call in naively would have **silently broken Lightning-send grouping**, and it took reading the package source to see why: `lightning_send` has no `activityTxids` at all, so for a send the reader takes txids only from the record's own `fundingArkTxid`, `refundArkTxid` and `lockupSpendArkTxids`. But this wallet stored its two send txids under *private profile keys* — `funding_txid` and `spend_txid` — added back when the manager had no field for either. The reader cannot see them. Every refunded send would have quietly split back into two unrelated rows.

ts-sdk#773 supplies the fields, so the funding txid moves onto the record where it belongs:

- **`fundingArkTxid` is set on the origin.** `funding_txid` is no longer written; it is still *read*, so a store written by an earlier preview deploy keeps its receipts and its grouping.
- **`spend_txid` stays where it is, deliberately.** It cannot move onto `lockupSpendArkTxids`: `updateRfqSwapRecord` strips that field and refills it from the live swap, so a value the wallet wrote there would survive exactly until the manager's next pass. `profile` is the half that survives — which is why the key was put there originally.

Because of that last point `listSwaps` is a thin composition rather than the bare helper: `swapActivityInputs()` calls `rfqSwapActivityInputs` and then merges in `spend_txid` for `lightning_send` records that came back. It reads only this wallet's own key, on this wallet's own corridor, which keeps C1's actual rule intact — nothing here interprets a profile it does not own.

**`recordEnding` now checks the record before reaching for the network.** The manager stamps the spend at finalization, so the indexer lookup it used to do unconditionally is a round trip for a permanent fact someone already fetched. The lookup stays for a record with no stamp.

## C2 — outcome tokens become copy

The resolver emits opaque tokens (`pending`, `settled`, `refunded`, `failed`, `lost`) and says nothing about wording. Two need care and they are exact opposites:

- **`refunded`** — "Refunded", not "Failed". Nothing broke from the user's side: the solver could not pay the invoice and the covenant returned the funds.
- **`lost`** — a `lightning_receive` that ended `refunded`. On that leg every non-claim leaf of the covenant is the **solver's**, so a lockup that went back is a payment that never arrived. Money gone, not money returned. Calling it "refunded" would tell the user the exact opposite of what happened — and would contradict #918's receive screen, which already renders it as a loss. It takes the same `burn` icon tone as `failed`.

`settled` adds no word: a payment that went through is just "Lightning send", the way a plain payment row carries no adverb.

## The receive row

`activitiesToTxs` only knew how to collapse a `lightning_send`, so a receive group fell through to a plain incoming row with no label and no outcome. It now has a builder — the mirror of the send's, minus the funding leg, since on this corridor the *solver* funds the lockup and our only transaction is the claim.

No `fundingTxid` is set on it, deliberately: `useLnSendReceipt` keys off exactly that field and returns undefined without it, which is what stops a receive row opening a receipt built for the other leg.

**One honest limitation.** A receive that never arrived contributes *no* transaction of this wallet's — the solver reclaimed the lockup, and that spend is not in our history — so it forms no activity and gets no row at all. The `lost` copy is reachable only for a receive that got *some* of its money, a piecemeal funding we partly claimed. Surfacing the rest is an activity-model question, not a row-builder one, and is not attempted here.

## Testing

`pnpm test:unit` — 86 files, **715 passed, 1 skipped**.

| Area | Cases |
|---|---|
| `swapActivityInputs` | funding read off the record rather than a profile key; the solver-pushed refund merged in; a settled send's spend left out (it pays the solver, so grouping against it groups nothing); **no indexer call once the manager has stamped the spend**; an indexer that throws costing that record its extra txids and nothing else |
| `lnSwapLabel` | `lost` reading as lost and explicitly not as refunded; a *send*'s `refunded` still reading as refunded on the same token set; `settled` adding no word on either leg |
| receive rows | a settled receive as one labelled row; no `fundingTxid`; a `lost` receive rendering as lost; a group with no anchorable member falling back to plain rows rather than being dropped |

Two test premises of mine were wrong and were corrected rather than worked around: `fundingArkTxid` alone does **not** suppress the indexer read (`spendUnknown` still triggers it — the stamp is what suppresses it), and an activity with no transactions cannot be constructed at all, so the "receive that never arrived" case is upstream of this function and is documented rather than asserted.

No e2e — same corridor gate as the rest of the stack.
