### PR TITLE
changes to allow running of ln send tests

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -26,10 +26,10 @@ ARKD_LOG_LEVEL=6
 # cross over with it. The remaining constraints it enforces: boarding must
 # differ from unilateral, and public unilateral must be >= unilateral.
 ARKD_VTXO_TREE_EXPIRY=86400
-ARKD_UNILATERAL_EXIT_DELAY=1024
-ARKD_PUBLIC_UNILATERAL_EXIT_DELAY=1024
-ARKD_BOARDING_EXIT_DELAY=2048
-ARKD_CHECKPOINT_EXIT_DELAY=512
+ARKD_UNILATERAL_EXIT_DELAY=3072
+ARKD_PUBLIC_UNILATERAL_EXIT_DELAY=3072
+ARKD_BOARDING_EXIT_DELAY=4096
+ARKD_CHECKPOINT_EXIT_DELAY=2048
 
 # Zero fees - faucetOffchain uses wallet.settle() without fee budget
 ARK_OFFCHAIN_INPUT_FEE="0.0"

--- a/docs/e2e-lightning.md
+++ b/docs/e2e-lightning.md
@@ -74,7 +74,7 @@ its relays, and there is no URL to configure instead. It is generated rather
 than committed because its `discovery_pubkey` is that deployment's own key.
 
 ```bash
-RELAY_URL= SOLVER_CARD_RELAYS=wss://localhost:10548 \
+RELAY_URL= SOLVER_CARD_RELAYS=ws://localhost:10547 \
   node --experimental-eventsource --env-file=.env.regtest dist/cli.js card regtest-lightning \
   > <path-to>/wallet/.regtest-lightning.card.json
 ```

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -91,7 +91,7 @@ const EMULATOR_PUBKEY: Record<NetworkName, string | null> = {
   // per-deployment: a local stack generates its own co-signer key, so there is
   // no constant to pin. Set VITE_EMULATOR_PUBKEY to your emulator's signer
   // key.
-  regtest: null,
+  regtest: '02999413c46fa10ada5cbc4bcc79a1d09160c2ba3cfc812705d7a13e5e545fb2a9',
   testnet: null,
 }
 

--- a/src/test/lib/emulatorPubkey.test.ts
+++ b/src/test/lib/emulatorPubkey.test.ts
@@ -28,11 +28,16 @@ describe('getEmulatorPubkeyForNetwork', () => {
     )
   })
 
+  it('supplies the regtest pin, matching the SDK and the live deployment', () => {
+    // pinned in .env.regtest
+    expect(hex.encode(getEmulatorPubkeyForNetwork('regtest')!)).toBe(
+      '999413c46fa10ada5cbc4bcc79a1d09160c2ba3cfc812705d7a13e5e545fb2a9',
+    )
+  })
+
   it('reports no key for networks with none pinned, so swaps stay off', () => {
     expect(getEmulatorPubkeyForNetwork('signet')).toBeUndefined()
     expect(getEmulatorPubkeyForNetwork('testnet')).toBeUndefined()
-    // regtest keys are per-deployment; a dev supplies one via VITE_EMULATOR_PUBKEY
-    expect(getEmulatorPubkeyForNetwork('regtest')).toBeUndefined()
   })
 
   describe('VITE_EMULATOR_PUBKEY override', () => {
@@ -51,7 +56,7 @@ describe('getEmulatorPubkeyForNetwork', () => {
       ['unsubstituted placeholder', '__VITE_EMULATOR_PUBKEY__'],
     ])('reads a %s value as no key rather than passing it through', (_label, value) => {
       vi.stubEnv('VITE_EMULATOR_PUBKEY', value)
-      expect(getEmulatorPubkeyForNetwork('regtest')).toBeUndefined()
+      expect(getEmulatorPubkeyForNetwork('testnet')).toBeUndefined()
       // and it must not fall back to another network's pinned key either
       expect(getEmulatorPubkeyForNetwork('signet')).toBeUndefined()
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Increased regtest exit-delay settings for unilateral, public unilateral, boarding, and checkpoint flows.

* **Documentation**
  * Updated Lightning end-to-end testing instructions to use the local relay connection.

* **Bug Fixes**
  * Added a configured fallback public key for the regtest emulator, improving reliability and consistency across regtest environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->