### PR TITLE
Unilateral exit UI support

### DIFF
--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -49,7 +49,10 @@ const TransactionLine = ({
   const swapStatus = swap ? swapStatusForTx(tx) : undefined
   const issuance = isIssuance(tx)
   const burn = isBurn(tx)
-  const prefix = issuance ? '+' : burn || tx.type === 'sent' ? '-' : '+'
+  // A unilateral exit: the money left the Ark layer for the chain. Debited like
+  // a send, but never labelled as one — nobody was paid.
+  const exit = tx.type === 'exit'
+  const prefix = issuance ? '+' : burn || exit || tx.type === 'sent' ? '-' : '+'
   const amountDisplay = useTransactionAmountDisplay(tx)
 
   const lnSwapKind = lnSwapLabel(tx)
@@ -86,7 +89,7 @@ const TransactionLine = ({
       />
     ) : issuance ? (
       <ReceivedIcon />
-    ) : burn ? (
+    ) : burn || exit ? (
       <SentIcon />
     ) : tx.type === 'sent' ? (
       <SentIcon />
@@ -114,9 +117,11 @@ const TransactionLine = ({
         ? 'Issuance'
         : burn
           ? 'Burn'
-          : tx.type === 'sent'
-            ? 'Sent'
-            : 'Received')
+          : exit
+            ? 'Exited'
+            : tx.type === 'sent'
+              ? 'Sent'
+              : 'Received')
   const Kind = () => <span className='activity-row__kind'>{kind}</span>
 
   const swapRoute = swap ? swapRouteLabel(tx) : ''

--- a/src/lib/activityHistory.ts
+++ b/src/lib/activityHistory.ts
@@ -4,6 +4,7 @@ import { ASSET_SWAP_ACTIVITY_KIND } from './activity/assetSwapResolver'
 import { consoleError } from './logs'
 import type { TransactionActivityMetadata } from './storage'
 import { buildAssetSwapActivityTx } from './swapDisplay'
+import type { ExitRecord } from './exitHistory'
 import type { LnSendView } from './lnSendRecords'
 import type { WalletAssetSwap } from './swapRepository'
 import { arkTransactionToTx, sortLocalTxs, txidOfArkTransaction } from './transactionHistory'
@@ -18,6 +19,11 @@ export interface ActivityHistoryOptions {
    * report at all, the only source of the row itself. See
    * `ungroupedLnSendTx`. */
   lnSends?: LnSendView[]
+  /** The unilaterally exited coins, already dated by `resolveExits`. Passed as
+   * records rather than read back out of `metadata`: an unconfirmed exit is
+   * deliberately never persisted, so the store cannot answer for it. See
+   * `exitTx`. */
+  exits?: ExitRecord[]
   /** Snapshot taken alongside the activity fetch. Never read in here: this
    * runs in a `useMemo`, so a `localStorage` read would be an undeclared dep. */
   metadata: Record<string, TransactionActivityMetadata>
@@ -192,13 +198,49 @@ const ungroupedLnSendTx = (send: LnSendView, metadata: Record<string, Transactio
     metadata[send.fundingTxid],
   )
 
+/**
+ * One row for a unilateral exit, which Arkade's history does not report.
+ *
+ * The sent side of `buildTransactionHistory` is gated on `isSpent`, and the SDK
+ * is explicit that an unrolled output never sets it — *"not set to true if the
+ * virtual output is unrolled or swept, only when it's spent offchain"*. So an
+ * exit leaves the original RECEIVED row standing and adds nothing, and the
+ * balance drops with nothing to explain it. Same shape of problem as
+ * `ungroupedLnSendTx`, same answer.
+ *
+ * Both rows stay. The money did arrive and then leave.
+ *
+ * No metadata graft: the store is keyed by txid, and for an exit that txid is
+ * the receive's — grafting would hang the receive's destination and network fee
+ * on the exit. `settled` because the exit is done, not because the sweep is:
+ * the sats are onchain behind their CSV timelock until the exit tool moves
+ * them. `networkFee` is 0 rather than `defaultFee` because a unilateral exit
+ * pays no Ark fee — its real cost went to miners across the exit branch, which
+ * this wallet never saw and cannot price.
+ */
+const exitTx = (exit: ExitRecord): Tx => ({
+  amount: exit.value,
+  boardingTxid: '',
+  createdAt: exit.exitedAt,
+  explorable: exit.txid,
+  historyKey: `exit:${exit.txid}:${exit.vout}`,
+  networkFee: 0,
+  preconfirmed: false,
+  // Onchain once unrolled, which is why the receipt must not treat this row as
+  // an offchain tx — see `isOffchainTx` in `screens/Wallet/Transaction`.
+  redeemTxid: exit.txid,
+  roundTxid: '',
+  settled: true,
+  type: 'exit',
+})
+
 /** `Activity[]` -> the `Tx[]` the UI already reads. Pure and synchronous.
  *
  * Only groups we know how to collapse become a single row; everything else
  * emits one row per member, so a built-in grouping deposits or exits cannot
  * change the row count. */
 export const activitiesToTxs = (activities: Activity[], options: ActivityHistoryOptions): Tx[] => {
-  const { swaps, metadata, network, assetDisplay, lnSends = [] } = options
+  const { swaps, metadata, network, assetDisplay, lnSends = [], exits = [] } = options
   const rows: Tx[] = []
   for (const activity of activities) {
     const swapKind = rfqSwapKindOf(activity)
@@ -249,6 +291,8 @@ export const activitiesToTxs = (activities: Activity[], options: ActivityHistory
   for (const send of lnSends) {
     if (!grouped.has(send.rfqId)) rows.push(ungroupedLnSendTx(send, metadata))
   }
+  // Exits last, for the same reason: history reports none of them either.
+  for (const exit of exits) rows.push(exitTx(exit))
   return sortLocalTxs(rows)
 }
 

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -237,15 +237,20 @@ export const getVtxos = async (wallet: ServiceWorkerWallet): Promise<{ spendable
  *
  * The set still stands after the user finishes the sweep with the exit tool:
  * the three facts behind `hasTerminalSpend` all report an OFFCHAIN spend, and
- * the SDK is explicit that unrolling or sweeping sets none of them. */
+ * the SDK is explicit that unrolling or sweeping sets none of them.
+ *
+ * Throws rather than degrading to an empty set. An empty answer is not a safe
+ * approximation of "we could not ask": it is indistinguishable from "nothing
+ * was exited", and `reloadWallet` spends it twice — once as the exit rows, once
+ * as the asset subtraction — while the sats headline still nets out the
+ * `unrolled` bucket, which comes from `getBalance` and would not have failed.
+ * That commits a snapshot whose sats say an exit happened and whose assets and
+ * history say it did not. Letting it throw hands the reload's catch a whole
+ * failure instead, which keeps the last good snapshot and, on a first load,
+ * surfaces the retry. */
 export const getUnrolledVtxos = async (wallet: ServiceWorkerWallet): Promise<Vtxo[]> => {
-  try {
-    const vtxos = await wallet.getVtxos({ withUnrolled: true })
-    return vtxos.filter((vtxo) => vtxo.isUnrolled && !hasTerminalSpend(vtxo))
-  } catch (err) {
-    consoleError(err, 'error getting unrolled vtxos')
-    return []
-  }
+  const vtxos = await wallet.getVtxos({ withUnrolled: true })
+  return vtxos.filter((vtxo) => vtxo.isUnrolled && !hasTerminalSpend(vtxo))
 }
 
 export const getReceivingAddresses = async (wallet: IWallet): Promise<Addresses> => {

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -212,6 +212,28 @@ export const getVtxos = async (wallet: ServiceWorkerWallet): Promise<{ spendable
   return { spendable, spent }
 }
 
+/** The exited set: coins whose unilateral exit already happened, so they now
+ * live onchain behind their CSV timelock and no batch can lift them back.
+ *
+ * Kept apart from `getVtxos` rather than folded into it. That split keys on
+ * `spentBy`/`settledBy`, and an exited coin has neither, so it would land in
+ * `spendable` and reach `calcNextRollover` — scheduling a rollover for money
+ * that has already left the Ark layer.
+ *
+ * `withUnrolled` is authoritative on the location axis alone: it returns an
+ * exited coin whatever else is true of it, spent ones included. So the filter
+ * keeps only what the flag was asked for, and the set stays complete after the
+ * user finishes the sweep with the exit tool. */
+export const getUnrolledVtxos = async (wallet: ServiceWorkerWallet): Promise<Vtxo[]> => {
+  try {
+    const vtxos = await wallet.getVtxos({ withUnrolled: true })
+    return vtxos.filter((vtxo) => vtxo.isUnrolled)
+  } catch (err) {
+    consoleError(err, 'error getting unrolled vtxos')
+    return []
+  }
+}
+
 export const getReceivingAddresses = async (wallet: IWallet): Promise<Addresses> => {
   const [offchainAddr, boardingAddr] = await Promise.all([wallet.getAddress(), wallet.getBoardingAddress()])
   return {

--- a/src/lib/asp.ts
+++ b/src/lib/asp.ts
@@ -13,6 +13,7 @@ import {
   ArkError,
   DelegateInfo,
   toXOnlySignerHex,
+  hasTerminalSpend,
 } from '@arkade-os/sdk'
 import { Addresses, Tx, Vtxo } from './types'
 import { AspInfo } from '../providers/asp'
@@ -220,14 +221,27 @@ export const getVtxos = async (wallet: ServiceWorkerWallet): Promise<{ spendable
  * `spendable` and reach `calcNextRollover` — scheduling a rollover for money
  * that has already left the Ark layer.
  *
- * `withUnrolled` is authoritative on the location axis alone: it returns an
- * exited coin whatever else is true of it, spent ones included. So the filter
- * keeps only what the flag was asked for, and the set stays complete after the
- * user finishes the sweep with the exit tool. */
+ * `withUnrolled` alone is not the exited set, because `isUnrolled` is a fact
+ * about the whole ancestry, not just the coin the user exited. `Unroll.Session`
+ * broadcasts the chain ancestry-first, so every earlier VTXO of ours in that
+ * chain also ends up onchain and also comes back flagged — each with the same
+ * value, since a chain of offchain transfers carries the amount forward. Those
+ * ancestors were spent offchain when their successor was created, so
+ * `hasTerminalSpend` is exactly the line between them and the coin that
+ * actually left: one exit, one row.
+ *
+ * It is also the line `computeOffchainBalance` draws — it skips terminal spends
+ * before it counts the `unrolled` bucket or adds to `owned` — so filtering here
+ * is what keeps the rows and the two subtractions in `reloadWallet` describing
+ * the same coins.
+ *
+ * The set still stands after the user finishes the sweep with the exit tool:
+ * the three facts behind `hasTerminalSpend` all report an OFFCHAIN spend, and
+ * the SDK is explicit that unrolling or sweeping sets none of them. */
 export const getUnrolledVtxos = async (wallet: ServiceWorkerWallet): Promise<Vtxo[]> => {
   try {
     const vtxos = await wallet.getVtxos({ withUnrolled: true })
-    return vtxos.filter((vtxo) => vtxo.isUnrolled)
+    return vtxos.filter((vtxo) => vtxo.isUnrolled && !hasTerminalSpend(vtxo))
   } catch (err) {
     consoleError(err, 'error getting unrolled vtxos')
     return []

--- a/src/lib/exitHistory.ts
+++ b/src/lib/exitHistory.ts
@@ -1,0 +1,141 @@
+import { Asset, ESPLORA_URL, EsploraProvider, NetworkName } from '@arkade-os/sdk'
+import { getRestApiExplorerURL } from './explorers'
+import { consoleError } from './logs'
+import { readAllTransactionActivityMetadata, saveTransactionActivityMetadata } from './storage'
+import type { Vtxo } from './types'
+
+/**
+ * One unilaterally exited VTXO, with the time its exit landed onchain.
+ *
+ * The wallet's own view of an exit, assembled here because no single source has
+ * it: the coin comes from the VTXO repo, the timestamp from the chain. Carrying
+ * the resolved `exitedAt` on the record rather than leaving it in the metadata
+ * store is what lets an unconfirmed exit still produce a row — that case is
+ * deliberately not persisted.
+ */
+export interface ExitRecord {
+  txid: string
+  vout: number
+  value: number
+  /** Unix seconds, matching `Tx.createdAt`. */
+  exitedAt: number
+}
+
+/**
+ * Esplora for `network`, or undefined when we cannot name one.
+ *
+ * `explorers.ts` has no `api` entry for mainnet, and `EsploraProvider`'s own
+ * constructor default is the mainnet URL — which would be right on mainnet by
+ * coincidence and wrong on every other network. So the SDK's per-network table
+ * is the fallback, never the constructor's.
+ */
+const exitProvider = (network?: string): EsploraProvider | undefined => {
+  const name = network as NetworkName | undefined
+  const url = name ? (getRestApiExplorerURL(name) ?? ESPLORA_URL[name]) : undefined
+  return url ? new EsploraProvider(url) : undefined
+}
+
+/**
+ * When the coin was received. The fallback for an exit we cannot date, and
+ * wrong on purpose rather than absent: it keeps the row in the list.
+ *
+ * `normalizeVtxo` coerces `expiresAt` but leaves `createdAt` alone, and the
+ * SDK's own note at that coercion says why it matters — a store that round-trips
+ * through JSON hands back an ISO string that typechecks as `Date` and returns
+ * NaN from `getTime()`. A NaN date sorts nowhere, so it becomes 0, which
+ * `sortLocalTxs` floats to the top where an undated row belongs.
+ */
+const receivedAt = (vtxo: Vtxo): number => {
+  const ms = new Date(vtxo.createdAt).getTime()
+  return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000)
+}
+
+/** The exit tx's confirmation time in unix seconds, or undefined while it is
+ * unconfirmed or the lookup fails. Never throws: the caller runs inside the
+ * reload whose catch blocks first load. */
+const confirmedAt = async (provider: EsploraProvider, txid: string): Promise<number | undefined> => {
+  try {
+    const status = await provider.getTxStatus(txid)
+    // `blockTime` is already unix seconds, which is what `Tx.createdAt` wants.
+    return status.confirmed ? status.blockTime : undefined
+  } catch (err) {
+    consoleError(err, `error resolving exit time for ${txid}`)
+    return undefined
+  }
+}
+
+/**
+ * Date each exited coin by its exit, not by its receive.
+ *
+ * A VTXO's `createdAt` is when the money arrived, so ordering an exit row by it
+ * puts the exit next to the receive and reads as nonsense. Once unrolled,
+ * `vtxo.txid` is an onchain txid — `prepareUnrollTransaction` relies on exactly
+ * that — so the chain can answer when the exit happened.
+ *
+ * Resolved times are persisted, so this is one lookup per exit transaction for
+ * the life of the wallet. Two things reopen it, both self-healing: an
+ * unconfirmed exit is deliberately not persisted and is retried on the next
+ * reload, and the metadata store's LRU cap can evict an old entry.
+ *
+ * Never rejects. It runs inside `reloadWallet`'s try block, whose catch blocks
+ * the first load, so a slow explorer must cost a row's date and nothing more.
+ */
+export const resolveExits = async (vtxos: Vtxo[], network?: string): Promise<ExitRecord[]> => {
+  if (vtxos.length === 0) return []
+  const stored = readAllTransactionActivityMetadata()
+  const provider = exitProvider(network)
+  // Keyed by TRANSACTION, not by coin: `exitedAt` is a property of the exit tx,
+  // and one exit can carry several of the wallet's outputs.
+  const resolved = new Map<string, number>()
+  const attempted = new Set<string>()
+  const records: ExitRecord[] = []
+  for (const vtxo of vtxos) {
+    let exitedAt = resolved.get(vtxo.txid) ?? stored[vtxo.txid]?.exitedAt
+    if (exitedAt === undefined && provider && !attempted.has(vtxo.txid)) {
+      attempted.add(vtxo.txid)
+      const confirmed = await confirmedAt(provider, vtxo.txid)
+      if (confirmed !== undefined) {
+        saveTransactionActivityMetadata(vtxo.txid, { exitedAt: confirmed })
+        resolved.set(vtxo.txid, confirmed)
+        exitedAt = confirmed
+      }
+    }
+    records.push({
+      txid: vtxo.txid,
+      vout: vtxo.vout,
+      value: vtxo.value,
+      exitedAt: exitedAt ?? receivedAt(vtxo),
+    })
+  }
+  return records
+}
+
+/**
+ * `assets` minus what rides on the exited coins.
+ *
+ * The satoshi half of this needs no help — `getBalance` reports `unrolled` as
+ * its own bucket. Assets have no such split: `computeOffchainBalance` adds every
+ * non-terminally-spent VTXO's assets to the owned map *before* it branches on
+ * `isUnrolled`, so `balance.assets` counts assets on exited coins while
+ * `availableAssets` does not. We hold the exited set, so the subtraction is
+ * exact rather than inferred.
+ *
+ * Clamped at zero and dropped when empty. The two figures come from one
+ * snapshot, but a balance read racing a repo sync is not worth a negative.
+ */
+export const subtractExitedAssets = (assets: Asset[], exited: Vtxo[]): Asset[] => {
+  if (exited.length === 0) return assets
+  const owed = new Map<string, bigint>()
+  for (const vtxo of exited) {
+    for (const asset of vtxo.assets ?? []) {
+      owed.set(asset.assetId, (owed.get(asset.assetId) ?? BigInt(0)) + asset.amount)
+    }
+  }
+  if (owed.size === 0) return assets
+  const remaining: Asset[] = []
+  for (const asset of assets) {
+    const amount = asset.amount - (owed.get(asset.assetId) ?? BigInt(0))
+    if (amount > BigInt(0)) remaining.push({ ...asset, amount })
+  }
+  return remaining
+}

--- a/src/lib/exitHistory.ts
+++ b/src/lib/exitHistory.ts
@@ -77,8 +77,16 @@ const confirmedAt = async (provider: EsploraProvider, txid: string): Promise<num
  * unconfirmed exit is deliberately not persisted and is retried on the next
  * reload, and the metadata store's LRU cap can evict an old entry.
  *
+ * The lookups fan out rather than run in sequence: `reloadWallet` waits on this,
+ * so on a cold cache a serial loop would hold the UI for the sum of the
+ * round-trips instead of the slowest one. The fan-out is bounded by the number
+ * of distinct exit transactions the wallet has, which is small — a unilateral
+ * exit is a rare, deliberate act, not routine traffic.
+ *
  * Never rejects. It runs inside `reloadWallet`'s try block, whose catch blocks
  * the first load, so a slow explorer must cost a row's date and nothing more.
+ * `confirmedAt` swallows its own failures, which is what keeps `Promise.all`
+ * from turning one dead lookup into a rejection for all of them.
  */
 export const resolveExits = async (vtxos: Vtxo[], network?: string): Promise<ExitRecord[]> => {
   if (vtxos.length === 0) return []
@@ -87,27 +95,22 @@ export const resolveExits = async (vtxos: Vtxo[], network?: string): Promise<Exi
   // Keyed by TRANSACTION, not by coin: `exitedAt` is a property of the exit tx,
   // and one exit can carry several of the wallet's outputs.
   const resolved = new Map<string, number>()
-  const attempted = new Set<string>()
-  const records: ExitRecord[] = []
-  for (const vtxo of vtxos) {
-    let exitedAt = resolved.get(vtxo.txid) ?? stored[vtxo.txid]?.exitedAt
-    if (exitedAt === undefined && provider && !attempted.has(vtxo.txid)) {
-      attempted.add(vtxo.txid)
-      const confirmed = await confirmedAt(provider, vtxo.txid)
-      if (confirmed !== undefined) {
-        saveTransactionActivityMetadata(vtxo.txid, { exitedAt: confirmed })
-        resolved.set(vtxo.txid, confirmed)
-        exitedAt = confirmed
-      }
-    }
-    records.push({
-      txid: vtxo.txid,
-      vout: vtxo.vout,
-      value: vtxo.value,
-      exitedAt: exitedAt ?? receivedAt(vtxo),
+  if (provider) {
+    const pending = [...new Set(vtxos.map((v) => v.txid))].filter((txid) => stored[txid]?.exitedAt === undefined)
+    const times = await Promise.all(pending.map((txid) => confirmedAt(provider, txid)))
+    pending.forEach((txid, i) => {
+      const confirmed = times[i]
+      if (confirmed === undefined) return
+      saveTransactionActivityMetadata(txid, { exitedAt: confirmed })
+      resolved.set(txid, confirmed)
     })
   }
-  return records
+  return vtxos.map((vtxo) => ({
+    txid: vtxo.txid,
+    vout: vtxo.vout,
+    value: vtxo.value,
+    exitedAt: resolved.get(vtxo.txid) ?? stored[vtxo.txid]?.exitedAt ?? receivedAt(vtxo),
+  }))
 }
 
 /**

--- a/src/lib/exitHistory.ts
+++ b/src/lib/exitHistory.ts
@@ -50,17 +50,41 @@ const receivedAt = (vtxo: Vtxo): number => {
   return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000)
 }
 
+/**
+ * How long one lookup may hold the reload before we give up on it.
+ *
+ * Esplora is reached with a plain `fetch`, which has no timeout of its own, and
+ * `getTxStatus` takes no signal to pass one down. A host that accepts the
+ * connection and then never answers is therefore unbounded, and `reloadWallet`
+ * awaits this before it commits anything — so on a first load it would park the
+ * wallet on the loading screen indefinitely, with no error and no retry.
+ *
+ * Giving up costs a date, not a row, and nothing is persisted, so the next
+ * reload asks again. Racing per lookup also bounds the whole fan-out: the
+ * lookups run together, so the set costs one timeout in the worst case however
+ * many exits it holds.
+ */
+const LOOKUP_TIMEOUT_MS = 5_000
+
 /** The exit tx's confirmation time in unix seconds, or undefined while it is
- * unconfirmed or the lookup fails. Never throws: the caller runs inside the
- * reload whose catch blocks first load. */
+ * unconfirmed, the lookup fails, or it outlives `LOOKUP_TIMEOUT_MS`. Never
+ * throws: the caller runs inside the reload whose catch blocks first load. */
 const confirmedAt = async (provider: EsploraProvider, txid: string): Promise<number | undefined> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
   try {
-    const status = await provider.getTxStatus(txid)
+    const status = await Promise.race([
+      provider.getTxStatus(txid),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), LOOKUP_TIMEOUT_MS)
+      }),
+    ])
     // `blockTime` is already unix seconds, which is what `Tx.createdAt` wants.
-    return status.confirmed ? status.blockTime : undefined
+    return status?.confirmed ? status.blockTime : undefined
   } catch (err) {
     consoleError(err, `error resolving exit time for ${txid}`)
     return undefined
+  } finally {
+    clearTimeout(timer)
   }
 }
 
@@ -83,10 +107,12 @@ const confirmedAt = async (provider: EsploraProvider, txid: string): Promise<num
  * of distinct exit transactions the wallet has, which is small — a unilateral
  * exit is a rare, deliberate act, not routine traffic.
  *
- * Never rejects. It runs inside `reloadWallet`'s try block, whose catch blocks
- * the first load, so a slow explorer must cost a row's date and nothing more.
- * `confirmedAt` swallows its own failures, which is what keeps `Promise.all`
- * from turning one dead lookup into a rejection for all of them.
+ * Never rejects, and never hangs. It runs inside `reloadWallet`'s try block,
+ * whose catch blocks the first load, so a slow explorer must cost a row's date
+ * and nothing more. `confirmedAt` swallows its own failures, which is what
+ * keeps `Promise.all` from turning one dead lookup into a rejection for all of
+ * them, and races each against `LOOKUP_TIMEOUT_MS`, which is what keeps a host
+ * that never answers from parking the reload.
  */
 export const resolveExits = async (vtxos: Vtxo[], network?: string): Promise<ExitRecord[]> => {
   if (vtxos.length === 0) return []

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -56,6 +56,11 @@ export const readWalletFromStorage = (): Wallet | undefined => {
 export type TransactionActivityMetadata = {
   assetAction?: 'issued' | 'reissued' | 'burned'
   destination?: string
+  /** When a unilaterally exited VTXO's exit transaction confirmed onchain, in
+   * unix seconds. Shares its entry with the receive row that was created by the
+   * same txid — harmless, since the graft in `activityHistory` reads none of
+   * the other fields from here. See `lib/exitHistory`. */
+  exitedAt?: number
   lnSend?: LnSendActivity
   networkFee?: number
   savedAt: number

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,6 +111,18 @@ export type LnSendSpend = {
   outcome: 'completed' | 'refunded'
 }
 
+/** The kinds of history row the wallet builds, and the only ones anything
+ * branches on. `'exit'` is the unilateral-exit row synthesised from unrolled
+ * VTXOs; the other three come from an activity, an `ArkTransaction`, or the
+ * swap resolver.
+ *
+ * The `(string & {})` arm keeps the union open, mirroring the SDK's own `TxTag`:
+ * `arkTransactionToTx` lowercases whatever `TxType` the SDK hands it, so a new
+ * direction there must widen this type rather than break the build. Open means
+ * a mistyped literal still compiles — what the union buys is that the four we
+ * do branch on are named in one place and autocomplete everywhere. */
+export type TxKind = 'received' | 'sent' | 'exit' | 'swap' | (string & {})
+
 export type Tx = {
   amount: number
   assetAction?: 'issued' | 'reissued' | 'burned'
@@ -134,7 +146,7 @@ export type Tx = {
   redeemTxid: string
   roundTxid: string
   settled: boolean
-  type: string
+  type: TxKind
   assetSwap?: {
     fromAssetId?: string
     fromTicker: string

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -31,7 +31,8 @@ import {
 } from '../lib/storage'
 import { NavigationContext, Pages } from './navigation'
 import { getRestApiExplorerURL } from '../lib/explorers'
-import { getBalance, getVtxos, settleVtxos } from '../lib/asp'
+import { getBalance, getUnrolledVtxos, getVtxos, settleVtxos } from '../lib/asp'
+import { resolveExits, subtractExitedAssets, type ExitRecord } from '../lib/exitHistory'
 import { AspContext } from './asp'
 import { AssetsContext } from './assets'
 import { NotificationsContext } from './notifications'
@@ -183,7 +184,8 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     activities: Activity[]
     metadata: Record<string, TransactionActivityMetadata>
     lnSends: LnSendView[]
-  }>({ activities: [], metadata: {}, lnSends: [] })
+    exits: ExitRecord[]
+  }>({ activities: [], metadata: {}, lnSends: [], exits: [] })
   const [assetSwaps, setAssetSwaps] = useState<WalletAssetSwap[]>([])
   const [balance, setBalance] = useState(0)
   const [availableBalance, setAvailableBalance] = useState(0)
@@ -213,6 +215,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         swaps: assetSwaps,
         metadata: history.metadata,
         lnSends: history.lnSends,
+        exits: history.exits,
         network: aspInfo.network,
         assetDisplay: (id) => assetMetadataCache.current.get(id)?.metadata,
       }),
@@ -233,6 +236,11 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   // user's saved theme (applyTheme(Auto) then falls back to the OS palette).
   const configRef = useRef(config)
   configRef.current = config
+  // Same hazard, same fix: a listener that captured an early `aspInfo` captured
+  // it before the server answered, when the network was still unset. The exit
+  // timestamp lookup needs the live one to pick an explorer.
+  const networkRef = useRef(aspInfo.network)
+  networkRef.current = aspInfo.network
 
   // Each init gets its own AbortSignal; lock/reset aborts the current signal
   // with 'lock-reset' so stale paths can decide whether to tear down the SW.
@@ -487,18 +495,34 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
     try {
       if (isFirstLoad) setLoadingStatus('Fetching coins...')
       const vtxos = await getVtxos(swWallet)
+      // Fetched apart from the set above, which must not learn about exits —
+      // see `getUnrolledVtxos`. Cheap: the worker answers both from its local
+      // repo, so this is a postMessage, not a request.
+      const unrolledVtxos = await getUnrolledVtxos(swWallet)
       if (isFirstLoad) setLoadingStatus('Fetching transactions...')
       const activities = await getActivities(swWallet)
+      // Before the metadata snapshot below, not after: `resolveExits` persists
+      // what it learns, and the history memo reads a snapshot taken here, so a
+      // write that lands after this line stays invisible until the next reload.
+      const exits = await resolveExits(unrolledVtxos, networkRef.current)
       const metadata = readAllTransactionActivityMetadata()
       // Read, never resolved here: `RfqSwapManager` owns a send's outcome and
       // has already written it (see providers/lnSwaps), so this pass only picks
       // up what the store says.
       const lnSends = await lnSendViews()
       if (isFirstLoad) setLoadingStatus('Updating balance...')
-      const { total, available, assets, availableAssets } = await getBalance(swWallet)
+      const { total, available, assets, availableAssets, unrolled } = await getBalance(swWallet)
+      // An exited coin is no longer Arkade money: it cannot be spent offchain,
+      // no batch can lift it back, and this wallet has no path that moves it —
+      // the sweep belongs to the exit tool. The SDK's `total` is right for what
+      // it claims (every sat the wallet owns), but this headline means the
+      // narrower thing, so the bucket is netted out at the display boundary and
+      // the exit is explained by a history row instead. `available` already
+      // excludes it, so Send, Swap and coin selection need nothing.
+      const ownedAssets = subtractExitedAssets(assets, unrolledVtxos)
       // prefetch asset metadata before triggering re-renders
-      if (isFirstLoad && assets.length > 0) setLoadingStatus('Loading asset metadata...')
-      for (const ab of assets) {
+      if (isFirstLoad && ownedAssets.length > 0) setLoadingStatus('Loading asset metadata...')
+      for (const ab of ownedAssets) {
         const cached = assetMetadataCache.current.get(ab.assetId)
         if (cached && Date.now() - cached.cachedAt < ASSET_METADATA_TTL_MS) continue
         try {
@@ -508,16 +532,16 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
           consoleError(err, `error prefetching metadata for ${ab.assetId}`)
         }
       }
-      setBalance(total)
+      setBalance(total - unrolled)
       setAvailableBalance(available)
-      setAssetBalances(assets)
+      setAssetBalances(ownedAssets)
       setAvailableAssetBalances(availableAssets)
-      if (assets.length > 0 && !configRef.current.apps.assets.enabled) {
+      if (ownedAssets.length > 0 && !configRef.current.apps.assets.enabled) {
         const live = configRef.current
         updateConfig({ ...live, apps: { ...live.apps, assets: { enabled: true } } })
       }
       setVtxos(vtxos)
-      setHistory({ activities, metadata, lnSends })
+      setHistory({ activities, metadata, lnSends, exits })
       if (!hasLoadedOnce.current) {
         hasLoadedOnce.current = true
         setDataReady(true)

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -236,11 +236,18 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
   // user's saved theme (applyTheme(Auto) then falls back to the OS palette).
   const configRef = useRef(config)
   configRef.current = config
-  // Same hazard, same fix: a listener that captured an early `aspInfo` captured
-  // it before the server answered, when the network was still unset. The exit
-  // timestamp lookup needs the live one to pick an explorer.
+  // Same hazard: a listener that captured an early `aspInfo` captured it before
+  // the server answered, when the network was still unset. The exit timestamp
+  // lookup needs the live one to pick an explorer. Synced after commit rather
+  // than during render, so the ref only ever holds a network React actually
+  // rendered with — a render that gets discarded must not leave its network
+  // behind for `reloadWallet` to pick an explorer from. Declared here, above
+  // every effect that reloads, so it is the first to run on the commit that
+  // brings the network in.
   const networkRef = useRef(aspInfo.network)
-  networkRef.current = aspInfo.network
+  useEffect(() => {
+    networkRef.current = aspInfo.network
+  }, [aspInfo.network])
 
   // Each init gets its own AbortSignal; lock/reset aborts the current signal
   // with 'lock-reset' so stale paths can decide whether to tear down the SW.

--- a/src/screens/Wallet/Transaction.tsx
+++ b/src/screens/Wallet/Transaction.tsx
@@ -88,6 +88,7 @@ export default function Transaction() {
     ? tx.assetAction === 'issued' || tx.assetAction === 'reissued' || (!tx.assetAction && isIssuance(tx))
     : false
   const burnTx = tx ? tx.assetAction === 'burned' || (!tx.assetAction && isBurn(tx)) : false
+  const exitTx = tx?.type === 'exit'
   const boardingTx = Boolean(tx?.boardingTxid)
   const defaultButtonLabel = 'Settle transaction'
   const boardingExitDelay = Number(aspInfo?.boardingExitDelay || 0)
@@ -186,9 +187,11 @@ export default function Transaction() {
         ? 'Amount issued'
         : burnTx
           ? 'Amount burned'
-          : tx.type === 'sent'
-            ? 'Amount sent'
-            : 'Amount received'
+          : exitTx
+            ? 'Amount exited'
+            : tx.type === 'sent'
+              ? 'Amount sent'
+              : 'Amount received'
   const date = tx.createdAt ? prettyDate(tx.createdAt) : !unconfirmedBoardingTx ? 'Unknown' : 'Unconfirmed'
   const txid = tx.boardingTxid || tx.redeemTxid || tx.roundTxid || ''
   const displayedAssets = amountDisplay?.raw.filter((amount) => amount.assetId) ?? []
@@ -246,7 +249,11 @@ export default function Transaction() {
         date,
         destination: tx.type === 'sent' && !boardingTx && !issuanceTx && !burnTx ? tx.destination : undefined,
         fees,
-        isOffchainTx: !tx.boardingTxid && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
+        // An exit is the one row whose txid is genuinely onchain, so it links
+        // to the block explorer rather than to Arkade's. Without the guard its
+        // `redeemTxid` alone would class it offchain and send the link to the
+        // vmempool explorer, which has never heard of the transaction.
+        isOffchainTx: !tx.boardingTxid && !exitTx && (Boolean(tx.redeemTxid) || Boolean(tx.roundTxid)),
         // Details' fallback row only (amountDisplay owns the rendered rows):
         // gross, matching the hook's convention
         satoshis: assetTransfer ? undefined : tx.amount,

--- a/src/test/components/transactions-list.test.tsx
+++ b/src/test/components/transactions-list.test.tsx
@@ -95,6 +95,48 @@ describe('TransactionsList', () => {
     expect(screen.queryByText('-2,000,000,000.00 BRL')).not.toBeInTheDocument()
   })
 
+  it('reads a unilateral exit as an exit, not as a payment to someone', () => {
+    const tx: Tx = {
+      amount: 5_000,
+      boardingTxid: '',
+      createdAt: 1_700_090_000,
+      explorable: 'exit-txid',
+      networkFee: 0,
+      preconfirmed: false,
+      redeemTxid: 'exit-txid',
+      roundTxid: '',
+      settled: true,
+      type: 'exit',
+    }
+
+    render(
+      <AspContext.Provider value={mockAspContextValue}>
+        <AssetsContext.Provider value={{ isRegistered: () => true } as any}>
+          <NavigationContext.Provider value={mockNavigationContextValue}>
+            <ConfigContext.Provider
+              value={
+                { ...mockConfigContextValue, config: { ...mockConfigContextValue.config, unit: Unit.SATS } } as any
+              }
+            >
+              <FiatContext.Provider value={mockFiatContextValue}>
+                <FlowContext.Provider value={mockFlowContextValue}>
+                  <WalletContext.Provider value={{ ...mockWalletContextValue, txs: [tx] } as any}>
+                    <TransactionsList mode='static' />
+                  </WalletContext.Provider>
+                </FlowContext.Provider>
+              </FiatContext.Provider>
+            </ConfigContext.Provider>
+          </NavigationContext.Provider>
+        </AssetsContext.Provider>
+      </AspContext.Provider>,
+    )
+
+    expect(screen.getByText('Exited')).toBeInTheDocument()
+    expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+    // debited like a send, and at face value: the exit paid no Ark fee
+    expect(screen.getByText(/^-\s*5,000/)).toBeInTheDocument()
+  })
+
   it('shows the bitcoin amount alongside the fiat value on plain BTC rows', () => {
     const tx: Tx = {
       amount: 1600,

--- a/src/test/lib/activityHistory.test.ts
+++ b/src/test/lib/activityHistory.test.ts
@@ -5,6 +5,7 @@ import { activitiesToTxs, getActivities } from '../../lib/activityHistory'
 import { swapActivityResolver } from '@arkade-os/swap'
 import { ASSET_SWAP_ACTIVITY_KIND, assetSwapResolver } from '../../lib/activity/assetSwapResolver'
 import { readAllTransactionActivityMetadata, saveTransactionActivityMetadata } from '../../lib/storage'
+import type { ExitRecord } from '../../lib/exitHistory'
 import type { LnSendView } from '../../lib/lnSendRecords'
 import type { WalletAssetSwap } from '../../lib/swapRepository'
 
@@ -442,4 +443,64 @@ describe('lightning receive activities', () => {
   // A receive that never arrived at all contributes no transaction of ours, so
   // it forms no activity and reaches this function not at all. That absence is
   // upstream of the row builder and cannot be asserted here.
+})
+
+describe('unilateral exits', () => {
+  const exit = (over: Partial<ExitRecord> = {}): ExitRecord => ({
+    txid: 'exit-txid',
+    vout: 0,
+    value: 5_000,
+    exitedAt: 1_700_090_000,
+    ...over,
+  })
+
+  it('synthesises one row per exited coin, keyed on the outpoint', () => {
+    const rows = activitiesToTxs([], { ...empty, exits: [exit({ vout: 0 }), exit({ vout: 1 })] })
+
+    expect(rows).toHaveLength(2)
+    expect(rows.map((row) => row.historyKey).sort()).toEqual(['exit:exit-txid:0', 'exit:exit-txid:1'])
+    expect(rows.every((row) => row.type === 'exit' && row.settled && !row.preconfirmed)).toBe(true)
+    expect(rows.map((row) => row.amount)).toEqual([5_000, 5_000])
+  })
+
+  it('dates the row by the exit, not by the receive that created the coin', () => {
+    const receive = activity('a', [arkTx('receive-txid')])
+
+    const rows = activitiesToTxs([receive], { ...empty, exits: [exit()] })
+    const exitRow = rows.find((row) => row.type === 'exit')
+
+    // the receive is at 1_700_000_000; sorted by the coin's own createdAt the
+    // exit would tie with it instead of leading the list
+    expect(exitRow?.createdAt).toBe(1_700_090_000)
+    expect(rows[0]).toBe(exitRow)
+  })
+
+  it('leaves the original receive standing — the money arrived and then left', () => {
+    const receive = activity('a', [arkTx('receive-txid')])
+
+    const rows = activitiesToTxs([receive], { ...empty, exits: [exit({ txid: 'receive-txid' })] })
+
+    expect(rows).toHaveLength(2)
+    expect(rows.map((row) => row.type).sort()).toEqual(['exit', 'received'])
+  })
+
+  it('does not wear the receive metadata it shares a txid with', () => {
+    saveTransactionActivityMetadata('receive-txid', { destination: 'someone', networkFee: 42 })
+
+    const [row] = activitiesToTxs([], {
+      ...empty,
+      metadata: readAllTransactionActivityMetadata(),
+      exits: [exit({ txid: 'receive-txid' })],
+    })
+
+    expect(row.destination).toBeUndefined()
+    expect(row.networkFee).toBe(0)
+  })
+
+  it('links to the exit transaction', () => {
+    const [row] = activitiesToTxs([], { ...empty, exits: [exit()] })
+
+    expect(row.redeemTxid).toBe('exit-txid')
+    expect(row.boardingTxid).toBe('')
+  })
 })

--- a/src/test/lib/asp.test.ts
+++ b/src/test/lib/asp.test.ts
@@ -29,7 +29,15 @@ vi.mock('@arkade-os/sdk', async (importOriginal) => {
 })
 
 import { ArkNote } from '@arkade-os/sdk'
-import { getAspInfo, aspErrorText, emptyAspInfo, byExpiryAsc, getTxHistory, redeemNotes } from '../../lib/asp'
+import {
+  getAspInfo,
+  aspErrorText,
+  emptyAspInfo,
+  byExpiryAsc,
+  getTxHistory,
+  getUnrolledVtxos,
+  redeemNotes,
+} from '../../lib/asp'
 import { saveTransactionActivityMetadata } from '../../lib/storage'
 import { walletFingerprint } from '../../lib/sentry'
 import fixtures from '../fixtures.json'
@@ -136,5 +144,33 @@ describe('getTxHistory', () => {
     expect(tx).toMatchObject({ redeemTxid: 'ark-txid', type: 'sent' })
     expect(tx.destination).toBeUndefined()
     expect(tx.networkFee).toBeUndefined()
+  })
+})
+
+describe('getUnrolledVtxos', () => {
+  const coin = (over: Record<string, unknown> = {}) => ({ txid: 'a', vout: 0, value: 1_000, isUnrolled: true, ...over })
+
+  it('asks for the exited set and keeps only what came back exited', async () => {
+    const getVtxos = vi.fn().mockResolvedValue([coin({ txid: 'exited' }), coin({ txid: 'live', isUnrolled: false })])
+
+    const result = await getUnrolledVtxos({ getVtxos } as any)
+
+    expect(getVtxos).toHaveBeenCalledWith({ withUnrolled: true })
+    expect(result.map((vtxo) => vtxo.txid)).toEqual(['exited'])
+  })
+
+  it('still returns an exit the user has already swept', async () => {
+    // `withUnrolled` is answered before the terminal-spend check, so the sweep
+    // never removes the coin from this query — which is what makes the history
+    // row permanent rather than one that vanishes when the money is collected.
+    const getVtxos = vi.fn().mockResolvedValue([coin({ txid: 'swept', spentBy: 'sweep-txid', isSpent: true })])
+
+    expect(await getUnrolledVtxos({ getVtxos } as any)).toHaveLength(1)
+  })
+
+  it('degrades to an empty set rather than failing the reload around it', async () => {
+    const getVtxos = vi.fn().mockRejectedValue(new Error('worker unreachable'))
+
+    expect(await getUnrolledVtxos({ getVtxos } as any)).toEqual([])
   })
 })

--- a/src/test/lib/asp.test.ts
+++ b/src/test/lib/asp.test.ts
@@ -186,9 +186,12 @@ describe('getUnrolledVtxos', () => {
     expect(await getUnrolledVtxos({ getVtxos } as any)).toHaveLength(1)
   })
 
-  it('degrades to an empty set rather than failing the reload around it', async () => {
+  it('fails the reload rather than passing off "we could not ask" as "nothing exited"', async () => {
+    // An empty set is spent as fact downstream — no exit rows, no asset
+    // subtraction — while the sats headline still nets out a bucket that came
+    // from a call that did not fail. Throwing keeps the last good snapshot.
     const getVtxos = vi.fn().mockRejectedValue(new Error('worker unreachable'))
 
-    expect(await getUnrolledVtxos({ getVtxos } as any)).toEqual([])
+    await expect(getUnrolledVtxos({ getVtxos } as any)).rejects.toThrow('worker unreachable')
   })
 })

--- a/src/test/lib/asp.test.ts
+++ b/src/test/lib/asp.test.ts
@@ -159,11 +159,29 @@ describe('getUnrolledVtxos', () => {
     expect(result.map((vtxo) => vtxo.txid)).toEqual(['exited'])
   })
 
+  it('drops the ancestors the unroll dragged onchain with the exited coin', async () => {
+    // One exit, not three: unrolling broadcasts the whole chain, so every
+    // earlier coin of ours in it comes back `isUnrolled` too, carrying the same
+    // value. Their offchain spend is what says they are not the money leaving.
+    const getVtxos = vi
+      .fn()
+      .mockResolvedValue([
+        coin({ txid: 'ancestor', spentBy: 'middle' }),
+        coin({ txid: 'middle', isSpent: true }),
+        coin({ txid: 'renewed', settledBy: 'commitment' }),
+        coin({ txid: 'exited' }),
+      ])
+
+    const result = await getUnrolledVtxos({ getVtxos } as any)
+
+    expect(result.map((vtxo) => vtxo.txid)).toEqual(['exited'])
+  })
+
   it('still returns an exit the user has already swept', async () => {
-    // `withUnrolled` is answered before the terminal-spend check, so the sweep
-    // never removes the coin from this query — which is what makes the history
-    // row permanent rather than one that vanishes when the money is collected.
-    const getVtxos = vi.fn().mockResolvedValue([coin({ txid: 'swept', spentBy: 'sweep-txid', isSpent: true })])
+    // The sweep is onchain, and none of the three terminal-spend facts report
+    // an onchain spend — so the row is permanent rather than one that vanishes
+    // when the money is finally collected.
+    const getVtxos = vi.fn().mockResolvedValue([coin({ txid: 'swept', isSwept: true })])
 
     expect(await getUnrolledVtxos({ getVtxos } as any)).toHaveLength(1)
   })

--- a/src/test/lib/exitHistory.test.ts
+++ b/src/test/lib/exitHistory.test.ts
@@ -68,6 +68,33 @@ describe('resolveExits', () => {
     expect(getTxStatus).toHaveBeenCalledTimes(1)
   })
 
+  it('fans the lookups out instead of waiting for each in turn', async () => {
+    const release: (() => void)[] = []
+    getTxStatus.mockImplementation(
+      () => new Promise((resolve) => release.push(() => resolve(confirmed(EXITED_SECONDS)))),
+    )
+
+    const pending = resolveExits([vtxo({ txid: 'exit-a' }), vtxo({ txid: 'exit-b' })], 'mutinynet')
+    await Promise.resolve()
+
+    // Both are in flight while neither has answered. A serial loop would be
+    // parked on the first, showing one call, and would cost the sum of the
+    // round-trips rather than the slowest.
+    expect(getTxStatus).toHaveBeenCalledTimes(2)
+    release.forEach((resolve) => resolve())
+    expect((await pending).map((r) => r.exitedAt)).toEqual([EXITED_SECONDS, EXITED_SECONDS])
+  })
+
+  it('asks only for the exits it has no persisted time for', async () => {
+    saveTransactionActivityMetadata('exit-a', { exitedAt: EXITED_SECONDS })
+    getTxStatus.mockResolvedValue(confirmed(EXITED_SECONDS))
+
+    await resolveExits([vtxo({ txid: 'exit-a' }), vtxo({ txid: 'exit-b' })], 'mutinynet')
+
+    expect(getTxStatus).toHaveBeenCalledTimes(1)
+    expect(getTxStatus).toHaveBeenCalledWith('exit-b')
+  })
+
   it('retries an unconfirmed exit rather than persisting a wrong answer', async () => {
     getTxStatus.mockResolvedValue({ confirmed: false })
 

--- a/src/test/lib/exitHistory.test.ts
+++ b/src/test/lib/exitHistory.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getTxStatus } = vi.hoisted(() => ({ getTxStatus: vi.fn() }))
+
+// Keep the real SDK — `ESPLORA_URL` is read for the network fallback — and only
+// stand in for the provider, so the test controls what the chain says.
+vi.mock('@arkade-os/sdk', async (importOriginal) => {
+  const actual = (await importOriginal()) as any
+  return {
+    ...actual,
+    EsploraProvider: class {
+      constructor(public baseUrl: string) {}
+      getTxStatus = getTxStatus
+    },
+  }
+})
+
+import { resolveExits, subtractExitedAssets } from '../../lib/exitHistory'
+import { readAllTransactionActivityMetadata, saveTransactionActivityMetadata } from '../../lib/storage'
+import type { Vtxo } from '../../lib/types'
+
+beforeEach(() => {
+  localStorage.clear()
+  getTxStatus.mockReset()
+})
+
+const RECEIVED_MS = 1_700_000_000_000
+const RECEIVED_SECONDS = 1_700_000_000
+const EXITED_SECONDS = 1_700_090_000
+
+const vtxo = (over: Partial<Vtxo> = {}): Vtxo =>
+  ({
+    txid: 'exit-txid',
+    vout: 0,
+    value: 5_000,
+    isUnrolled: true,
+    createdAt: new Date(RECEIVED_MS),
+    ...over,
+  }) as unknown as Vtxo
+
+const confirmed = (blockTime: number) => ({ confirmed: true, blockTime, blockHeight: 100 })
+
+describe('resolveExits', () => {
+  it('dates the exit by its onchain confirmation and persists it', async () => {
+    getTxStatus.mockResolvedValue(confirmed(EXITED_SECONDS))
+
+    const [record] = await resolveExits([vtxo()], 'mutinynet')
+
+    expect(record).toEqual({ txid: 'exit-txid', vout: 0, value: 5_000, exitedAt: EXITED_SECONDS })
+    expect(readAllTransactionActivityMetadata()['exit-txid'].exitedAt).toBe(EXITED_SECONDS)
+  })
+
+  it('reuses a persisted time without asking the chain again', async () => {
+    saveTransactionActivityMetadata('exit-txid', { exitedAt: EXITED_SECONDS })
+
+    const [record] = await resolveExits([vtxo()], 'mutinynet')
+
+    expect(record.exitedAt).toBe(EXITED_SECONDS)
+    expect(getTxStatus).not.toHaveBeenCalled()
+  })
+
+  it('looks up once per exit transaction, not once per coin', async () => {
+    getTxStatus.mockResolvedValue(confirmed(EXITED_SECONDS))
+
+    const records = await resolveExits([vtxo({ vout: 0 }), vtxo({ vout: 1 })], 'mutinynet')
+
+    expect(records.map((r) => r.exitedAt)).toEqual([EXITED_SECONDS, EXITED_SECONDS])
+    expect(getTxStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries an unconfirmed exit rather than persisting a wrong answer', async () => {
+    getTxStatus.mockResolvedValue({ confirmed: false })
+
+    const [record] = await resolveExits([vtxo()], 'mutinynet')
+
+    expect(record.exitedAt).toBe(RECEIVED_SECONDS)
+    expect(readAllTransactionActivityMetadata()['exit-txid']).toBeUndefined()
+  })
+
+  it('falls back without persisting when the lookup throws, and does not reject', async () => {
+    getTxStatus.mockRejectedValue(new Error('esplora down'))
+
+    const [record] = await resolveExits([vtxo()], 'mutinynet')
+
+    expect(record.exitedAt).toBe(RECEIVED_SECONDS)
+    expect(readAllTransactionActivityMetadata()['exit-txid']).toBeUndefined()
+  })
+
+  it('asks nobody when no explorer can be named for the network', async () => {
+    const [record] = await resolveExits([vtxo()], 'not-a-network')
+
+    expect(record.exitedAt).toBe(RECEIVED_SECONDS)
+    expect(getTxStatus).not.toHaveBeenCalled()
+  })
+
+  it('names an explorer on mainnet, where the app table has no api entry', async () => {
+    getTxStatus.mockResolvedValue(confirmed(EXITED_SECONDS))
+
+    const [record] = await resolveExits([vtxo()], 'bitcoin')
+
+    expect(record.exitedAt).toBe(EXITED_SECONDS)
+  })
+
+  it('reads a createdAt that came back from storage as an ISO string', async () => {
+    getTxStatus.mockResolvedValue({ confirmed: false })
+
+    const [record] = await resolveExits([vtxo({ createdAt: new Date(RECEIVED_MS).toISOString() as any })], 'mutinynet')
+
+    expect(record.exitedAt).toBe(RECEIVED_SECONDS)
+  })
+
+  it('does nothing at all when nothing has been exited', async () => {
+    expect(await resolveExits([], 'mutinynet')).toEqual([])
+    expect(getTxStatus).not.toHaveBeenCalled()
+  })
+})
+
+describe('subtractExitedAssets', () => {
+  const asset = (assetId: string, amount: bigint) => ({ assetId, amount })
+
+  it('takes the exited amount off the owned figure', () => {
+    const exited = vtxo({ assets: [asset('usdt', BigInt(400))] } as Partial<Vtxo>)
+
+    expect(subtractExitedAssets([asset('usdt', BigInt(1_000))], [exited])).toEqual([asset('usdt', BigInt(600))])
+  })
+
+  it('drops an asset the wallet only held on an exited coin', () => {
+    const exited = vtxo({ assets: [asset('usdt', BigInt(1_000))] } as Partial<Vtxo>)
+
+    expect(subtractExitedAssets([asset('usdt', BigInt(1_000))], [exited])).toEqual([])
+  })
+
+  it('sums several exited coins carrying the same asset', () => {
+    const exits = [
+      vtxo({ vout: 0, assets: [asset('usdt', BigInt(300))] } as Partial<Vtxo>),
+      vtxo({ vout: 1, assets: [asset('usdt', BigInt(200))] } as Partial<Vtxo>),
+    ]
+
+    expect(subtractExitedAssets([asset('usdt', BigInt(1_000))], exits)).toEqual([asset('usdt', BigInt(500))])
+  })
+
+  it('clamps rather than reporting a negative balance', () => {
+    const exited = vtxo({ assets: [asset('usdt', BigInt(9_000))] } as Partial<Vtxo>)
+
+    expect(subtractExitedAssets([asset('usdt', BigInt(1_000))], [exited])).toEqual([])
+  })
+
+  it('leaves assets alone when nothing has been exited, and when exits carry none', () => {
+    const assets = [asset('usdt', BigInt(1_000))]
+
+    expect(subtractExitedAssets(assets, [])).toBe(assets)
+    expect(subtractExitedAssets(assets, [vtxo()])).toBe(assets)
+  })
+})

--- a/src/test/lib/exitHistory.test.ts
+++ b/src/test/lib/exitHistory.test.ts
@@ -5,7 +5,7 @@ const { getTxStatus } = vi.hoisted(() => ({ getTxStatus: vi.fn() }))
 // Keep the real SDK — `ESPLORA_URL` is read for the network fallback — and only
 // stand in for the provider, so the test controls what the chain says.
 vi.mock('@arkade-os/sdk', async (importOriginal) => {
-  const actual = (await importOriginal()) as any
+  const actual = await importOriginal<typeof import('@arkade-os/sdk')>()
   return {
     ...actual,
     EsploraProvider: class {
@@ -111,6 +111,24 @@ describe('resolveExits', () => {
 
     expect(record.exitedAt).toBe(RECEIVED_SECONDS)
     expect(readAllTransactionActivityMetadata()['exit-txid']).toBeUndefined()
+  })
+
+  it('gives up on a lookup that never answers rather than parking the reload', async () => {
+    vi.useFakeTimers()
+    try {
+      // A host that accepts the connection and never replies: `fetch` has no
+      // timeout of its own, so without the race this reload never returns.
+      getTxStatus.mockReturnValue(new Promise(() => {}))
+
+      const pending = resolveExits([vtxo()], 'mutinynet')
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      const [record] = await pending
+      expect(record.exitedAt).toBe(RECEIVED_SECONDS)
+      expect(readAllTransactionActivityMetadata()['exit-txid']).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('asks nobody when no explorer can be named for the network', async () => {

--- a/src/test/screens/wallet/transaction.test.tsx
+++ b/src/test/screens/wallet/transaction.test.tsx
@@ -399,6 +399,61 @@ describe('Transaction screen', () => {
     expect(screen.getByTestId('Total')).toHaveTextContent('0.0001')
   })
 
+  it('labels a unilateral exit and links it to the block explorer, not to Arkade', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const exitTxInfo = {
+      amount: 5_000,
+      boardingTxid: '',
+      createdAt: 1_700_090_000,
+      explorable: 'exit-txid',
+      networkFee: 0,
+      preconfirmed: false,
+      redeemTxid: 'exit-txid',
+      roundTxid: '',
+      settled: true,
+      type: 'exit',
+    }
+
+    render(
+      <NavigationContext.Provider value={mockNavigationContextValue}>
+        <AspContext.Provider value={mockAspContextValue}>
+          <ConfigContext.Provider value={mockConfigContextValue}>
+            <FiatContext.Provider value={mockFiatContextValue}>
+              <FlowContext.Provider value={{ ...mockFlowContextValue, txInfo: exitTxInfo }}>
+                <WalletContext.Provider
+                  value={
+                    {
+                      ...mockWalletContextValue,
+                      txs: [exitTxInfo],
+                      wallet: { ...mockWalletContextValue.wallet, network: 'regtest' },
+                    } as any
+                  }
+                >
+                  <LimitsContext.Provider value={mockLimitsContextValue}>
+                    <Transaction />
+                  </LimitsContext.Provider>
+                </WalletContext.Provider>
+              </FlowContext.Provider>
+            </FiatContext.Provider>
+          </ConfigContext.Provider>
+        </AspContext.Provider>
+      </NavigationContext.Provider>,
+    )
+
+    expect(screen.getByText('Amount exited')).toBeInTheDocument()
+    // no Ark fee: the exit's real cost went to miners across the exit branch
+    expect(screen.getByTestId('Network fees')).toHaveTextContent('0')
+    // an exit is settled, so the receipt must not offer to settle it again
+    expect(screen.queryByText('Settle transaction')).not.toBeInTheDocument()
+
+    const row = document.getElementById('Transaction ID') as HTMLElement
+    await userEvent.click(row.querySelector('.table-row__external') as HTMLElement)
+
+    // the exit tx is on the chain — the vmempool explorer (:7080) never saw it
+    expect(open).toHaveBeenCalledWith('http://localhost:5000/tx/exit-txid', '_blank', 'noreferrer')
+    open.mockRestore()
+  })
+
   it('labels a burn with the exact action and hides the direction row', async () => {
     const mockBurnTxInfo = {
       ...mockIssuanceTxInfo,


### PR DESCRIPTION
- identify correctly unrolled VTXOs and exclude them from available funds. 
- show exit events as ad-hoc activity

## Before/after
<img width="1506" height="927" alt="image" src="https://github.com/user-attachments/assets/4f76835c-87fc-48d4-9969-86fbec1f84a4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for unilateral exits throughout wallet activity and transaction history.
  * Exit transactions now appear as “Exited” with accurate amounts and timestamps.
  * Confirmed exits link to the appropriate blockchain explorer.
  * Wallet balances and asset holdings exclude funds that have exited the Ark layer.

* **Bug Fixes**
  * Improved handling of exited, renewed, and swept funds to prevent inaccurate balances or duplicate activity entries.
  * Added safeguards for delayed blockchain confirmation lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->