### PR TITLE
Route an onchain send through a solver, falling back to the collaborative exit

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,7 @@ jobs:
             test_files: >-
               src/test/e2e/asset.test.ts
               src/test/e2e/send.test.ts
+              src/test/e2e/onchainsend.test.ts
           - group: core
             test_files: >-
               src/test/e2e/backup.test.ts

--- a/src/lib/chainSource.ts
+++ b/src/lib/chainSource.ts
@@ -42,19 +42,24 @@ const MTP_WINDOW = 11
 export const ESPLORA_TIMEOUT_MS = 15_000
 
 /**
- * `fetch` with a deadline, cancelled at both ends.
+ * A whole esplora exchange under one deadline, cancelled at both ends.
  *
- * The signal is what stops a real request; the race is what stops WAITING on
+ * **Takes the operation, not just the request.** `fetch` resolves as soon as
+ * the status and headers arrive — the body is a stream that may still be
+ * running — so a deadline that ends when the response object appears leaves
+ * `.json()` and `.text()` undeadlined, and a server that stalls mid-body hangs
+ * exactly as if there were no timeout at all. `run` therefore covers the read
+ * as well as the request.
+ *
+ * The signal is what stops a real exchange; the race is what stops WAITING on
  * one — an implementation that ignores `signal`, and every injected test double,
  * would otherwise leave the promise pending forever. Belt and braces, because
  * only one of the two is under this file's control.
  */
-const withDeadline = async (
-  fetchImpl: typeof fetch,
-  url: string,
-  init: RequestInit = {},
+const withDeadline = async <T>(
+  run: (signal: AbortSignal) => Promise<T>,
   timeoutMs = ESPLORA_TIMEOUT_MS,
-): Promise<Response> => {
+): Promise<T> => {
   const controller = new AbortController()
   const abortTimer = setTimeout(() => controller.abort(), timeoutMs)
   // Hoisted so the race's timer is cleared too. Leaving it running is harmless
@@ -63,7 +68,7 @@ const withDeadline = async (
   let raceTimer: ReturnType<typeof setTimeout>
   try {
     return await Promise.race([
-      fetchImpl(url, { ...init, signal: controller.signal }),
+      run(controller.signal),
       new Promise<never>((_, reject) => {
         raceTimer = setTimeout(() => reject(new Error(`esplora did not answer within ${timeoutMs}ms`)), timeoutMs)
       }),
@@ -110,17 +115,21 @@ export const esploraChainSource = (
 ): ChainSource => {
   const root = baseUrl.replace(/\/+$/, '')
 
-  const get = async (path: string): Promise<Response> => {
-    const response = await withDeadline(fetchImpl, `${root}${path}`)
-    if (!response.ok) throw new Error(`esplora ${path} failed: ${response.status}`)
-    return response
-  }
+  /** One GET, status check and body read included, under one deadline. */
+  const read = <T>(path: string, body: (response: Response) => Promise<T>): Promise<T> =>
+    withDeadline(async (signal) => {
+      const response = await fetchImpl(`${root}${path}`, { signal })
+      if (!response.ok) throw new Error(`esplora ${path} failed: ${response.status}`)
+      return body(response)
+    })
 
-  const json = async <T>(path: string): Promise<T> => (await get(path)).json() as Promise<T>
+  const json = <T>(path: string): Promise<T> => read(path, (response) => response.json() as Promise<T>)
+
+  const text = (path: string): Promise<string> => read(path, async (response) => (await response.text()).trim())
 
   /** The chain tip's height — the anchor both block reads start from. */
   const tipHeight = async (): Promise<number> => {
-    const height = Number((await (await get('/blocks/tip/height')).text()).trim())
+    const height = Number(await text('/blocks/tip/height'))
     if (!Number.isInteger(height) || height < 0) throw new Error('esplora returned no usable tip height')
     return height
   }
@@ -147,14 +156,16 @@ export const esploraChainSource = (
     async getSpendingTx(txid: string, vout: number): Promise<{ txHex: string } | null> {
       const outspend = await json<{ spent?: boolean; txid?: string }>(`/tx/${txid}/outspend/${vout}`)
       if (!outspend.spent || !outspend.txid) return null
-      return { txHex: (await (await get(`/tx/${outspend.txid}/hex`)).text()).trim() }
+      return { txHex: await text(`/tx/${outspend.txid}/hex`) }
     },
 
     async broadcast(txHex: string): Promise<string> {
-      const response = await withDeadline(fetchImpl, `${root}/tx`, { method: 'POST', body: txHex })
-      const body = (await response.text()).trim()
-      if (!response.ok) throw new Error(`esplora rejected the transaction: ${body || response.status}`)
-      return body
+      return withDeadline(async (signal) => {
+        const response = await fetchImpl(`${root}/tx`, { method: 'POST', body: txHex, signal })
+        const body = (await response.text()).trim()
+        if (!response.ok) throw new Error(`esplora rejected the transaction: ${body || response.status}`)
+        return body
+      })
     },
 
     async getMtp(): Promise<number> {
@@ -196,9 +207,11 @@ export const MIN_CLAIM_FEE_RATE = 1
  */
 export const claimFeeRate = async (baseUrl: string, fetchImpl: typeof fetch = globalFetch): Promise<number> => {
   try {
-    const response = await withDeadline(fetchImpl, `${baseUrl.replace(/\/+$/, '')}/fee-estimates`)
-    if (!response.ok) return MIN_CLAIM_FEE_RATE
-    const estimates = (await response.json()) as Record<string, number>
+    const estimates = await withDeadline(async (signal) => {
+      const response = await fetchImpl(`${baseUrl.replace(/\/+$/, '')}/fee-estimates`, { signal })
+      if (!response.ok) return {} as Record<string, number>
+      return (await response.json()) as Record<string, number>
+    })
     const target = estimates['2'] ?? estimates['1'] ?? estimates['3']
     return typeof target === 'number' && Number.isFinite(target) && target > MIN_CLAIM_FEE_RATE
       ? Math.ceil(target)

--- a/src/lib/chainSource.ts
+++ b/src/lib/chainSource.ts
@@ -29,6 +29,45 @@ import type { ChainSource, ChainUtxo, OnchainNetwork } from '@arkade-os/swap'
 /** How many timestamps consensus takes the median of. */
 const MTP_WINDOW = 11
 
+/**
+ * How long any single esplora request may take.
+ *
+ * Not politeness — `RfqSwapManager` awaits these reads and the claim they lead
+ * to before it schedules its next pass, so one request that never settles stops
+ * the swap being driven at all. On this corridor that is the failure with a
+ * deadline attached: the claim window shuts while the wallet waits on a socket.
+ * A rejection is recoverable (the next pass retries); a hang is not.
+ */
+export const ESPLORA_TIMEOUT_MS = 15_000
+
+/**
+ * `fetch` with a deadline, cancelled at both ends.
+ *
+ * The signal is what stops a real request; the race is what stops WAITING on
+ * one — an implementation that ignores `signal`, and every injected test double,
+ * would otherwise leave the promise pending forever. Belt and braces, because
+ * only one of the two is under this file's control.
+ */
+const withDeadline = async (
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit = {},
+  timeoutMs = ESPLORA_TIMEOUT_MS,
+): Promise<Response> => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await Promise.race([
+      fetchImpl(url, { ...init, signal: controller.signal }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error(`esplora did not answer within ${timeoutMs}ms`)), timeoutMs),
+      ),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 const NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
   bitcoin: btc.NETWORK,
   testnet: btc.TEST_NETWORK,
@@ -62,7 +101,7 @@ export const esploraChainSource = (
   const root = baseUrl.replace(/\/+$/, '')
 
   const get = async (path: string): Promise<Response> => {
-    const response = await fetchImpl(`${root}${path}`)
+    const response = await withDeadline(fetchImpl, `${root}${path}`)
     if (!response.ok) throw new Error(`esplora ${path} failed: ${response.status}`)
     return response
   }
@@ -102,7 +141,7 @@ export const esploraChainSource = (
     },
 
     async broadcast(txHex: string): Promise<string> {
-      const response = await fetchImpl(`${root}/tx`, { method: 'POST', body: txHex })
+      const response = await withDeadline(fetchImpl, `${root}/tx`, { method: 'POST', body: txHex })
       const body = (await response.text()).trim()
       if (!response.ok) throw new Error(`esplora rejected the transaction: ${body || response.status}`)
       return body
@@ -147,7 +186,7 @@ export const MIN_CLAIM_FEE_RATE = 1
  */
 export const claimFeeRate = async (baseUrl: string, fetchImpl: typeof fetch = fetch): Promise<number> => {
   try {
-    const response = await fetchImpl(`${baseUrl.replace(/\/+$/, '')}/fee-estimates`)
+    const response = await withDeadline(fetchImpl, `${baseUrl.replace(/\/+$/, '')}/fee-estimates`)
     if (!response.ok) return MIN_CLAIM_FEE_RATE
     const estimates = (await response.json()) as Record<string, number>
     const target = estimates['2'] ?? estimates['1'] ?? estimates['3']

--- a/src/lib/chainSource.ts
+++ b/src/lib/chainSource.ts
@@ -68,6 +68,16 @@ const withDeadline = async (
   }
 }
 
+/**
+ * The default transport: a bare call to the global, not a reference to it.
+ *
+ * `fetchImpl = fetch` would capture the function object and call it detached.
+ * Browsers happen to tolerate that for a Window operation, but the tolerance is
+ * a WebIDL detail rather than something this file should be relying on, and it
+ * costs nothing to call `fetch` the same way every other module here does.
+ */
+const globalFetch: typeof fetch = (input, init) => fetch(input, init)
+
 const NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
   bitcoin: btc.NETWORK,
   testnet: btc.TEST_NETWORK,
@@ -96,7 +106,7 @@ interface EsploraBlock {
 export const esploraChainSource = (
   baseUrl: string,
   network: OnchainNetwork,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = globalFetch,
 ): ChainSource => {
   const root = baseUrl.replace(/\/+$/, '')
 
@@ -184,7 +194,7 @@ export const MIN_CLAIM_FEE_RATE = 1
  * Never throws. An esplora that cannot answer must not stop a claim that is
  * otherwise ready; the floor still relays.
  */
-export const claimFeeRate = async (baseUrl: string, fetchImpl: typeof fetch = fetch): Promise<number> => {
+export const claimFeeRate = async (baseUrl: string, fetchImpl: typeof fetch = globalFetch): Promise<number> => {
   try {
     const response = await withDeadline(fetchImpl, `${baseUrl.replace(/\/+$/, '')}/fee-estimates`)
     if (!response.ok) return MIN_CLAIM_FEE_RATE

--- a/src/lib/chainSource.ts
+++ b/src/lib/chainSource.ts
@@ -25,6 +25,7 @@
  */
 import * as btc from '@scure/btc-signer'
 import type { ChainSource, ChainUtxo, OnchainNetwork } from '@arkade-os/swap'
+import { L1_NETWORKS } from './onchainPayout'
 
 /** How many timestamps consensus takes the median of. */
 const MTP_WINDOW = 11
@@ -55,16 +56,21 @@ const withDeadline = async (
   timeoutMs = ESPLORA_TIMEOUT_MS,
 ): Promise<Response> => {
   const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  const abortTimer = setTimeout(() => controller.abort(), timeoutMs)
+  // Hoisted so the race's timer is cleared too. Leaving it running is harmless
+  // in effect — rejecting a settled promise is a no-op — but it is one live
+  // timer per esplora call, and this file makes several per swap per poll.
+  let raceTimer: ReturnType<typeof setTimeout>
   try {
     return await Promise.race([
       fetchImpl(url, { ...init, signal: controller.signal }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`esplora did not answer within ${timeoutMs}ms`)), timeoutMs),
-      ),
+      new Promise<never>((_, reject) => {
+        raceTimer = setTimeout(() => reject(new Error(`esplora did not answer within ${timeoutMs}ms`)), timeoutMs)
+      }),
     ])
   } finally {
-    clearTimeout(timer)
+    clearTimeout(abortTimer)
+    clearTimeout(raceTimer!)
   }
 }
 
@@ -77,12 +83,6 @@ const withDeadline = async (
  * costs nothing to call `fetch` the same way every other module here does.
  */
 const globalFetch: typeof fetch = (input, init) => fetch(input, init)
-
-const NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
-  bitcoin: btc.NETWORK,
-  testnet: btc.TEST_NETWORK,
-  regtest: { bech32: 'bcrt', pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef },
-}
 
 interface EsploraUtxo {
   txid: string
@@ -127,7 +127,7 @@ export const esploraChainSource = (
 
   return {
     async getScriptUtxos(pkScript: Uint8Array): Promise<ChainUtxo[]> {
-      const address = btc.Address(NETWORKS[network]).encode(btc.OutScript.decode(pkScript))
+      const address = btc.Address(L1_NETWORKS[network]).encode(btc.OutScript.decode(pkScript))
       const [utxos, tip] = await Promise.all([json<EsploraUtxo[]>(`/address/${address}/utxo`), tipHeight()])
       return utxos.map((utxo) => ({
         txid: utxo.txid,

--- a/src/lib/chainSource.ts
+++ b/src/lib/chainSource.ts
@@ -1,0 +1,160 @@
+/**
+ * The wallet's Bitcoin-L1 view, as `@arkade-os/swap` asks for it.
+ *
+ * The package is backend-free by design: it derives the onchain HTLC, decides
+ * when the fill is claimable, and builds the claim — but every read and the
+ * broadcast belong to the caller. This is that caller, over esplora, which the
+ * wallet already points at per network for its unilateral-exit history.
+ *
+ * Two things here are less obvious than they look.
+ *
+ * **Outputs are looked up by ADDRESS, not by script hash.** `getScriptUtxos`
+ * is handed a `pkScript`, and esplora does expose `/scripthash/:hash/utxo` —
+ * but that hash is byte-reversed by convention, and getting the endianness
+ * wrong returns an empty list rather than an error. An empty list is exactly
+ * what "not funded yet" looks like, so the mistake would not surface as a bug;
+ * it would surface as a claim window that quietly expired. Decoding the script
+ * to its address costs one pure call and cannot fail silently.
+ *
+ * **Median-time-past, not the tip's timestamp.** Consensus matures a
+ * `OP_CHECKLOCKTIMEVERIFY` leaf against MTP — the median of the last eleven
+ * block timestamps — which lags the tip by roughly an hour. Comparing a
+ * locktime against the tip's own timestamp would call a leaf mature before the
+ * network does, and `classifyOnchainHtlc` would report `refundable` while the
+ * claim was in fact still open.
+ */
+import * as btc from '@scure/btc-signer'
+import type { ChainSource, ChainUtxo, OnchainNetwork } from '@arkade-os/swap'
+
+/** How many timestamps consensus takes the median of. */
+const MTP_WINDOW = 11
+
+const NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
+  bitcoin: btc.NETWORK,
+  testnet: btc.TEST_NETWORK,
+  regtest: { bech32: 'bcrt', pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef },
+}
+
+interface EsploraUtxo {
+  txid: string
+  vout: number
+  value: number
+  status?: { confirmed?: boolean; block_height?: number }
+}
+
+interface EsploraBlock {
+  height: number
+  timestamp: number
+}
+
+/**
+ * An esplora-backed `ChainSource`.
+ *
+ * `baseUrl` is the REST root including `/api` where the deployment uses one —
+ * the same string `getRestApiExplorerURL` returns. `fetchImpl` is injectable so
+ * the unit tests can drive every branch without a network.
+ */
+export const esploraChainSource = (
+  baseUrl: string,
+  network: OnchainNetwork,
+  fetchImpl: typeof fetch = fetch,
+): ChainSource => {
+  const root = baseUrl.replace(/\/+$/, '')
+
+  const get = async (path: string): Promise<Response> => {
+    const response = await fetchImpl(`${root}${path}`)
+    if (!response.ok) throw new Error(`esplora ${path} failed: ${response.status}`)
+    return response
+  }
+
+  const json = async <T>(path: string): Promise<T> => (await get(path)).json() as Promise<T>
+
+  /** The chain tip's height — the anchor both block reads start from. */
+  const tipHeight = async (): Promise<number> => {
+    const height = Number((await (await get('/blocks/tip/height')).text()).trim())
+    if (!Number.isInteger(height) || height < 0) throw new Error('esplora returned no usable tip height')
+    return height
+  }
+
+  return {
+    async getScriptUtxos(pkScript: Uint8Array): Promise<ChainUtxo[]> {
+      const address = btc.Address(NETWORKS[network]).encode(btc.OutScript.decode(pkScript))
+      const [utxos, tip] = await Promise.all([json<EsploraUtxo[]>(`/address/${address}/utxo`), tipHeight()])
+      return utxos.map((utxo) => ({
+        txid: utxo.txid,
+        vout: utxo.vout,
+        amount: BigInt(utxo.value),
+        // An unconfirmed output is zero confirmations, not one: it is exactly
+        // the depth `minConfirmations` is being compared against, and calling
+        // a mempool output "1 deep" would let a 1-confirmation policy claim
+        // against a transaction that can still be replaced.
+        confirmations:
+          utxo.status?.confirmed && typeof utxo.status.block_height === 'number'
+            ? Math.max(0, tip - utxo.status.block_height + 1)
+            : 0,
+      }))
+    },
+
+    async getSpendingTx(txid: string, vout: number): Promise<{ txHex: string } | null> {
+      const outspend = await json<{ spent?: boolean; txid?: string }>(`/tx/${txid}/outspend/${vout}`)
+      if (!outspend.spent || !outspend.txid) return null
+      return { txHex: (await (await get(`/tx/${outspend.txid}/hex`)).text()).trim() }
+    },
+
+    async broadcast(txHex: string): Promise<string> {
+      const response = await fetchImpl(`${root}/tx`, { method: 'POST', body: txHex })
+      const body = (await response.text()).trim()
+      if (!response.ok) throw new Error(`esplora rejected the transaction: ${body || response.status}`)
+      return body
+    },
+
+    async getMtp(): Promise<number> {
+      // `/blocks` answers with the ten newest; MTP needs eleven, so the second
+      // page is fetched from where the first ends. Sorting by height rather
+      // than trusting the order means a deployment that pages differently
+      // still yields the right window.
+      const newest = await json<EsploraBlock[]>('/blocks')
+      if (newest.length === 0) throw new Error('esplora returned no blocks')
+      const oldest = Math.min(...newest.map((block) => block.height))
+      const older = oldest > 0 ? await json<EsploraBlock[]>(`/blocks/${oldest - 1}`) : []
+      const timestamps = [...newest, ...older]
+        .sort((a, b) => b.height - a.height)
+        .slice(0, MTP_WINDOW)
+        .map((block) => block.timestamp)
+        .sort((a, b) => a - b)
+      // Fewer than eleven blocks exist only on a fresh regtest chain; the
+      // median of what there is, is what consensus uses there too.
+      return timestamps[Math.floor(timestamps.length / 2)]
+    },
+  }
+}
+
+/** The floor, and what an unusable estimate falls back to. One sat/vB is the
+ * default relay minimum: below it the claim would not propagate at all. */
+export const MIN_CLAIM_FEE_RATE = 1
+
+/**
+ * A fee rate for the L1 claim, sat/vB.
+ *
+ * Deliberately NOT part of `ChainSource`: the package does not ask for one, and
+ * this is a policy choice rather than an observation. The two-block bucket is
+ * the target because the claim races a deadline — `claimOnchainFill` already
+ * refuses inside `ONCHAIN_CLAIM_MARGIN_SECONDS` of the refund leaf, so a claim
+ * that sits unconfirmed is a claim that loses the fill.
+ *
+ * Never throws. An esplora that cannot answer must not stop a claim that is
+ * otherwise ready; the floor still relays.
+ */
+export const claimFeeRate = async (baseUrl: string, fetchImpl: typeof fetch = fetch): Promise<number> => {
+  try {
+    const response = await fetchImpl(`${baseUrl.replace(/\/+$/, '')}/fee-estimates`)
+    if (!response.ok) return MIN_CLAIM_FEE_RATE
+    const estimates = (await response.json()) as Record<string, number>
+    const target = estimates['2'] ?? estimates['1'] ?? estimates['3']
+    return typeof target === 'number' && Number.isFinite(target) && target > MIN_CLAIM_FEE_RATE
+      ? Math.ceil(target)
+      : MIN_CLAIM_FEE_RATE
+  } catch {
+    return MIN_CLAIM_FEE_RATE
+  }
+}

--- a/src/lib/onchainPayout.ts
+++ b/src/lib/onchainPayout.ts
@@ -1,0 +1,54 @@
+/**
+ * The wallet's Bitcoin-L1 side of an onchain send: which key claims the HTLC,
+ * where the claim pays, and whether this deployment can do either at all.
+ *
+ * The key is the wallet's own identity key rather than a fresh one. That is
+ * the same choice `provisionRefundKey` makes in the SDK, for the same reason:
+ * it re-derives from the seed with nothing stored, so a swap survives a
+ * restart, a reinstall, or a restore onto another device — and this corridor's
+ * claim is the one that cannot simply be waited out. A per-swap key would have
+ * to be persisted before funding and would be lost with the record.
+ */
+import * as btc from '@scure/btc-signer'
+import type { IWallet, NetworkName } from '@arkade-os/sdk'
+import type { OnchainNetwork } from '@arkade-os/swap'
+import { getRestApiExplorerURL } from './explorers'
+
+const NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
+  bitcoin: btc.NETWORK,
+  testnet: btc.TEST_NETWORK,
+  regtest: { bech32: 'bcrt', pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef },
+}
+
+/**
+ * The Arkade network name mapped onto a Bitcoin one, mirroring the private
+ * narrowing `requestOnchainSend` applies (`l1NetworkFromArk`): signet,
+ * mutinynet and testnet4 all settle on the same L1 rules as testnet.
+ *
+ * Duplicated rather than imported because the SDK does not export it, and only
+ * used to build the chain source — every stored swap carries the SDK's own
+ * answer in `profile.network`, which is what the claim re-derives from.
+ */
+export const l1NetworkOf = (network: NetworkName | string): OnchainNetwork =>
+  network === 'bitcoin' ? 'bitcoin' : network === 'regtest' ? 'regtest' : 'testnet'
+
+/** The P2TR script an L1 claim pays to, for an x-only key this wallet holds. */
+export const l1PayoutScript = (xOnlyPubkey: Uint8Array, network: OnchainNetwork): Uint8Array =>
+  btc.p2tr(xOnlyPubkey, undefined, NETWORKS[network]).script
+
+/** The x-only key bound into the HTLC's claim leaf. Identity, so it is the
+ * same key at claim time without anything having been written down. */
+export const l1PayoutPubkey = (wallet: IWallet): Promise<Uint8Array> => wallet.identity.xOnlyPublicKey()
+
+/**
+ * Whether this wallet can complete an onchain send at all.
+ *
+ * The gate exists because funding is irreversible and one-sided: the solver
+ * fills an L1 HTLC that only this wallet can open, before a deadline, and a
+ * wallet with no way to watch or broadcast on L1 would fund it and then sit
+ * there. Falling back to a collaborative exit is strictly better than that, so
+ * a network with no esplora endpoint configured simply has no solver route.
+ *
+ * Returns the endpoint so the caller does not look it up twice.
+ */
+export const onchainClaimEndpoint = (network: NetworkName): string | undefined => getRestApiExplorerURL(network)

--- a/src/lib/onchainPayout.ts
+++ b/src/lib/onchainPayout.ts
@@ -2,6 +2,14 @@
  * The wallet's Bitcoin-L1 side of an onchain send: which key claims the HTLC,
  * where the claim pays, and whether this deployment can do either at all.
  *
+ * **Two different things, and conflating them misdirects the payment.** The
+ * HTLC's claim leaf binds a KEY, and only this wallet can hold it — the
+ * recipient cannot sign for us, and an address is not a key in any case. The
+ * claim transaction's OUTPUT is a separate choice made by whoever spends, and
+ * that is where the recipient's address belongs. Pay the claim to the key's own
+ * address and the corridor stops being a payment: the sats land back in this
+ * wallet, on L1, while the screen says the recipient was paid.
+ *
  * The key is the wallet's own identity key rather than a fresh one. That is
  * the same choice `provisionRefundKey` makes in the SDK, for the same reason:
  * it re-derives from the seed with nothing stored, so a swap survives a
@@ -10,6 +18,7 @@
  * to be persisted before funding and would be lost with the record.
  */
 import * as btc from '@scure/btc-signer'
+import { hex } from '@scure/base'
 import type { IWallet, NetworkName } from '@arkade-os/sdk'
 import type { OnchainNetwork } from '@arkade-os/swap'
 import { getRestApiExplorerURL } from './explorers'
@@ -32,13 +41,44 @@ const NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
 export const l1NetworkOf = (network: NetworkName | string): OnchainNetwork =>
   network === 'bitcoin' ? 'bitcoin' : network === 'regtest' ? 'regtest' : 'testnet'
 
-/** The P2TR script an L1 claim pays to, for an x-only key this wallet holds. */
-export const l1PayoutScript = (xOnlyPubkey: Uint8Array, network: OnchainNetwork): Uint8Array =>
-  btc.p2tr(xOnlyPubkey, undefined, NETWORKS[network]).script
+/**
+ * The output script for an L1 address — **where the claim actually pays.**
+ *
+ * The recipient's address, resolved once at quote time and carried on the
+ * record, because the claim can happen days later in another process and the
+ * send flow's state is long gone by then. Throws on an address this network
+ * cannot spend to, which is a reason to exit collaboratively rather than an
+ * error: the send itself is perfectly possible, just not through a solver.
+ */
+export const l1ScriptForAddress = (address: string, network: OnchainNetwork): Uint8Array =>
+  btc.OutScript.encode(btc.Address(NETWORKS[network]).decode(address))
 
 /** The x-only key bound into the HTLC's claim leaf. Identity, so it is the
- * same key at claim time without anything having been written down. */
+ * same key at claim time without anything having been written down.
+ *
+ * Note this is the key that AUTHORISES the claim, never where it pays — see
+ * {@link l1ScriptForAddress} and the module doc. */
 export const l1PayoutPubkey = (wallet: IWallet): Promise<Uint8Array> => wallet.identity.xOnlyPublicKey()
+
+/** Where a stored swap's claim must pay, as the record recorded it. */
+export const CLAIM_PAYOUT_SCRIPT = 'payout_pkscript'
+
+/**
+ * Read the recipient's script back off a stored record.
+ *
+ * Throws rather than falling back to anything. A missing script has exactly one
+ * safe response, and paying somewhere else is not it: refusing the claim leaves
+ * the solver to take its L1 refund and the Arkade lockup to refund to the user,
+ * so the money comes back untouched. Claiming to a guessed script would move it
+ * somewhere nobody asked for, and that is not reversible.
+ */
+export const claimPayoutScript = (profile: Record<string, unknown>): Uint8Array => {
+  const stored = profile[CLAIM_PAYOUT_SCRIPT]
+  if (typeof stored !== 'string' || !stored) {
+    throw new Error('swap record carries no payout script — refusing to claim to anywhere else')
+  }
+  return hex.decode(stored)
+}
 
 /**
  * Whether this wallet can complete an onchain send at all.

--- a/src/lib/onchainPayout.ts
+++ b/src/lib/onchainPayout.ts
@@ -23,7 +23,10 @@ import type { IWallet, NetworkName } from '@arkade-os/sdk'
 import type { OnchainNetwork } from '@arkade-os/swap'
 import { getRestApiExplorerURL } from './explorers'
 
-const NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
+/** The one definition of each L1's address parameters. Shared with
+ * `chainSource.ts`, so the regtest magic bytes cannot drift between the module
+ * that decodes an address and the module that encodes one. */
+export const L1_NETWORKS: Record<OnchainNetwork, typeof btc.NETWORK> = {
   bitcoin: btc.NETWORK,
   testnet: btc.TEST_NETWORK,
   regtest: { bech32: 'bcrt', pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef },
@@ -51,7 +54,7 @@ export const l1NetworkOf = (network: NetworkName | string): OnchainNetwork =>
  * error: the send itself is perfectly possible, just not through a solver.
  */
 export const l1ScriptForAddress = (address: string, network: OnchainNetwork): Uint8Array =>
-  btc.OutScript.encode(btc.Address(NETWORKS[network]).decode(address))
+  btc.OutScript.encode(btc.Address(L1_NETWORKS[network]).decode(address))
 
 /** The x-only key bound into the HTLC's claim leaf. Identity, so it is the
  * same key at claim time without anything having been written down.

--- a/src/lib/onchainSendRecords.ts
+++ b/src/lib/onchainSendRecords.ts
@@ -128,27 +128,6 @@ const onchainSends = async (): Promise<RfqSwapRecord[]> =>
   (await assetSwapRepository.getAllRfqSwaps()).filter((record) => record.kind === 'onchain_send')
 
 /**
- * The stored onchain sends, rebuilt into the live swaps `RfqSwapManager.start`
- * takes. Same shape as `restoreLnSendSwaps`: prune terminal records past their
- * retention window, skip the terminal ones that remain, and skip — never
- * delete — a record whose covenant is no longer in the contract store, because
- * the row it renders is still the history of a real payment.
- *
- * One thing this corridor has that the Lightning leg does not: a record with no
- * funding txid at all. `reserveOnchainSend` writes it BEFORE the lockup is
- * funded, deliberately, so a crash between the write and the funding leaves one
- * behind. Two cases hide under that, and they need opposite treatment — the
- * lockup WAS funded and the second write never landed (must be monitored, this
- * is the whole reason the record is written first), or it was never funded at
- * all (must not be, or the user gets a "Pending" row for a payment they never
- * made, watched until the refund locktime prunes it).
- *
- * Time cannot tell them apart, so `funded` is asked instead: a lockup with no
- * VTXO was never paid. Only records missing a funding txid pay for that read.
- * Omit `funded` and the old behaviour returns — every record is kept — which is
- * what a caller with no indexer should get.
- */
-/**
  * A record that was reserved and then never funded.
  *
  * The one question `reserveOnchainSend`'s ordering creates and nothing else can
@@ -182,6 +161,27 @@ export const isUnfundedReservation = async (
   }
 }
 
+/**
+ * The stored onchain sends, rebuilt into the live swaps `RfqSwapManager.start`
+ * takes. Same shape as `restoreLnSendSwaps`: prune terminal records past their
+ * retention window, skip the terminal ones that remain, and skip — never
+ * delete — a record whose covenant is no longer in the contract store, because
+ * the row it renders is still the history of a real payment.
+ *
+ * One thing this corridor has that the Lightning leg does not: a record with no
+ * funding txid at all. `reserveOnchainSend` writes it BEFORE the lockup is
+ * funded, deliberately, so a crash between the write and the funding leaves one
+ * behind. Two cases hide under that, and they need opposite treatment — the
+ * lockup WAS funded and the second write never landed (must be monitored, this
+ * is the whole reason the record is written first), or it was never funded at
+ * all (must not be, or the user gets a "Pending" row for a payment they never
+ * made, watched until the refund locktime prunes it).
+ *
+ * Time cannot tell them apart, so `funded` is asked instead: a lockup with no
+ * VTXO was never paid. Only records missing a funding txid pay for that read.
+ * Omit `funded` and the old behaviour returns — every record is kept — which is
+ * what a caller with no indexer should get.
+ */
 export const restoreOnchainSendSwaps = async (
   contracts: LockupContractReader,
   funded?: (lockupPkScript: Uint8Array) => Promise<unknown[]>,

--- a/src/lib/onchainSendRecords.ts
+++ b/src/lib/onchainSendRecords.ts
@@ -17,7 +17,7 @@
  * states in capitals: this wallet must claim the L1 fill itself, and a record
  * that did not survive the funding cannot be claimed from.
  */
-import type { ProvisionedClaimSecret, VHTLC } from '@arkade-os/sdk'
+import { ArkAddress, type ProvisionedClaimSecret, type VHTLC } from '@arkade-os/sdk'
 import {
   createRfqSwapRecord,
   isRfqSwapTerminal,
@@ -133,9 +133,46 @@ const onchainSends = async (): Promise<RfqSwapRecord[]> =>
  * retention window, skip the terminal ones that remain, and skip — never
  * delete — a record whose covenant is no longer in the contract store, because
  * the row it renders is still the history of a real payment.
+ *
+ * One thing this corridor has that the Lightning leg does not: a record with no
+ * funding txid at all. `reserveOnchainSend` writes it BEFORE the lockup is
+ * funded, deliberately, so a crash between the write and the funding leaves one
+ * behind. Two cases hide under that, and they need opposite treatment — the
+ * lockup WAS funded and the second write never landed (must be monitored, this
+ * is the whole reason the record is written first), or it was never funded at
+ * all (must not be, or the user gets a "Pending" row for a payment they never
+ * made, watched until the refund locktime prunes it).
+ *
+ * Time cannot tell them apart, so `funded` is asked instead: a lockup with no
+ * VTXO was never paid. Only records missing a funding txid pay for that read.
+ * Omit `funded` and the old behaviour returns — every record is kept — which is
+ * what a caller with no indexer should get.
  */
+/**
+ * A record that was reserved and then never funded.
+ *
+ * The one question `reserveOnchainSend`'s ordering creates and nothing else can
+ * answer. A record with no funding txid has two possible histories that need
+ * opposite treatment — the lockup WAS funded and the second write never landed,
+ * or it was never funded at all — and only the chain distinguishes them, so a
+ * caller with no chain reader gets `false` and keeps everything. A record that
+ * already names its funding transaction is never asked about: it is funded by
+ * construction, and the read would be a round trip for a known answer.
+ *
+ * Deliberately conservative: anything other than "no outputs at this lockup"
+ * keeps the record, because dropping a funded one abandons a real claim.
+ */
+export const isUnfundedReservation = async (
+  record: Pick<RfqSwapRecord, 'fundingArkTxid' | 'lockupAddress'>,
+  funded?: (lockupPkScript: Uint8Array) => Promise<unknown[]>,
+): Promise<boolean> => {
+  if (record.fundingArkTxid || !funded) return false
+  return (await funded(ArkAddress.decode(record.lockupAddress).pkScript)).length === 0
+}
+
 export const restoreOnchainSendSwaps = async (
   contracts: LockupContractReader,
+  funded?: (lockupPkScript: Uint8Array) => Promise<unknown[]>,
   nowSeconds = Math.floor(Date.now() / 1000),
 ): Promise<PersistableRfqSwap[]> => {
   let records: RfqSwapRecord[]
@@ -153,6 +190,15 @@ export const restoreOnchainSendSwaps = async (
       continue
     }
     if (isRfqSwapTerminal(record.state)) continue
+    // Asked BEFORE the rebuild: a record with nothing behind it is not worth a
+    // contract read, and dropping it must not depend on its covenant still
+    // being in the store.
+    if (await isUnfundedReservation(record, funded)) {
+      await assetSwapRepository
+        .removeRfqSwap(record.rfqId)
+        .catch((err) => consoleError(err, 'error dropping an unfunded onchain send'))
+      continue
+    }
     try {
       live.push(rebuildRfqSwap(record, await lockupContractParams(contracts, record.lockupAddress)))
     } catch (err) {

--- a/src/lib/onchainSendRecords.ts
+++ b/src/lib/onchainSendRecords.ts
@@ -33,6 +33,8 @@ import {
   type PersistableRfqSwap,
   type RfqSwapRecord,
 } from '@arkade-os/swap'
+import { hex } from '@scure/base'
+import { CLAIM_PAYOUT_SCRIPT } from './onchainPayout'
 import { consoleError } from './logs'
 import { assetSwapRepository } from './swapRepository'
 
@@ -47,6 +49,17 @@ export interface OnchainSendRecordFacts {
   secrets: ProvisionedClaimSecret
   /** The Arkade covenant. Without it the manager can only poll. */
   script: InstanceType<typeof VHTLC.ScriptV2>
+  /**
+   * The RECIPIENT's L1 output script — where the claim pays.
+   *
+   * A wallet-private profile key, because the package has none: the claim
+   * transaction's output is the spender's own choice and nothing in
+   * `OnchainSendProfile`, the quote, or the HTLC records it. It has to be here
+   * because the claim can run in a later process, and the only alternative a
+   * claim-time derivation could reach is this wallet's own address — which
+   * would quietly turn a payment into a transfer to self.
+   */
+  payoutPkScript: Uint8Array
   /** The expected L1 fill — what this wallet has to watch and claim. */
   htlc: OnchainHtlc
   /** The inputs the HTLC was built from. Nothing else gives them back. */
@@ -103,6 +116,7 @@ export const onchainSendSwapRecord = (input: OnchainSendRecordInput, nowSeconds?
       profile: {
         ...rfqSecretsProfile(input.secrets, input.paymentHash),
         ...onchainSendProfile(input),
+        [CLAIM_PAYOUT_SCRIPT]: hex.encode(input.payoutPkScript),
       },
       amount: input.amount,
       ...(input.fundingTxid ? { fundingArkTxid: input.fundingTxid } : {}),

--- a/src/lib/onchainSendRecords.ts
+++ b/src/lib/onchainSendRecords.ts
@@ -1,0 +1,149 @@
+/**
+ * The store behind the onchain-send leg, in the same repository the Lightning
+ * sends use. `lnSendRecords.ts` owns the generic half — reading, writing, and
+ * the manager's `saveSwap` — so this file is only what is different about
+ * `arkade:BTC -> onchain:BTC`.
+ *
+ * What is different is that this corridor's second contract has nowhere else
+ * to live. The Arkade lockup gets a contract row, so `rebuildRfqSwap` can
+ * derive it back from the wallet's own contract store; the L1 HTLC is a
+ * Bitcoin output, not an Arkade artifact, and `OnchainHtlc` exposes only
+ * derived values — never the keys it was built from. `onchainSendProfile` is
+ * the package's own mapper for exactly that, and skipping it in favour of
+ * copying fields by hand is how a restored swap ends up watching an address
+ * nobody funded (see its docstring: the renames are not cosmetic).
+ *
+ * Persisting all of this BEFORE funding is the obligation `requestOnchainSend`
+ * states in capitals: this wallet must claim the L1 fill itself, and a record
+ * that did not survive the funding cannot be claimed from.
+ */
+import type { ProvisionedClaimSecret, VHTLC } from '@arkade-os/sdk'
+import {
+  createRfqSwapRecord,
+  isRfqSwapTerminal,
+  lockupContractParams,
+  onchainSendProfile,
+  rebuildRfqSwap,
+  rfqSecretsProfile,
+  shouldRetainRfqSwap,
+  type LockupContractReader,
+  type OnchainHtlc,
+  type OnchainHtlcParams,
+  type OnchainNetwork,
+  type PersistableRfqSwap,
+  type RfqSwapRecord,
+} from '@arkade-os/swap'
+import { consoleError } from './logs'
+import { assetSwapRepository } from './swapRepository'
+
+/** What the quote knew and nothing afterwards can give back. All public:
+ * `secrets` is a descriptor for recovering the sender key and the preimage,
+ * never key material — see `requestOnchainSend`. */
+export interface OnchainSendRecordFacts {
+  /** `sha256(P)`, hex. The SAME hash both legs carry: one P unlocks both. */
+  paymentHash: string
+  /** The ARKADE lockup's `refund_locktime`, unix seconds. Not the L1 one. */
+  refundLocktime: number
+  secrets: ProvisionedClaimSecret
+  /** The Arkade covenant. Without it the manager can only poll. */
+  script: InstanceType<typeof VHTLC.ScriptV2>
+  /** The expected L1 fill — what this wallet has to watch and claim. */
+  htlc: OnchainHtlc
+  /** The inputs the HTLC was built from. Nothing else gives them back. */
+  htlcParams: OnchainHtlcParams
+  l1Network: OnchainNetwork
+  minConfirmations: number
+}
+
+export interface OnchainSendRecordInput extends OnchainSendRecordFacts {
+  rfqId: string
+  /** The Arkade address that was funded — the lockup covenant. */
+  lockupAddress: string
+  /** Sats the lockup was funded with. */
+  amount: number
+  /**
+   * The tx the wallet signed to fund it — absent on the record written BEFORE
+   * funding.
+   *
+   * That record is not an optimisation. `requestOnchainSend` states the
+   * obligation in capitals: this corridor's L1 claim is the wallet's own, and
+   * everything needed to make it is in this record and nowhere else. A store
+   * that only learns about the swap once the funding transaction came back has
+   * a window in which the lockup is funded and the HTLC unclaimable, and the
+   * width of that window is however long a tab takes to close.
+   */
+  fundingTxid?: string
+}
+
+/** The live swap the manager drives, for a send just funded. */
+export const onchainSendSwap = (
+  input: OnchainSendRecordInput,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): PersistableRfqSwap => ({
+  kind: 'onchain_send',
+  rfqId: input.rfqId,
+  state: 'pending',
+  lockupPkScript: input.script.pkScript,
+  lockup: { script: input.script, address: input.lockupAddress },
+  paymentHash: input.paymentHash,
+  refundLocktime: input.refundLocktime,
+  htlc: input.htlc,
+  minConfirmations: input.minConfirmations,
+  createdAt: nowSeconds,
+  updatedAt: nowSeconds,
+})
+
+/** Its first record. `rfqSecretsProfile` first, then the corridor's own half
+ * through the package's mapper — the uniform rule `rfqCorridors.ts` keeps. */
+export const onchainSendSwapRecord = (input: OnchainSendRecordInput, nowSeconds?: number): RfqSwapRecord =>
+  createRfqSwapRecord(
+    {
+      kind: 'onchain_send',
+      lockupAddress: input.lockupAddress,
+      profile: {
+        ...rfqSecretsProfile(input.secrets, input.paymentHash),
+        ...onchainSendProfile(input),
+      },
+      amount: input.amount,
+      ...(input.fundingTxid ? { fundingArkTxid: input.fundingTxid } : {}),
+    },
+    onchainSendSwap(input, nowSeconds),
+  )
+
+const onchainSends = async (): Promise<RfqSwapRecord[]> =>
+  (await assetSwapRepository.getAllRfqSwaps()).filter((record) => record.kind === 'onchain_send')
+
+/**
+ * The stored onchain sends, rebuilt into the live swaps `RfqSwapManager.start`
+ * takes. Same shape as `restoreLnSendSwaps`: prune terminal records past their
+ * retention window, skip the terminal ones that remain, and skip — never
+ * delete — a record whose covenant is no longer in the contract store, because
+ * the row it renders is still the history of a real payment.
+ */
+export const restoreOnchainSendSwaps = async (
+  contracts: LockupContractReader,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<PersistableRfqSwap[]> => {
+  let records: RfqSwapRecord[]
+  try {
+    records = await onchainSends()
+  } catch (err) {
+    consoleError(err, 'error reading onchain send swap records')
+    return []
+  }
+
+  const live: PersistableRfqSwap[] = []
+  for (const record of records) {
+    if (!shouldRetainRfqSwap(record, nowSeconds)) {
+      await assetSwapRepository.removeRfqSwap(record.rfqId).catch((err) => consoleError(err, 'error pruning record'))
+      continue
+    }
+    if (isRfqSwapTerminal(record.state)) continue
+    try {
+      live.push(rebuildRfqSwap(record, await lockupContractParams(contracts, record.lockupAddress)))
+    } catch (err) {
+      consoleError(err, `cannot rebuild onchain send swap ${record.rfqId}`)
+    }
+  }
+  return live
+}

--- a/src/lib/onchainSendRecords.ts
+++ b/src/lib/onchainSendRecords.ts
@@ -159,15 +159,27 @@ const onchainSends = async (): Promise<RfqSwapRecord[]> =>
  * already names its funding transaction is never asked about: it is funded by
  * construction, and the read would be a round trip for a known answer.
  *
- * Deliberately conservative: anything other than "no outputs at this lockup"
- * keeps the record, because dropping a funded one abandons a real claim.
+ * Deliberately conservative: anything other than a successful lookup returning
+ * no outputs keeps the record — a failed lookup included — because dropping a
+ * funded one abandons a real claim.
  */
 export const isUnfundedReservation = async (
   record: Pick<RfqSwapRecord, 'fundingArkTxid' | 'lockupAddress'>,
   funded?: (lockupPkScript: Uint8Array) => Promise<unknown[]>,
 ): Promise<boolean> => {
   if (record.fundingArkTxid || !funded) return false
-  return (await funded(ArkAddress.decode(record.lockupAddress).pkScript)).length === 0
+  try {
+    return (await funded(ArkAddress.decode(record.lockupAddress).pkScript)).length === 0
+  } catch (err) {
+    // A lookup that failed is not evidence of anything, and it must not
+    // propagate: `restoreOnchainSendSwaps` runs inside the provider's
+    // `Promise.all`, so a rejection here stops `RfqSwapManager.start` from
+    // running at all — every swap on both send legs, including funded ones
+    // waiting on an L1 claim. An esplora blip at startup would cost far more
+    // than the stale row this check exists to avoid.
+    consoleError(err, `cannot tell whether onchain send ${record.lockupAddress} was funded`)
+    return false
+  }
 }
 
 export const restoreOnchainSendSwaps = async (

--- a/src/lib/onchainSwap.ts
+++ b/src/lib/onchainSwap.ts
@@ -1,0 +1,392 @@
+/**
+ * The wallet's boundary onto the `arkade:BTC -> onchain:BTC` corridor — paying
+ * an L1 address out of an Arkade balance through a solver instead of through a
+ * collaborative exit.
+ *
+ * Two jobs, mirroring `lnSwap.ts` for the Lightning leg:
+ *
+ * 1. Pick the rendezvous out of the discovered markets, and refuse a card that
+ *    serves the pair but not the SIZE. The two refusals are distinct values
+ *    rather than one `undefined`, because the send flow has to say which one
+ *    happened: "no solver serves this" and "no solver serves 4,000,000 sats"
+ *    are different problems for the user, and both have to be visible when the
+ *    wallet quietly does a collaborative exit instead.
+ * 2. Negotiate the quote and hand back what the caller must fund.
+ *
+ * **The fallback is the whole point.** Every failure here — no card, a card
+ * that cannot take the size, a refusal, a timeout, a quote that does not price
+ * the trade the user asked for — is a reason to do the collaborative exit the
+ * wallet has always done, never a reason to fail the payment. So nothing in
+ * this file decides that; it reports, and `Form.tsx` chooses. What must NOT
+ * happen is a silent swallow, which is why the reasons are a closed set.
+ *
+ * Everything the swap client itself does — deriving BOTH contracts locally,
+ * refusing a lockup address it did not derive, the `assertFundable` gates on
+ * the timelock order and the L1 claim window — stays in `@arkade-os/swap`.
+ */
+import { hex } from '@scure/base'
+import { marketCorridor, sideLimits, type DiscoveredMarket } from '@arkade-os/solver-discovery'
+import {
+  requestOnchainSend,
+  type OnchainHtlc,
+  type OnchainHtlcParams,
+  type OnchainNetwork,
+  type RfqTransport,
+} from '@arkade-os/swap'
+import type { OnchainSendRecordFacts } from './onchainSendRecords'
+
+/**
+ * Where to reach the solver for an onchain send, and the bounds its card
+ * advertises. Structurally the same as `LnSendRendezvous` — deliberately, so
+ * `withRfqTransport` takes either — but kept as its own type because the
+ * corridor it names is different.
+ */
+export interface OnchainSendRendezvous {
+  solverPubkey: string
+  transports: { nostr: { relays: string[] } }
+  /** The card's `emulator_pubkey`, x-only hex. See `lnSwap.ts` for why the
+   * covenant cannot be derived without it. */
+  emulatorPubkey: string
+  /** Card bounds on the onchain side, sats. Indicative; the quote binds. */
+  minSats: number
+  maxSats: number
+}
+
+/**
+ * Why the solver route was not taken. A closed set so the caller can branch,
+ * and so the log line that explains a collaborative exit is a value rather
+ * than a string someone has to keep in sync.
+ */
+export type OnchainRouteRefusal =
+  /** No discovered card advertises `arkade:BTC -> onchain:BTC` at all. */
+  | 'no_solver'
+  /** A card serves the pair, but not at this size. */
+  | 'amount_out_of_bounds'
+  /**
+   * This wallet has no Bitcoin-L1 endpoint for the network, so it could not
+   * watch or claim the fill the solver would make. Checked BEFORE quoting: a
+   * funded HTLC nobody opens is worse than a collaborative exit, and the
+   * whole point of the fallback is that the wallet never gets into that state.
+   */
+  | 'no_l1_endpoint'
+  /** Market discovery itself failed — an unreachable registry, a bad cache. */
+  | 'discovery_failed'
+  /** The negotiation failed: a refusal, a timeout, a quote we would not fund. */
+  | 'quote_failed'
+
+/** The solver route is unavailable, and the caller should exit collaboratively. */
+export class OnchainRouteUnavailable extends Error {
+  readonly reason: OnchainRouteRefusal
+  /** The bounds that rejected the amount, when that is what happened. */
+  readonly bounds?: { minSats: number; maxSats: number }
+
+  constructor(
+    reason: OnchainRouteRefusal,
+    message: string,
+    options?: { bounds?: OnchainRouteUnavailable['bounds']; cause?: unknown },
+  ) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined)
+    this.name = 'OnchainRouteUnavailable'
+    this.reason = reason
+    this.bounds = options?.bounds
+  }
+}
+
+/**
+ * The prefix every routing decision is logged under.
+ *
+ * A constant because it is the ONLY trace of a choice the user never sees: an
+ * exit that fell back looks exactly like an exit that was always going to be
+ * collaborative. Exported so the e2e test asserts on the same string the code
+ * writes rather than a copy of it.
+ */
+export const ONCHAIN_ROUTE_LOG = 'onchain send:'
+
+/** 64 lowercase hex chars — the registry's own `emulator_pubkey` pattern. */
+const XONLY_HEX = /^[0-9a-f]{64}$/
+
+/** What a market's card must carry before it can be a rendezvous, resolved
+ * under the same rules the Lightning corridor uses (see `lnSwap.ts`): the
+ * card's own `emulator_pubkey` wins, an absent one falls back to the pinned
+ * per-network key, a malformed one fails closed even with a pin, and a
+ * disagreement between the two is skipped rather than resolved. */
+const rendezvousOf = (market: DiscoveredMarket, pinned?: string): OnchainSendRendezvous | undefined => {
+  const transports = { nostr: { relays: market.transports?.nostr?.relays ?? [] } }
+  if (!market.discovery_pubkey || !transports.nostr.relays.length) return undefined
+
+  const advertised = (market as { emulator_pubkey?: unknown }).emulator_pubkey
+  const emulatorPubkey =
+    advertised === undefined || advertised === null || advertised === ''
+      ? pinned
+      : typeof advertised === 'string' && XONLY_HEX.test(advertised)
+        ? advertised
+        : undefined
+  if (!emulatorPubkey) return undefined
+  if (pinned && emulatorPubkey !== pinned) return undefined
+
+  // A side's bounds are what the SOLVER pays out on it, so the send leg —
+  // arkade in, L1 out — is bounded by the quote (onchain) side. `sideLimits`
+  // is the registry's own parser and reads a disabled side (max "0") or a
+  // malformed bound as null, which is what keeps a disabled corridor from
+  // reaching the user as "amount outside solver bounds".
+  const bounds = sideLimits(market, 'quote')
+  if (!bounds) return undefined
+
+  return {
+    solverPubkey: market.discovery_pubkey,
+    transports,
+    emulatorPubkey,
+    minSats: Number(bounds.min),
+    maxSats: Number(bounds.max),
+  }
+}
+
+/**
+ * Pick the onchain-send rendezvous for THIS amount.
+ *
+ * The size check is not a courtesy. A card advertises the range its solver can
+ * actually fill, and quoting outside it burns a negotiation, tells a third
+ * party what the user is about to do, and comes back as `amount_out_of_range`
+ * anyway — so a card that serves the pair but not the size must not be
+ * selected. It is skipped, not fatal: another card may take the size, and only
+ * when none does is `amount_out_of_bounds` reported, carrying the widest range
+ * seen so the caller can say what would have fitted.
+ *
+ * Returns a refusal rather than throwing, because "no solver" is the ordinary
+ * case for a wallet with no cards and the ordinary case must not be an error.
+ */
+export const onchainSendRendezvous = (
+  markets: DiscoveredMarket[],
+  amountSats: number,
+  fallbackEmulatorPubkey?: Uint8Array,
+):
+  | { ok: true; rendezvous: OnchainSendRendezvous }
+  | { ok: false; reason: 'no_solver' }
+  | { ok: false; reason: 'amount_out_of_bounds'; bounds: { minSats: number; maxSats: number } } => {
+  const pinned = fallbackEmulatorPubkey ? hex.encode(fallbackEmulatorPubkey) : undefined
+  let widest: { minSats: number; maxSats: number } | undefined
+
+  for (const market of markets) {
+    // The send leg goes arkade -> L1: anything else on the base side is a
+    // corridor this wallet cannot fund from, and the receive direction lives
+    // on the other side of the same market.
+    if (marketCorridor(market, 'base') !== 'arkade') continue
+    if (marketCorridor(market, 'quote') !== 'onchain') continue
+
+    const rendezvous = rendezvousOf(market, pinned)
+    if (!rendezvous) continue
+
+    const { minSats, maxSats } = rendezvous
+    if (amountSats >= minSats && amountSats <= maxSats) return { ok: true, rendezvous }
+
+    // Serves the pair, not the size. Remember the range so the caller can name
+    // one, preferring the widest on offer.
+    if (!widest || maxSats - minSats > widest.maxSats - widest.minSats) widest = { minSats, maxSats }
+  }
+
+  if (widest) return { ok: false, reason: 'amount_out_of_bounds', bounds: widest }
+  return { ok: false, reason: 'no_solver' }
+}
+
+/**
+ * What the send flow needs in order to pay. Deliberately no swap object to
+ * "execute" later: funding the address IS acceptance, exactly as on the
+ * Lightning leg.
+ */
+export interface OnchainSendRequest {
+  /** Negotiation id, for correlating status lookups. */
+  rfqId: string
+  /** The wallet's OWN derivation of the Arkade lockup. Fund only this. */
+  address: string
+  /** Sats the lockup must carry — what LEAVES the wallet. */
+  fundAmount: number
+  /** Sats that land at the user's L1 address — the quote's `to_amount`. */
+  payoutAmount: number
+  /** Unix seconds after which the quote is dead and must not be funded. */
+  validUntil: number
+  rendezvous: OnchainSendRendezvous
+  /** What the record needs and nothing later can give back. */
+  record: OnchainSendRecordFacts
+  /** The expected L1 fill, for the claim this wallet must make. */
+  htlc: OnchainHtlc
+  htlcParams: OnchainHtlcParams
+  l1Network: OnchainNetwork
+  minConfirmations: number
+}
+
+/**
+ * Negotiate an onchain-send quote and return what the caller must fund.
+ *
+ * `amountSide: 'from'` — the user types what leaves the wallet, which is how
+ * this wallet has always priced an onchain send (the fee comes out of the
+ * amount, see `Details.tsx`), so the solver route displays on the existing
+ * screen without changing what the number means.
+ *
+ * Two checks the package does not make on this leg, both cheap and both about
+ * paying more than the user agreed to:
+ *
+ * - the quote must price the trade that was ASKED for. `assertQuotedAmount` is
+ *   applied on the receive legs only, so a send quote naming a different
+ *   `from_amount` would otherwise be funded at the solver's number.
+ * - it must actually deliver something. A quote whose payout is zero, negative
+ *   or larger than the input is not one to fund.
+ */
+export const requestOnchainExit = async (args: {
+  wallet: Parameters<typeof requestOnchainSend>[0]
+  arkServerUrl: string
+  transport: RfqTransport
+  /** Sats to spend — `quote.from_amount` must come back equal to this. */
+  amountSats: number
+  /** The user's x-only L1 key that will claim the HTLC. */
+  payoutPubkey: Uint8Array
+  rendezvous: OnchainSendRendezvous
+  /** 33-byte compressed hex override for the covenant co-signer, when this
+   * deployment pins one. Absent lets the package use its per-network pin. */
+  emulatorPubkey?: string
+}): Promise<OnchainSendRequest> => {
+  const result = await requestOnchainSend(args.wallet, args.arkServerUrl, args.transport, {
+    amount: args.amountSats,
+    amountSide: 'from',
+    payoutPubkey: args.payoutPubkey,
+    ...(args.emulatorPubkey ? { emulatorPubkey: args.emulatorPubkey } : {}),
+  })
+
+  if (result.fundAmount !== args.amountSats) {
+    throw new Error(`solver quoted ${result.fundAmount} sats in, not the requested ${args.amountSats}`)
+  }
+  const payoutAmount = result.quote.to_amount
+  if (!Number.isInteger(payoutAmount) || payoutAmount <= 0 || payoutAmount >= result.fundAmount) {
+    throw new Error(`solver quoted an unusable payout of ${String(payoutAmount)} sats`)
+  }
+
+  return {
+    rfqId: result.rfqId,
+    address: result.address,
+    fundAmount: result.fundAmount,
+    payoutAmount,
+    validUntil: result.quote.valid_until,
+    rendezvous: args.rendezvous,
+    htlc: result.htlc,
+    htlcParams: result.htlcParams,
+    l1Network: result.l1Network,
+    minConfirmations: result.minConfirmations,
+    record: {
+      paymentHash: result.htlcParams.paymentHash,
+      // The ARKADE lockup's deadline, not the L1 HTLC's. `assertFundable`'s
+      // timelock-order gate has already put the two in the required order.
+      refundLocktime: result.quote.refund_locktime ?? 0,
+      secrets: result.secrets,
+      script: result.script,
+      htlc: result.htlc,
+      htlcParams: result.htlcParams,
+      l1Network: result.l1Network,
+      minConfirmations: result.minConfirmations,
+    },
+  }
+}
+
+/** The user-facing half of a refusal — what the send screen shows when it
+ * quietly falls back. Kept beside the reasons so a new one cannot be added
+ * without a message. */
+export const onchainRouteRefusalText = (error: OnchainRouteUnavailable): string => {
+  switch (error.reason) {
+    case 'no_solver':
+      return 'No solver serves onchain sends — using a collaborative exit'
+    case 'amount_out_of_bounds':
+      return error.bounds
+        ? `Amount outside solver bounds (${error.bounds.minSats}-${error.bounds.maxSats} sats) — using a collaborative exit`
+        : 'Amount outside solver bounds — using a collaborative exit'
+    case 'no_l1_endpoint':
+      return 'No Bitcoin endpoint for this network — using a collaborative exit'
+    case 'discovery_failed':
+      return 'Could not reach the solver registry — using a collaborative exit'
+    case 'quote_failed':
+      return 'No usable solver quote — using a collaborative exit'
+  }
+}
+
+/**
+ * The whole solver route, as one decision: can a solver take this send, and if
+ * so what must be funded.
+ *
+ * **Rejects with `OnchainRouteUnavailable` and nothing else.** Every step
+ * inside — discovery, selection, the size check, the negotiation, the client's
+ * own address and gate checks — is a way for the answer to be "no", and the
+ * caller's response to all of them is identical: do the collaborative exit.
+ * Collapsing them to one rejection type is what stops a new failure mode
+ * inside `@arkade-os/swap` from escaping as an unhandled error and taking a
+ * payment down that the wallet could always have made. The original is kept as
+ * `cause` and the `reason` says which step, so the fallback is never silent.
+ *
+ * The seams (`discover`, `connect`) are injected for the same reason
+ * `requestLnSend` takes its transport: the decision is testable without a
+ * solver, a relay, or a registry.
+ */
+export const planOnchainSend = async (args: {
+  wallet: Parameters<typeof requestOnchainSend>[0]
+  arkServerUrl: string
+  /** Sats to spend. Bound-checked before anything is asked of a solver. */
+  amountSats: number
+  payoutPubkey: Uint8Array
+  /** The L1 endpoint this wallet would claim the fill through, if it has one. */
+  claimEndpoint?: string
+  fallbackEmulatorPubkey?: Uint8Array
+  emulatorPubkey?: string
+  discover: () => Promise<DiscoveredMarket[]>
+  connect: <T>(rendezvous: OnchainSendRendezvous, fn: (transport: RfqTransport) => Promise<T>) => Promise<T>
+}): Promise<OnchainSendRequest> => {
+  // First, and before any network call: a wallet that cannot claim on L1 must
+  // not negotiate a swap whose claim is its own responsibility.
+  if (!args.claimEndpoint) {
+    throw new OnchainRouteUnavailable('no_l1_endpoint', 'no L1 endpoint is configured for this network')
+  }
+
+  let markets: DiscoveredMarket[]
+  try {
+    markets = await args.discover()
+  } catch (cause) {
+    throw new OnchainRouteUnavailable('discovery_failed', 'market discovery failed', { cause })
+  }
+
+  const choice = onchainSendRendezvous(markets, args.amountSats, args.fallbackEmulatorPubkey)
+  if (!choice.ok) {
+    if (choice.reason === 'amount_out_of_bounds') {
+      throw new OnchainRouteUnavailable(
+        'amount_out_of_bounds',
+        `${args.amountSats} sats is outside the solver's ${choice.bounds.minSats}-${choice.bounds.maxSats} range`,
+        { bounds: choice.bounds },
+      )
+    }
+    throw new OnchainRouteUnavailable('no_solver', 'no solver advertises arkade:BTC -> onchain:BTC')
+  }
+
+  try {
+    return await args.connect(choice.rendezvous, (transport) =>
+      requestOnchainExit({
+        wallet: args.wallet,
+        arkServerUrl: args.arkServerUrl,
+        transport,
+        amountSats: args.amountSats,
+        payoutPubkey: args.payoutPubkey,
+        rendezvous: choice.rendezvous,
+        ...(args.emulatorPubkey ? { emulatorPubkey: args.emulatorPubkey } : {}),
+      }),
+    )
+  } catch (cause) {
+    throw new OnchainRouteUnavailable('quote_failed', quoteFailureMessage(cause), { cause })
+  }
+}
+
+/**
+ * Name the negotiation failure without inventing one.
+ *
+ * `SwapRefusal` carries a closed-set `reason` and every gate in the package
+ * throws `Error & { reason }`, so the reason code is what to report — the
+ * message is prose that changes. Anything else keeps its own message, which is
+ * what a transport timeout and an address mismatch both rely on.
+ */
+const quoteFailureMessage = (cause: unknown): string => {
+  const reason = (cause as { reason?: unknown } | null)?.reason
+  if (typeof reason === 'string' && reason) return `solver route refused: ${reason}`
+  return cause instanceof Error && cause.message ? cause.message : 'the solver quote could not be used'
+}

--- a/src/lib/onchainSwap.ts
+++ b/src/lib/onchainSwap.ts
@@ -26,6 +26,7 @@
  */
 import { hex } from '@scure/base'
 import { marketCorridor, sideLimits, type DiscoveredMarket } from '@arkade-os/solver-discovery'
+import { l1ScriptForAddress } from './onchainPayout'
 import {
   requestOnchainSend,
   type OnchainHtlc,
@@ -69,6 +70,11 @@ export type OnchainRouteRefusal =
    * whole point of the fallback is that the wallet never gets into that state.
    */
   | 'no_l1_endpoint'
+  /**
+   * The destination is an L1 address this wallet cannot build an output for,
+   * so the claim would have nowhere to pay. Also checked before quoting.
+   */
+  | 'unsupported_address'
   /** Market discovery itself failed — an unreachable registry, a bad cache. */
   | 'discovery_failed'
   /** The negotiation failed: a refusal, a timeout, a quote we would not fund. */
@@ -237,8 +243,20 @@ export const requestOnchainExit = async (args: {
   transport: RfqTransport
   /** Sats to spend — `quote.from_amount` must come back equal to this. */
   amountSats: number
-  /** The user's x-only L1 key that will claim the HTLC. */
+  /** The user's x-only L1 key that will AUTHORISE the claim. Never where it
+   * pays: the HTLC's claim leaf binds a key this wallet must sign with, and
+   * the recipient cannot. */
   payoutPubkey: Uint8Array
+  /**
+   * The RECIPIENT's output script — where the claim actually pays.
+   *
+   * Carried on the record because the claim happens later, possibly in another
+   * process, long after this screen is gone. Nothing in the quote or on the
+   * HTLC names it: the claim transaction's output is the spender's own choice,
+   * which is exactly why it has to be pinned here rather than derived at claim
+   * time from whatever is to hand.
+   */
+  payoutPkScript: Uint8Array
   rendezvous: OnchainSendRendezvous
   /** 33-byte compressed hex override for the covenant co-signer, when this
    * deployment pins one. Absent lets the package use its per-network pin. */
@@ -277,6 +295,7 @@ export const requestOnchainExit = async (args: {
       refundLocktime: result.quote.refund_locktime ?? 0,
       secrets: result.secrets,
       script: result.script,
+      payoutPkScript: args.payoutPkScript,
       htlc: result.htlc,
       htlcParams: result.htlcParams,
       l1Network: result.l1Network,
@@ -298,6 +317,8 @@ export const onchainRouteRefusalText = (error: OnchainRouteUnavailable): string 
         : 'Amount outside solver bounds — using a collaborative exit'
     case 'no_l1_endpoint':
       return 'No Bitcoin endpoint for this network — using a collaborative exit'
+    case 'unsupported_address':
+      return 'Solver route cannot pay this address type — using a collaborative exit'
     case 'discovery_failed':
       return 'Could not reach the solver registry — using a collaborative exit'
     case 'quote_failed':
@@ -328,6 +349,10 @@ export const planOnchainSend = async (args: {
   /** Sats to spend. Bound-checked before anything is asked of a solver. */
   amountSats: number
   payoutPubkey: Uint8Array
+  /** The recipient's L1 address — the destination the user actually typed. */
+  payoutAddress: string
+  /** Which Bitcoin network that address must be spendable on. */
+  l1Network: OnchainNetwork
   /** The L1 endpoint this wallet would claim the fill through, if it has one. */
   claimEndpoint?: string
   fallbackEmulatorPubkey?: Uint8Array
@@ -339,6 +364,18 @@ export const planOnchainSend = async (args: {
   // not negotiate a swap whose claim is its own responsibility.
   if (!args.claimEndpoint) {
     throw new OnchainRouteUnavailable('no_l1_endpoint', 'no L1 endpoint is configured for this network')
+  }
+  // Resolved here, before anything is negotiated, because a destination the
+  // claim cannot pay to makes the whole route pointless — and because the
+  // record must carry it: the claim's output is not derivable from the quote,
+  // the HTLC, or anything else that survives this screen.
+  let payoutPkScript: Uint8Array
+  try {
+    payoutPkScript = l1ScriptForAddress(args.payoutAddress, args.l1Network)
+  } catch (cause) {
+    throw new OnchainRouteUnavailable('unsupported_address', `cannot build an output for ${args.payoutAddress}`, {
+      cause,
+    })
   }
 
   let markets: DiscoveredMarket[]
@@ -368,6 +405,7 @@ export const planOnchainSend = async (args: {
         transport,
         amountSats: args.amountSats,
         payoutPubkey: args.payoutPubkey,
+        payoutPkScript,
         rendezvous: choice.rendezvous,
         ...(args.emulatorPubkey ? { emulatorPubkey: args.emulatorPubkey } : {}),
       }),

--- a/src/lib/onchainSwap.ts
+++ b/src/lib/onchainSwap.ts
@@ -206,7 +206,15 @@ export interface OnchainSendRequest {
   address: string
   /** Sats the lockup must carry — what LEAVES the wallet. */
   fundAmount: number
-  /** Sats that land at the user's L1 address — the quote's `to_amount`. */
+  /**
+   * Sats the solver puts INTO the L1 HTLC — the quote's `to_amount`.
+   *
+   * Not quite what the recipient nets: `buildHtlcClaim` pays the claim
+   * transaction's fee out of this output, so they receive it less whatever the
+   * fee rate is at claim time. That rate is not knowable now — the claim can be
+   * hours away — so this is the honest number to show rather than a guess
+   * dressed up as a total.
+   */
   payoutAmount: number
   /** Unix seconds after which the quote is dead and must not be funded. */
   validUntil: number

--- a/src/lib/onchainSwap.ts
+++ b/src/lib/onchainSwap.ts
@@ -202,6 +202,16 @@ export const onchainSendRendezvous = (
 export interface OnchainSendRequest {
   /** Negotiation id, for correlating status lookups. */
   rfqId: string
+  /**
+   * The L1 address this quote was negotiated FOR.
+   *
+   * Carried so the quote can be checked against the send it is about to pay,
+   * which is the whole of {@link onchainQuoteMatches}. A quote is a fact about
+   * one destination and one amount; the screen it was requested from can be
+   * navigated away from, edited, and returned to, and nothing about the quote
+   * itself would look wrong afterwards.
+   */
+  payoutAddress: string
   /** The wallet's OWN derivation of the Arkade lockup. Fund only this. */
   address: string
   /** Sats the lockup must carry — what LEAVES the wallet. */
@@ -265,6 +275,9 @@ export const requestOnchainExit = async (args: {
    * time from whatever is to hand.
    */
   payoutPkScript: Uint8Array
+  /** The address {@link payoutPkScript} was derived from — carried onto the
+   * request so a stored quote can say which send it belongs to. */
+  payoutAddress: string
   rendezvous: OnchainSendRendezvous
   /** 33-byte compressed hex override for the covenant co-signer, when this
    * deployment pins one. Absent lets the package use its per-network pin. */
@@ -287,6 +300,7 @@ export const requestOnchainExit = async (args: {
 
   return {
     rfqId: result.rfqId,
+    payoutAddress: args.payoutAddress,
     address: result.address,
     fundAmount: result.fundAmount,
     payoutAmount,
@@ -314,6 +328,27 @@ export const requestOnchainExit = async (args: {
     },
   }
 }
+
+/**
+ * Whether a stored quote is still the quote for THIS send.
+ *
+ * A quote binds one destination and one amount, and the screen it came from can
+ * be left, edited and returned to — so "there is a quote in hand" is not the
+ * same question as "this quote is for what the user is now about to send", and
+ * treating them as one pays the previous recipient.
+ *
+ * The check lives here, next to the type, rather than at the call sites,
+ * because there are two of them and they need different things from it: the
+ * send form uses it to decide whether to re-quote, and the sign screen uses it
+ * to refuse to fund. The second is what makes a wrong-address payment
+ * impossible rather than merely unlikely — a send flow that forgets to clear a
+ * stale quote (there are two dozen places that write this state) still cannot
+ * spend one, because the screen that moves the money checks for itself.
+ */
+export const onchainQuoteMatches = (
+  quote: Pick<OnchainSendRequest, 'payoutAddress' | 'fundAmount'>,
+  send: { address?: string; satoshis?: number },
+): boolean => quote.payoutAddress === send.address && quote.fundAmount === send.satoshis
 
 /** The user-facing half of a refusal — what the send screen shows when it
  * quietly falls back. Kept beside the reasons so a new one cannot be added
@@ -417,6 +452,7 @@ export const planOnchainSend = async (args: {
         amountSats: args.amountSats,
         payoutPubkey: args.payoutPubkey,
         payoutPkScript,
+        payoutAddress: args.payoutAddress,
         rendezvous: choice.rendezvous,
         ...(args.emulatorPubkey ? { emulatorPubkey: args.emulatorPubkey } : {}),
       }),

--- a/src/lib/onchainSwap.ts
+++ b/src/lib/onchainSwap.ts
@@ -298,8 +298,11 @@ export const requestOnchainExit = async (args: {
     minConfirmations: result.minConfirmations,
     record: {
       paymentHash: result.htlcParams.paymentHash,
-      // The ARKADE lockup's deadline, not the L1 HTLC's. `assertFundable`'s
-      // timelock-order gate has already put the two in the required order.
+      // The ARKADE lockup's deadline, not the L1 HTLC's. Never actually
+      // absent on this leg: `assertFundable`'s `direction: 'send'` branch
+      // fails `timelock_order` on an undefined `refund_locktime`, so a quote
+      // without one cannot reach here. The `?? 0` is the type narrowing that
+      // fact needs, not a default anything is expected to take.
       refundLocktime: result.quote.refund_locktime ?? 0,
       secrets: result.secrets,
       script: result.script,

--- a/src/providers/flow.tsx
+++ b/src/providers/flow.tsx
@@ -1,4 +1,5 @@
 import type { LnSendRequest } from '../lib/lnSwap'
+import type { OnchainSendRequest } from '../lib/onchainSwap'
 import { ReactNode, SetStateAction, createContext, useState } from 'react'
 import type { Asset, AssetDetails, ServiceWorkerWalletMode } from '@arkade-os/sdk'
 import { Tx } from '../lib/types'
@@ -64,6 +65,12 @@ export type SendInfo = {
   invoice?: string
   lnUrl?: string
   pendingLnSend?: LnSendRequest
+  /**
+   * A negotiated `arkade:BTC -> onchain:BTC` quote, when a solver could take
+   * this send. Absent is the ordinary case and means exactly one thing: the
+   * exit goes out collaboratively, as it always has.
+   */
+  pendingOnchainSend?: OnchainSendRequest
   recipient?: string
   satoshis?: number
   scan?: boolean

--- a/src/providers/lnSwaps.tsx
+++ b/src/providers/lnSwaps.tsx
@@ -29,7 +29,8 @@
  * the user an L1 HTLC that only they can open, before a consensus deadline. So
  * `chain` is not optional decoration here: without it `RfqSwapManager` fails
  * such a swap on its first pass rather than watching it blind, and the send
- * flow refuses to take the solver route at all (see `canRouteOnchain`).
+ * flow refuses to take the solver route at all (see `planOnchainSend`'s
+ * `claimEndpoint` gate).
  */
 import { ReactNode, createContext, useContext, useEffect, useRef } from 'react'
 import { NetworkName, RestArkProvider, RestIndexerProvider } from '@arkade-os/sdk'

--- a/src/providers/lnSwaps.tsx
+++ b/src/providers/lnSwaps.tsx
@@ -99,10 +99,10 @@ export const LnSwapsContext = createContext<LnSwapsContextProps>({
     throw new Error('lightning swaps not initialized')
   },
   reserveOnchainSend: async () => {
-    throw new Error('lightning swaps not initialized')
+    throw new Error('swap manager not initialized')
   },
   trackOnchainSend: async () => {
-    throw new Error('lightning swaps not initialized')
+    throw new Error('swap manager not initialized')
   },
 })
 
@@ -178,6 +178,11 @@ export const LnSwapsProvider = ({ children }: { children: ReactNode }) => {
             preimage,
             payoutPkScript,
             feeRateSatVb,
+            // The ONLY thing this identity signs on the L1 side, and it is a
+            // BIP-341 sighash built by the package from the covenant and the
+            // outputs above — never caller-supplied bytes. If `signMessage`
+            // ever reaches a broader set of callers, this coupling is what has
+            // to be re-examined first.
             sign: (sighash: Uint8Array) => svcWallet.identity.signMessage(sighash, 'schnorr'),
           })
         },
@@ -217,7 +222,9 @@ export const LnSwapsProvider = ({ children }: { children: ReactNode }) => {
       // a second subscriber to the same lockups.
       const [lnSwaps, onchainSwaps] = await Promise.all([
         restoreLnSendSwaps(contracts),
-        restoreOnchainSendSwaps(contracts),
+        // The indexer is what tells a swap that was funded from one that never
+        // was — see `restoreOnchainSendSwaps`.
+        restoreOnchainSendSwaps(contracts, (pkScript) => findLockupVtxos(indexer, pkScript)),
       ])
       if (stopped) return
       await manager.start([...lnSwaps, ...onchainSwaps])

--- a/src/providers/lnSwaps.tsx
+++ b/src/providers/lnSwaps.tsx
@@ -16,15 +16,35 @@
  * spender's txid, and only for a swap the manager did not stamp itself; see
  * `lnSendRecords.ts`.
  *
- * Scoped to `lightning_send` deliberately. The receive leg has a manager of its
- * own in `providers/lnReceive`, which holds a Web Lock the whole time it drives
- * one — so wiring `claimLockup` here would put a second, unsynchronised claimer
- * on the same lockup.
+ * Scoped to the two SEND legs — `lightning_send` and `onchain_send`. The
+ * receive leg has a manager of its own in `providers/lnReceive`, which holds a
+ * Web Lock the whole time it drives one, so wiring `claimLockup` here would put
+ * a second, unsynchronised claimer on the same Arkade lockup. `claimOnchain`
+ * carries no such risk: it spends a BITCOIN output that only an onchain-send
+ * swap has, and nothing else in this wallet watches one.
+ *
+ * The onchain leg is the one corridor whose claim the wallet MUST make itself.
+ * A Lightning send resolves either way with the user offline — the solver
+ * claims with the preimage or the covenant refunds — but an onchain send hands
+ * the user an L1 HTLC that only they can open, before a consensus deadline. So
+ * `chain` is not optional decoration here: without it `RfqSwapManager` fails
+ * such a swap on its first pass rather than watching it blind, and the send
+ * flow refuses to take the solver route at all (see `canRouteOnchain`).
  */
 import { ReactNode, createContext, useContext, useEffect, useRef } from 'react'
-import { RestArkProvider, RestIndexerProvider } from '@arkade-os/sdk'
+import { NetworkName, RestArkProvider, RestIndexerProvider } from '@arkade-os/sdk'
 import { hex } from '@scure/base'
-import { RfqSwapManager, findLockupVtxos, pushRefundWithoutReceiver, type RfqSwap } from '@arkade-os/swap'
+import {
+  RfqSwapManager,
+  claimOnchainFill,
+  findLockupVtxos,
+  preimageForSwapRecord,
+  pushRefundWithoutReceiver,
+  rfqClaimSecretOf,
+  type ChainUtxo,
+  type OnchainSendSwap,
+  type RfqSwap,
+} from '@arkade-os/swap'
 import { AspContext } from './asp'
 import { WalletContext } from './wallet'
 import {
@@ -41,6 +61,15 @@ import {
   saveSwapUpdate,
   type LnSendRecordInput,
 } from '../lib/lnSendRecords'
+import {
+  onchainSendSwap,
+  onchainSendSwapRecord,
+  restoreOnchainSendSwaps,
+  type OnchainSendRecordInput,
+} from '../lib/onchainSendRecords'
+import { claimFeeRate, esploraChainSource } from '../lib/chainSource'
+import { l1NetworkOf, l1PayoutScript } from '../lib/onchainPayout'
+import { getRestApiExplorerURL } from '../lib/explorers'
 import { lockupSpenderTxid } from '../lib/lnSwap'
 import { consoleError } from '../lib/logs'
 
@@ -48,20 +77,40 @@ interface LnSwapsContextProps {
   /** Record a just-funded send and hand it to the manager. Resolves once the
    * record is durable — the caller's refresh must not run ahead of the store. */
   trackLnSend: (input: LnSendRecordInput) => Promise<void>
+  /**
+   * Persist an onchain send BEFORE its lockup is funded.
+   *
+   * The order is the whole point, and it is the opposite of the Lightning
+   * leg's. A Lightning send that is funded but unrecorded still resolves
+   * without the wallet: the solver claims, or the covenant refunds. An onchain
+   * send that is funded but unrecorded is an L1 HTLC whose claim parameters
+   * exist nowhere — not in the contract store, which holds only the Arkade
+   * lockup — so the fill is forfeit. Rejecting here means nothing was funded,
+   * which is why the caller can still fall back to a collaborative exit.
+   */
+  reserveOnchainSend: (input: OnchainSendRecordInput) => Promise<void>
+  /** Note the funding transaction and start monitoring. */
+  trackOnchainSend: (input: OnchainSendRecordInput) => Promise<void>
 }
 
 export const LnSwapsContext = createContext<LnSwapsContextProps>({
   trackLnSend: async () => {
     throw new Error('lightning swaps not initialized')
   },
+  reserveOnchainSend: async () => {
+    throw new Error('lightning swaps not initialized')
+  },
+  trackOnchainSend: async () => {
+    throw new Error('lightning swaps not initialized')
+  },
 })
 
 const notWired = (action: string) => async (): Promise<never> => {
-  // Required by the callbacks type, unreachable for this corridor: the manager
-  // calls neither on a `lightning_send` swap, and this provider monitors no
-  // others. A throw rather than a silent no-op, so a corridor added here
-  // without its action surfaces at once instead of expiring quietly.
-  throw new Error(`${action} is not wired: this wallet drives lightning sends only`)
+  // Required by the callbacks type, unreachable for these corridors: the
+  // manager calls this on a receive leg only, and this provider monitors none.
+  // A throw rather than a silent no-op, so a corridor added here without its
+  // action surfaces at once instead of expiring quietly.
+  throw new Error(`${action} is not wired: this wallet drives send legs only`)
 }
 
 export const LnSwapsProvider = ({ children }: { children: ReactNode }) => {
@@ -83,10 +132,48 @@ export const LnSwapsProvider = ({ children }: { children: ReactNode }) => {
       const indexer = new RestIndexerProvider(aspInfo.url)
       const ark = new RestArkProvider(aspInfo.url)
       const contracts = await svcWallet.getContractManager()
+      const network = aspInfo.network as NetworkName
+      const esploraUrl = getRestApiExplorerURL(network)
+      const l1Network = l1NetworkOf(aspInfo.network)
+      const chain = esploraUrl ? esploraChainSource(esploraUrl, l1Network) : undefined
 
-      manager = new RfqSwapManager({ indexer, contracts })
+      manager = new RfqSwapManager({ indexer, contracts, ...(chain ? { chain } : {}) })
       manager.setCallbacks({
-        claimOnchain: notWired('claimOnchain'),
+        /**
+         * Take the L1 fill. `claimOnchainFill` refuses inside the claim margin
+         * of the refund leaf — publishing P into the solver's live refund
+         * window risks losing the race AND giving the preimage away — so a
+         * throw here is not always a failure to retry; the manager's next pass
+         * re-decides against the same deadline.
+         *
+         * The preimage re-derives from the record's own descriptor, which is
+         * why `mustPersistPreimage` had to be honoured at quote time: on an HD
+         * wallet nothing secret was stored, and this call is where that shows.
+         */
+        claimOnchain: async (swap: OnchainSendSwap, utxo: ChainUtxo) => {
+          if (!chain || !esploraUrl) throw new Error('no L1 endpoint is configured for this network')
+          const record = await readRecord(swap.rfqId)
+          if (!record) throw new Error(`no stored record for rfq ${swap.rfqId}`)
+          // No hashlock on the record means no preimage can be recovered, and
+          // this leg's claim is nothing but the preimage. Named rather than
+          // left to `preimageForSwapRecord`, whose message is about a
+          // projection the caller never wrote.
+          const secrets = rfqClaimSecretOf(record)
+          if (!secrets) throw new Error(`swap ${swap.rfqId} was stored without its hashlock`)
+          const [preimage, xOnlyPubkey, feeRateSatVb] = await Promise.all([
+            preimageForSwapRecord(svcWallet, secrets),
+            svcWallet.identity.xOnlyPublicKey(),
+            claimFeeRate(esploraUrl),
+          ])
+          return claimOnchainFill(chain, {
+            htlc: swap.htlc,
+            utxo,
+            preimage,
+            payoutPkScript: l1PayoutScript(xOnlyPubkey, l1Network),
+            feeRateSatVb,
+            sign: (sighash: Uint8Array) => svcWallet.identity.signMessage(sighash, 'schnorr'),
+          })
+        },
         claimLockup: notWired('claimLockup'),
         saveSwap: (swap) => saveSwapUpdate(swap),
         // Wired to the atomic push, NOT to `refundIfUnresolved`: that helper is
@@ -118,9 +205,15 @@ export const LnSwapsProvider = ({ children }: { children: ReactNode }) => {
           .catch((err) => consoleError(err, `error resolving the spend of swap ${swap.rfqId}`))
       })
 
-      const swaps = await restoreLnSendSwaps(contracts)
+      // Both send legs, in one manager: they share every seam it needs, and a
+      // second manager over the same indexer and contract store would only add
+      // a second subscriber to the same lockups.
+      const [lnSwaps, onchainSwaps] = await Promise.all([
+        restoreLnSendSwaps(contracts),
+        restoreOnchainSendSwaps(contracts),
+      ])
       if (stopped) return
-      await manager.start(swaps)
+      await manager.start([...lnSwaps, ...onchainSwaps])
       managerRef.current = manager
     }
 
@@ -142,7 +235,24 @@ export const LnSwapsProvider = ({ children }: { children: ReactNode }) => {
     await managerRef.current?.addSwap(lnSendSwap(input))
   }
 
-  return <LnSwapsContext.Provider value={{ trackLnSend }}>{children}</LnSwapsContext.Provider>
+  const reserveOnchainSend = async (input: OnchainSendRecordInput) => {
+    await saveRecord(onchainSendSwapRecord(input))
+  }
+
+  const trackOnchainSend = async (input: OnchainSendRecordInput) => {
+    // The same record again, now naming the funding transaction, then handed
+    // to the manager. Rewriting rather than patching keeps one builder for the
+    // shape — and `reserveOnchainSend` has already made the claim recoverable,
+    // so a failure here costs the history row, not the money.
+    await saveRecord(onchainSendSwapRecord(input))
+    await managerRef.current?.addSwap(onchainSendSwap(input))
+  }
+
+  return (
+    <LnSwapsContext.Provider value={{ trackLnSend, reserveOnchainSend, trackOnchainSend }}>
+      {children}
+    </LnSwapsContext.Provider>
+  )
 }
 
 /** Name the tx that ended a swap, when it is one of ours. Returns it, so the

--- a/src/providers/lnSwaps.tsx
+++ b/src/providers/lnSwaps.tsx
@@ -69,7 +69,7 @@ import {
   type OnchainSendRecordInput,
 } from '../lib/onchainSendRecords'
 import { claimFeeRate, esploraChainSource } from '../lib/chainSource'
-import { l1NetworkOf, l1PayoutScript } from '../lib/onchainPayout'
+import { claimPayoutScript, l1NetworkOf } from '../lib/onchainPayout'
 import { getRestApiExplorerURL } from '../lib/explorers'
 import { lockupSpenderTxid } from '../lib/lnSwap'
 import { consoleError } from '../lib/logs'
@@ -161,16 +161,22 @@ export const LnSwapsProvider = ({ children }: { children: ReactNode }) => {
           // projection the caller never wrote.
           const secrets = rfqClaimSecretOf(record)
           if (!secrets) throw new Error(`swap ${swap.rfqId} was stored without its hashlock`)
-          const [preimage, xOnlyPubkey, feeRateSatVb] = await Promise.all([
+          // The RECIPIENT's script, off the record. Never derived here: the
+          // only thing derivable at claim time is this wallet's own address,
+          // and paying there would turn the send into a transfer to self while
+          // the receipt says otherwise. `claimPayoutScript` throws rather than
+          // substitute one, which loses the fill to the solver's L1 refund and
+          // returns the lockup — recoverable, unlike paying the wrong place.
+          const payoutPkScript = claimPayoutScript(record.profile)
+          const [preimage, feeRateSatVb] = await Promise.all([
             preimageForSwapRecord(svcWallet, secrets),
-            svcWallet.identity.xOnlyPublicKey(),
             claimFeeRate(esploraUrl),
           ])
           return claimOnchainFill(chain, {
             htlc: swap.htlc,
             utxo,
             preimage,
-            payoutPkScript: l1PayoutScript(xOnlyPubkey, l1Network),
+            payoutPkScript,
             feeRateSatVb,
             sign: (sighash: Uint8Array) => svcWallet.identity.signMessage(sighash, 'schnorr'),
           })
@@ -241,12 +247,18 @@ export const LnSwapsProvider = ({ children }: { children: ReactNode }) => {
   }
 
   const trackOnchainSend = async (input: OnchainSendRecordInput) => {
-    // The same record again, now naming the funding transaction, then handed
-    // to the manager. Rewriting rather than patching keeps one builder for the
-    // shape — and `reserveOnchainSend` has already made the claim recoverable,
-    // so a failure here costs the history row, not the money.
-    await saveRecord(onchainSendSwapRecord(input))
-    await managerRef.current?.addSwap(onchainSendSwap(input))
+    // Two independent jobs, deliberately not sequenced. The write names the
+    // funding transaction the history row needs; the hand-off is what gets the
+    // L1 claim driven in THIS session rather than at the next start. Chaining
+    // them meant a store that refused the txid also cost the claim its
+    // session — and this corridor's claim is the one on a deadline.
+    //
+    // Rewriting the whole record rather than patching keeps one builder for the
+    // shape, and `reserveOnchainSend` has already made the claim recoverable,
+    // so neither failure here costs money.
+    const monitored = managerRef.current?.addSwap(onchainSendSwap(input))
+    const stored = saveRecord(onchainSendSwapRecord(input))
+    await Promise.all([monitored, stored])
   }
 
   return (

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -15,9 +15,10 @@ import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import { collaborativeExitWithFees, sendAssets, sendOffChain } from '../../../lib/asp'
 import { type LnSendRequest } from '../../../lib/lnSwap'
+import { ONCHAIN_ROUTE_LOG, type OnchainSendRequest } from '../../../lib/onchainSwap'
 import { extractError } from '../../../lib/error'
 import LoadingLogo from '../../../components/LoadingLogo'
-import { consoleError } from '../../../lib/logs'
+import { consoleError, consoleLog } from '../../../lib/logs'
 import { LimitsContext } from '../../../providers/limits'
 import { FeesContext } from '../../../providers/fees'
 import { buildTransactionAmountDisplay } from '../../../lib/transactionAmountDisplay'
@@ -33,7 +34,7 @@ export default function SendDetails() {
   const isAssetSend = Boolean(sendInfo.account || sendInfo.assets?.length)
   const { utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { assetMetadataCache, balance, reloadWallet, svcWallet } = useContext(WalletContext)
-  const { trackLnSend } = useContext(LnSwapsContext)
+  const { trackLnSend, reserveOnchainSend, trackOnchainSend } = useContext(LnSwapsContext)
 
   const assetId = sendInfo.account?.assetId ?? sendInfo.assets?.[0]?.assetId
   const assetMeta = assetId ? assetMetadataCache.get(assetId) : undefined
@@ -46,7 +47,7 @@ export default function SendDetails() {
   const [sending, setSending] = useState(false)
   const [sendDone, setSendDone] = useState(false)
 
-  const { address, arkAddress, invoice, pendingLnSend, satoshis } = sendInfo
+  const { address, arkAddress, invoice, pendingLnSend, pendingOnchainSend, satoshis } = sendInfo
   const amountDisplay = buildTransactionAmountDisplay({
     ...displayContext,
     assets: sendInfo.account
@@ -96,7 +97,16 @@ export default function SendDetails() {
     // The RFQ lockup carries exactly the invoice amount (exact-out, fee_bps
     // from the card; 0 today), so total == satoshis on the Lightning path.
     const total = pendingLnSend ? pendingLnSend.fundAmount : satoshis
-    const amount = direction === 'Paying to mainnet' ? satoshis - calcOnchainOutputFee() : satoshis
+    // On the solver exit the quote is exact-IN: the user spends what they
+    // typed and the solver's own fee decides what lands, so the payout comes
+    // off the quote rather than off arkd's onchain-output fee. Using the
+    // collaborative-exit fee here would display a number the solver route is
+    // not going to charge.
+    const amount = pendingOnchainSend
+      ? pendingOnchainSend.payoutAmount
+      : direction === 'Paying to mainnet'
+        ? satoshis - calcOnchainOutputFee()
+        : satoshis
     const fees = total - amount > 0 ? total - amount : 0
     setDetails({
       destination,
@@ -176,6 +186,58 @@ export default function SendDetails() {
     handleTxid(txid)
   }
 
+  /**
+   * Pay an L1 address through the solver that quoted it, falling back to the
+   * collaborative exit while that is still possible.
+   *
+   * "While that is still possible" is the shape of this function. Everything
+   * before `sendOffChain` can still change its mind, because nothing has moved:
+   * a quote that expired while the user read the screen, a store that refused
+   * the record, a quote that does not cost what the screen says it does. After
+   * the covenant is funded there is no fallback left and never can be — funding
+   * IS acceptance, exactly as on the Lightning leg — so from there on a failure
+   * is reported, not routed around.
+   *
+   * The record is written BEFORE funding, which is the one ordering this
+   * corridor cannot get away with reversing. See `reserveOnchainSend`.
+   */
+  const payOnchainThroughSolver = async (request: OnchainSendRequest, exit: () => Promise<string>) => {
+    const fallback = async (reason: string, detail = '') => {
+      consoleLog(`${ONCHAIN_ROUTE_LOG} collaborative exit (${reason})${detail ? ` — ${detail}` : ''}`)
+      handleTxid(await exit())
+    }
+    if (Math.floor(Date.now() / 1000) >= request.validUntil) return fallback('quote_expired')
+    // The screen quoted `details.total`; the solver must not be funded for
+    // anything else. A mismatch is a bug rather than an attack — the client
+    // already refuses a lockup address it did not derive — but it would spend
+    // a number the user never agreed to, so it exits collaboratively instead.
+    if (request.fundAmount !== details!.total) {
+      return fallback('amount_mismatch', `quote wants ${request.fundAmount}, screen shows ${details!.total}`)
+    }
+
+    const record = {
+      ...request.record,
+      rfqId: request.rfqId,
+      lockupAddress: request.address,
+      amount: request.fundAmount,
+    }
+    try {
+      await reserveOnchainSend(record)
+    } catch (err) {
+      return fallback('record_failed', extractError(err))
+    }
+
+    const txid = await sendOffChain(svcWallet!, request.fundAmount, request.address)
+    if (!txid) return handleError('Error sending transaction')
+    // Committed from here. The reserve above already made the L1 claim
+    // recoverable, so a store that refuses this second write costs the history
+    // row and not the fill — reported, never raised.
+    await trackOnchainSend({ ...record, fundingTxid: txid }).catch((err) =>
+      consoleError(err, 'error tracking onchain send'),
+    )
+    handleTxid(txid)
+  }
+
   const handleContinue = async () => {
     if (!details || !svcWallet) return
     if (!isAssetSend && (!details.total || !details.satoshis)) return
@@ -210,9 +272,18 @@ export default function SendDetails() {
     } else if (address) {
       if (!details.total) return handleError('Missing total amount')
       if (!details.satoshis) return handleError('Missing satoshis amount')
-      collaborativeExitWithFees(svcWallet, details.total, details.satoshis, address)
-        .then((txId: string) => handleTxid(txId))
-        .catch(handleError)
+      const { total, satoshis: payout } = details
+      const exit = () => collaborativeExitWithFees(svcWallet, total, payout, address)
+      // No quote in hand means no solver could take this send — the reason was
+      // logged where the decision was made — so this is the exit the wallet has
+      // always done, byte for byte.
+      if (!pendingOnchainSend) {
+        exit()
+          .then((txId: string) => handleTxid(txId))
+          .catch(handleError)
+        return
+      }
+      payOnchainThroughSolver(pendingOnchainSend, exit).catch(handleError)
     }
   }
 

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -15,7 +15,7 @@ import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
 import { collaborativeExitWithFees, sendAssets, sendOffChain } from '../../../lib/asp'
 import { type LnSendRequest } from '../../../lib/lnSwap'
-import { ONCHAIN_ROUTE_LOG, type OnchainSendRequest } from '../../../lib/onchainSwap'
+import { ONCHAIN_ROUTE_LOG, onchainQuoteMatches, type OnchainSendRequest } from '../../../lib/onchainSwap'
 import { extractError } from '../../../lib/error'
 import LoadingLogo from '../../../components/LoadingLogo'
 import { consoleError, consoleLog } from '../../../lib/logs'
@@ -207,12 +207,22 @@ export default function SendDetails() {
       handleTxid(await exit())
     }
     if (Math.floor(Date.now() / 1000) >= request.validUntil) return fallback('quote_expired')
-    // The screen quoted `details.total`; the solver must not be funded for
-    // anything else. A mismatch is a bug rather than an attack — the client
-    // already refuses a lockup address it did not derive — but it would spend
-    // a number the user never agreed to, so it exits collaboratively instead.
-    if (request.fundAmount !== details!.total) {
-      return fallback('amount_mismatch', `quote wants ${request.fundAmount}, screen shows ${details!.total}`)
+    // The quote must be for THIS send — this address, this amount — not merely
+    // present. A quote is negotiated on the previous screen, which can be left,
+    // edited and returned to; a stale one names the previous recipient, and the
+    // claim it leads to would pay them. The send flow clears the quote when the
+    // address changes, but that is two dozen `setSendInfo` call sites' worth of
+    // discipline, and this is the one place the money actually moves — so it
+    // checks for itself rather than trusting that.
+    // Checked against `details.total` rather than `satoshis` because that is the
+    // number the screen actually displayed — derived, not copied — and it is
+    // what the user agreed to.
+    if (!onchainQuoteMatches(request, { address, satoshis: details!.total })) {
+      return fallback(
+        'quote_mismatch',
+        `quote is for ${request.fundAmount} sats to ${request.payoutAddress}, ` +
+          `screen shows ${details!.total} to ${address}`,
+      )
     }
 
     const record = {

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -22,7 +22,7 @@ import Text from '../../../components/Text'
 import Shadow from '../../../components/Shadow'
 import Scanner from '../../../components/Scanner'
 import LoadingLogo from '../../../components/LoadingLogo'
-import { consoleError } from '../../../lib/logs'
+import { consoleError, consoleLog } from '../../../lib/logs'
 import { Addresses, AssetOption, Currencies, Themes, Unit } from '../../../lib/types'
 import { aspErrorText, getReceivingAddresses } from '../../../lib/asp'
 import { isMobileBrowser } from '../../../lib/browser'
@@ -34,6 +34,13 @@ import { checkLnUrlConditions, fetchInvoice, fetchArkAddress, isValidLnUrl, LnUr
 import { extractError } from '../../../lib/error'
 import { decodeInvoice } from '../../../lib/bolt11'
 import { lnSendRendezvous, requestLnSend } from '../../../lib/lnSwap'
+import {
+  ONCHAIN_ROUTE_LOG,
+  OnchainRouteUnavailable,
+  onchainRouteRefusalText,
+  planOnchainSend,
+} from '../../../lib/onchainSwap'
+import { l1PayoutPubkey, onchainClaimEndpoint } from '../../../lib/onchainPayout'
 import { withRfqTransport } from '../../../lib/nostrRfq'
 import { discoverMarkets } from '../../../lib/swapMarkets'
 import { decodeBip21, isBip21 } from '../../../lib/bip21'
@@ -58,7 +65,7 @@ import {
   DropdownMenuTrigger,
 } from '../../../components/ui/dropdown-menu'
 import { hapticLight } from '../../../lib/haptics'
-import { getEmulatorPubkeyForNetwork, testDomains } from '../../../lib/constants'
+import { getEmulatorPubkeyForNetwork, getEmulatorPubkeyOverrideForNetwork, testDomains } from '../../../lib/constants'
 import UnverifiedBadge from '../../../components/UnverifiedBadge'
 
 const isProductionEnv = !testDomains.some((d) => window.location.hostname.includes(d))
@@ -607,10 +614,68 @@ export default function SendForm() {
     setLabel('Server unreachable')
   }, [aspInfo.unreachable, aspInfo.outdated])
 
+  /**
+   * Try to route an exit through a solver, and go to the sign screen either
+   * way.
+   *
+   * The fallback is the contract: `planOnchainSend` rejects with
+   * `OnchainRouteUnavailable` for every reason there is — no card, a card that
+   * cannot take the size, a refusal, a timeout, a quote the client would not
+   * fund — and all of them mean the same thing here, which is that the wallet
+   * does the collaborative exit it has always done. So this never calls
+   * `handleError`: a payment the wallet can make must not be stopped by a
+   * solver that could not help with it.
+   *
+   * Never silent, though. The reason goes to the wallet's own log (Settings →
+   * Logs), because "the solver route was not taken" is otherwise invisible —
+   * the user sees an ordinary exit and no indication that anything was tried.
+   * The `catch` below is the belt-and-braces case: a rejection that is somehow
+   * not an `OnchainRouteUnavailable` is still a fallback, and still logged.
+   */
+  const routeOnchainExit = () => {
+    const collaborativeExit = (reason: string, detail: string) => {
+      consoleLog(`${ONCHAIN_ROUTE_LOG} collaborative exit (${reason}) — ${detail}`)
+      navigate(Pages.SendDetails)
+    }
+    if (!svcWallet) return collaborativeExit('no_wallet', 'the wallet is not ready')
+    const network = aspInfo.network as NetworkName
+    const negotiate = async () =>
+      planOnchainSend({
+        wallet: svcWallet,
+        arkServerUrl: aspInfo.url,
+        amountSats: sendInfo.satoshis ?? 0,
+        payoutPubkey: await l1PayoutPubkey(svcWallet),
+        claimEndpoint: onchainClaimEndpoint(network),
+        fallbackEmulatorPubkey: getEmulatorPubkeyForNetwork(network),
+        emulatorPubkey: getEmulatorPubkeyOverrideForNetwork(network),
+        discover: () => discoverMarkets(network),
+        connect: (rendezvous, fn) => withRfqTransport(rendezvous, fn),
+      })
+
+    negotiate()
+      .then((pendingOnchainSend) => {
+        consoleLog(`${ONCHAIN_ROUTE_LOG} solver route (${pendingOnchainSend.rendezvous.solverPubkey})`)
+        setSendInfo((prev) => ({ ...prev, pendingOnchainSend }))
+      })
+      .catch((err) => {
+        if (err instanceof OnchainRouteUnavailable) return collaborativeExit(err.reason, onchainRouteRefusalText(err))
+        // Not a refusal this module knows how to name. Still a fallback: the
+        // collaborative exit does not depend on any of this having worked.
+        collaborativeExit('unexpected', extractError(err))
+      })
+  }
+
   // proceed to next step
   useEffect(() => {
     if (!proceed) return
     if (!sendInfo.address && !sendInfo.arkAddress && !sendInfo.invoice) return
+    // An L1 address with no ark address or invoice beside it is an exit. Ask
+    // the solvers first — see `routeOnchainExit` for why a failure here is not
+    // an error.
+    if (sendInfo.address && !sendInfo.arkAddress && !sendInfo.invoice && !sendInfo.pendingOnchainSend) {
+      routeOnchainExit()
+      return
+    }
     // Everything except an un-negotiated invoice goes straight through: an ark
     // address, an on-chain address, and an invoice whose quote is already in
     // hand all have all they need to be signed on the next screen.
@@ -649,7 +714,14 @@ export default function SendForm() {
       }
       negotiate().catch(handleError)
     }
-  }, [proceed, sendInfo.address, sendInfo.arkAddress, sendInfo.invoice, sendInfo.pendingLnSend])
+  }, [
+    proceed,
+    sendInfo.address,
+    sendInfo.arkAddress,
+    sendInfo.invoice,
+    sendInfo.pendingLnSend,
+    sendInfo.pendingOnchainSend,
+  ])
 
   // deal with fees deduction from amount
   useEffect(() => {

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -40,7 +40,7 @@ import {
   onchainRouteRefusalText,
   planOnchainSend,
 } from '../../../lib/onchainSwap'
-import { l1PayoutPubkey, onchainClaimEndpoint } from '../../../lib/onchainPayout'
+import { l1NetworkOf, l1PayoutPubkey, onchainClaimEndpoint } from '../../../lib/onchainPayout'
 import { withRfqTransport } from '../../../lib/nostrRfq'
 import { discoverMarkets } from '../../../lib/swapMarkets'
 import { decodeBip21, isBip21 } from '../../../lib/bip21'
@@ -645,6 +645,10 @@ export default function SendForm() {
         arkServerUrl: aspInfo.url,
         amountSats: sendInfo.satoshis ?? 0,
         payoutPubkey: await l1PayoutPubkey(svcWallet),
+        // The address the user typed. The key above only authorises the claim;
+        // this is where it pays, and the two are not interchangeable.
+        payoutAddress: sendInfo.address ?? '',
+        l1Network: l1NetworkOf(network),
         claimEndpoint: onchainClaimEndpoint(network),
         fallbackEmulatorPubkey: getEmulatorPubkeyForNetwork(network),
         emulatorPubkey: getEmulatorPubkeyOverrideForNetwork(network),

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -4,7 +4,7 @@ import Button from '../../../components/Button'
 import ErrorMessage from '../../../components/Error'
 import ButtonsOnBottom from '../../../components/ButtonsOnBottom'
 import { NavigationContext, Pages } from '../../../providers/navigation'
-import { FlowContext } from '../../../providers/flow'
+import { FlowContext, type SendInfo } from '../../../providers/flow'
 import Padded from '../../../components/Padded'
 import { isBTCAddress, decodeArkAddress, isLightningInvoice, isURLWithLightningQueryString } from '../../../lib/address'
 import { AspContext } from '../../../providers/asp'
@@ -37,6 +37,7 @@ import { lnSendRendezvous, requestLnSend } from '../../../lib/lnSwap'
 import {
   ONCHAIN_ROUTE_LOG,
   OnchainRouteUnavailable,
+  onchainQuoteMatches,
   onchainRouteRefusalText,
   planOnchainSend,
 } from '../../../lib/onchainSwap'
@@ -127,6 +128,30 @@ function AssetIcon({ asset }: { asset: AssetOption | null }) {
     </span>
   )
 }
+
+/**
+ * The quote to carry forward when the recipient is re-parsed.
+ *
+ * A negotiated `pendingOnchainSend` is a fact about ONE destination: it names
+ * that recipient's payout script, and the L1 claim it leads to pays them. The
+ * send form can be left for the sign screen, come back, and be edited — so a
+ * quote that survives an address change pays the previous recipient while the
+ * screen shows the new one.
+ *
+ * Conditional rather than an unconditional clear, mirroring what the Lightning
+ * leg does with `pendingLnSend` and `invoice`: a user who returns without
+ * changing anything is still entitled to the quote they were given, and
+ * dropping it burns a negotiation and hands the invoice-equivalent to a solver
+ * a second time for nothing.
+ *
+ * Exported for the same reason `isPlainOnchainTypedRecipient` is: it is the
+ * rule, and a rule that only exists inline in four `setSendInfo` calls is one
+ * the fifth call site will get wrong.
+ */
+export const onchainQuoteAfterAddressChange = (
+  prev: Pick<SendInfo, 'address' | 'pendingOnchainSend'>,
+  address: string | undefined,
+): SendInfo['pendingOnchainSend'] => (address === prev.address ? prev.pendingOnchainSend : undefined)
 
 export default function SendForm() {
   const { aspInfo } = useContext(AspContext)
@@ -364,6 +389,7 @@ export default function SendForm() {
             satoshis: 0,
             assets: [{ assetId, amount: rawAmount }],
             pendingLnSend: invoice === prev.invoice ? prev.pendingLnSend : undefined,
+            pendingOnchainSend: onchainQuoteAfterAddressChange(prev, address),
           }))
         }
         setSendInfo((prev) => ({
@@ -377,12 +403,18 @@ export default function SendForm() {
           recipient,
           satoshis: satoshis ?? prev.satoshis,
           pendingLnSend: invoice === prev.invoice ? prev.pendingLnSend : undefined,
+          pendingOnchainSend: onchainQuoteAfterAddressChange(prev, address),
         }))
         if (satoshis) setAmountTextValue(getTextValue(satoshis))
         return
       }
       if (isValidArkAddress(lowerCaseData)) {
-        return setSendInfo((prev) => ({ ...prev, arkAddress: lowerCaseData, pendingLnSend: undefined }))
+        return setSendInfo((prev) => ({
+          ...prev,
+          arkAddress: lowerCaseData,
+          pendingLnSend: undefined,
+          pendingOnchainSend: undefined,
+        }))
       }
       if (isLightningInvoice(lowerCaseData)) {
         if (isAssetSend) {
@@ -402,6 +434,7 @@ export default function SendForm() {
           invoice: lowerCaseData,
           satoshis,
           pendingLnSend: lowerCaseData === prev.invoice ? prev.pendingLnSend : undefined,
+          pendingOnchainSend: undefined,
         }))
         setAmountTextValue(getTextValue(satoshis))
         setAmountIsReadOnly(true)
@@ -411,7 +444,17 @@ export default function SendForm() {
         if (isAssetSend) {
           return setRecipientError('Assets can only be sent to Arkade addresses')
         }
-        return setSendInfo({ ...sendInfo, address: recipient })
+        return setSendInfo((prev) => ({
+          ...prev,
+          address: recipient,
+          // Same rule the Lightning path applies to `pendingLnSend`: a quote
+          // belongs to the address it was negotiated for. Typing a new one
+          // here after coming back from the sign screen used to leave the old
+          // quote in place, and the gate below would then skip re-quoting —
+          // paying the FIRST recipient. (`prev` rather than `sendInfo` for the
+          // same reason: this branch ran off a captured render's state.)
+          pendingOnchainSend: onchainQuoteAfterAddressChange(prev, recipient),
+        }))
       }
       if (isArkNote(lowerCaseData)) {
         try {
@@ -635,6 +678,10 @@ export default function SendForm() {
   const routeOnchainExit = () => {
     const collaborativeExit = (reason: string, detail: string) => {
       consoleLog(`${ONCHAIN_ROUTE_LOG} collaborative exit (${reason}) — ${detail}`)
+      // Drop whatever was in hand on the way out. Re-quoting only happens
+      // because the stored quote did not match this send, so leaving it would
+      // hand the sign screen the very quote that was just rejected.
+      setSendInfo((prev) => ({ ...prev, pendingOnchainSend: undefined }))
       navigate(Pages.SendDetails)
     }
     if (!svcWallet) return collaborativeExit('no_wallet', 'the wallet is not ready')
@@ -676,7 +723,18 @@ export default function SendForm() {
     // An L1 address with no ark address or invoice beside it is an exit. Ask
     // the solvers first — see `routeOnchainExit` for why a failure here is not
     // an error.
-    if (sendInfo.address && !sendInfo.arkAddress && !sendInfo.invoice && !sendInfo.pendingOnchainSend) {
+    // A quote in hand is not the same as a quote for THIS send: the sign screen
+    // can be left, the address or amount edited, and returned to. Asking
+    // `onchainQuoteMatches` rather than merely "is there one" is what makes the
+    // clears above a tidiness measure instead of the only thing standing
+    // between a re-typed address and the previous recipient.
+    const quoted = sendInfo.pendingOnchainSend
+    if (
+      sendInfo.address &&
+      !sendInfo.arkAddress &&
+      !sendInfo.invoice &&
+      (!quoted || !onchainQuoteMatches(quoted, sendInfo))
+    ) {
       routeOnchainExit()
       return
     }

--- a/src/test/e2e/onchainsend.test.ts
+++ b/src/test/e2e/onchainsend.test.ts
@@ -1,0 +1,162 @@
+import { existsSync, readFileSync } from 'fs'
+import { execSync } from 'child_process'
+import { test, expect, createWallet, fundWallet, prePay, dismissPaymentSuccess } from './utils'
+
+/**
+ * Sending to an L1 address, end to end: through a solver when one can serve the
+ * amount, through the collaborative exit when none can.
+ *
+ * The two halves are tested differently on purpose.
+ *
+ * **The fallback runs everywhere**, against nothing but the regtest stack. It
+ * has to: it is the path every wallet without a matching card takes, it is what
+ * this repo already shipped, and the one regression this change could cause is
+ * breaking it. The card injected below advertises the corridor and refuses the
+ * size, which is the case that is easy to get wrong in the opposite direction —
+ * a wallet that quoted anyway would burn a negotiation and leak the trade for
+ * an answer the card already gave.
+ *
+ * **The solver route needs a solver**, and there is no
+ * `arkade:BTC -> onchain:BTC` service in this stack. It follows `lnsend.test.ts`
+ * exactly: the card is deployment-specific (its `discovery_pubkey` is the
+ * solver's own key) so it is generated rather than committed, and the test skips
+ * loudly when it is missing instead of failing as though the wallet were broken.
+ *
+ *   1. `pnpm regtest:start`
+ *   2. arkade-os/lightning-swap-service running `cli relay` with
+ *      ONCHAIN_SEND_ENABLED=true against ws://localhost:10547
+ *   3. its `cli card` output saved to .regtest-onchain.card.json
+ *
+ * The assertions read the wallet's OWN log (Settings -> Logs, backed by
+ * localStorage) because a routing decision has no other trace: a send that fell
+ * back looks on screen exactly like a send that was never going to be routed.
+ * That invisibility is precisely what the log exists to fix, so asserting on it
+ * is asserting on the feature rather than around it.
+ */
+const ONCHAIN_ADDRESS = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+
+/** The routing decisions the wallet recorded, oldest first. */
+const routeLog = (page: import('@playwright/test').Page) =>
+  page.evaluate(() =>
+    (JSON.parse(localStorage.getItem('logs') ?? '[]') as { msg: string }[])
+      .map((line) => line.msg)
+      .filter((msg) => msg.startsWith('onchain send:')),
+  )
+
+/** Put solver cards in place before any app script runs, so the markets cache
+ * is built with them rather than without. */
+const withCards = (page: import('@playwright/test').Page, cards: unknown[]) =>
+  page.addInitScript((stored) => localStorage.setItem('solverCards', JSON.stringify(stored)), cards)
+
+/**
+ * A regtest card serving `arkade:BTC -> onchain:BTC` between `min` and `max`.
+ *
+ * `emulator_pubkey` is absent so the wallet's per-network pin supplies the
+ * covenant co-signer, which is the same resolution the Lightning corridor uses.
+ * Nothing here has to be a real solver: every assertion below is about a
+ * decision the wallet reaches BEFORE it addresses one.
+ */
+const onchainCard = (min: string, max: string) => ({
+  version: 0,
+  name: 'regtest-onchain-bounds',
+  discovery_pubkey: 'b'.repeat(64),
+  transports: { nostr: { relays: ['wss://localhost:10548'] } },
+  markets: [
+    {
+      pair: 'BTC/onchain:BTC',
+      base_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+      quote_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+      base_corridor: 'arkade',
+      quote_corridor: 'onchain',
+      fee_bps: 10,
+      min_base_amount: min,
+      max_base_amount: max,
+      min_quote_amount: min,
+      max_quote_amount: max,
+    },
+  ],
+})
+
+test.describe('sending onchain', () => {
+  test('falls back to a collaborative exit when no card can take the amount', async ({ page, isMobile }) => {
+    test.setTimeout(120_000)
+    // The onchain-output fee has to be non-zero for the exit to be the exit
+    // this wallet actually performs; `send.test.ts` sets it the same way.
+    execSync('docker exec -t arkd arkd fees intent --onchain-output "200.0"')
+
+    try {
+      // Serves the pair, and only in millions of sats. A wallet that checked
+      // the pair without the size would negotiate against this card.
+      await withCards(page, [{ network: 'regtest', label: 'too-big', card: onchainCard('1000000', '2000000') }])
+
+      await createWallet(page)
+      await fundWallet(page, 1800)
+      await prePay(page, ONCHAIN_ADDRESS, isMobile, 900)
+
+      // The exit still happens, unchanged, and the reason it was an exit is on
+      // the record. `amount_out_of_bounds` rather than `no_solver` is the whole
+      // point: the card WAS found, and rejected on size alone.
+      await page.getByText('Tap to Sign').click({ timeout: 60_000 })
+      await page.waitForSelector('text=Payment sent', { timeout: 60_000 })
+
+      const log = await routeLog(page)
+      expect(log.at(-1)).toContain('collaborative exit (amount_out_of_bounds)')
+
+      await dismissPaymentSuccess(page)
+      await page.waitForSelector('text=Sent', { timeout: 20_000 })
+    } finally {
+      execSync('docker exec -t arkd arkd fees clear')
+    }
+  })
+
+  test('falls back, and says so, when no card serves the corridor at all', async ({ page, isMobile }) => {
+    test.setTimeout(120_000)
+    execSync('docker exec -t arkd arkd fees intent --onchain-output "200.0"')
+
+    try {
+      // The shipping default: a wallet with no onchain-send card. This must
+      // behave exactly as it did before the solver route existed.
+      await createWallet(page)
+      await fundWallet(page, 1800)
+      await prePay(page, ONCHAIN_ADDRESS, isMobile, 900)
+
+      await page.getByText('Tap to Sign').click({ timeout: 60_000 })
+      await page.waitForSelector('text=Payment sent', { timeout: 60_000 })
+
+      const log = await routeLog(page)
+      expect(log.at(-1)).toContain('collaborative exit (no_solver)')
+    } finally {
+      execSync('docker exec -t arkd arkd fees clear')
+    }
+  })
+})
+
+const CARD_PATH = process.env.ONCHAIN_SOLVER_CARD_PATH ?? '.regtest-onchain.card.json'
+const solverCard = existsSync(CARD_PATH) ? JSON.parse(readFileSync(CARD_PATH, 'utf8')) : null
+
+test.describe('sending onchain through a solver', () => {
+  test.skip(
+    !solverCard,
+    `no onchain solver card at ${CARD_PATH} — start the swap service with ONCHAIN_SEND_ENABLED=true and run its \`cli card\``,
+  )
+
+  test('routes the exit through the solver that quoted it', async ({ page, isMobile }) => {
+    test.setTimeout(180_000)
+    await withCards(page, [{ network: 'regtest', label: 'regtest-onchain', card: solverCard }])
+
+    await createWallet(page)
+    await fundWallet(page, 50_000)
+    await prePay(page, ONCHAIN_ADDRESS, isMobile, 20_000)
+
+    // Reaching the sign screen with a quote in hand already means the solver
+    // answered and the wallet accepted its lockup address as matching its own
+    // derivation — the client refuses to return a mismatched one.
+    await page.getByText('Tap to Sign').click({ timeout: 60_000 })
+    await page.getByTestId('loading-logo').waitFor({ timeout: 30_000 })
+    await page.waitForSelector('text=Payment sent', { timeout: 60_000 })
+
+    const log = await routeLog(page)
+    expect(log.at(-1)).toContain('solver route')
+    expect(log.join(' ')).not.toContain('collaborative exit')
+  })
+})

--- a/src/test/lib/chainSource.test.ts
+++ b/src/test/lib/chainSource.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import * as btc from '@scure/btc-signer'
 import { secp256k1 } from '@noble/curves/secp256k1.js'
-import { MIN_CLAIM_FEE_RATE, claimFeeRate, esploraChainSource } from '../../lib/chainSource'
+import { ESPLORA_TIMEOUT_MS, MIN_CLAIM_FEE_RATE, claimFeeRate, esploraChainSource } from '../../lib/chainSource'
 
 /**
  * The wallet's L1 reads, which decide whether an onchain-send fill is claimable
@@ -146,6 +146,56 @@ describe('esploraChainSource', () => {
       const chain = esploraChainSource('http://esplora/api', 'regtest', impl)
       await expect(chain.broadcast('0200')).rejects.toThrow(/min relay fee not met/)
     })
+  })
+})
+
+describe('deadlines', () => {
+  /**
+   * `RfqSwapManager` awaits these reads before it schedules its next pass, so a
+   * request that never settles does not merely slow the wallet down — it stops
+   * the swap being driven, and this is the corridor whose claim has a consensus
+   * deadline. A rejection is recoverable; a hang is not.
+   */
+  const hangs = (() => {
+    let aborted = false
+    const impl = (async (_url: string, init?: { signal?: AbortSignal }) => {
+      init?.signal?.addEventListener('abort', () => {
+        aborted = true
+      })
+      return new Promise<never>(() => {})
+    }) as unknown as typeof fetch
+    return { impl, wasAborted: () => aborted }
+  })()
+
+  it('rejects rather than hanging when esplora never answers', async () => {
+    vi.useFakeTimers()
+    try {
+      const chain = esploraChainSource('http://esplora/api', 'regtest', hangs.impl)
+      const pending = chain.getMtp()
+      const assertion = expect(pending).rejects.toThrow(/did not answer within/)
+      await vi.advanceTimersByTimeAsync(ESPLORA_TIMEOUT_MS + 1)
+      await assertion
+      // The socket is closed too, not merely stopped being waited on.
+      expect(hangs.wasAborted()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('gives up on a hung fee estimate and uses the floor', async () => {
+    vi.useFakeTimers()
+    try {
+      const rate = claimFeeRate('http://esplora/api', hangs.impl)
+      await vi.advanceTimersByTimeAsync(ESPLORA_TIMEOUT_MS + 1)
+      expect(await rate).toBe(MIN_CLAIM_FEE_RATE)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not reject a request that answers in time', async () => {
+    const { chain } = source({ '/blocks': [{ height: 0, timestamp: 100 }] })
+    expect(await chain.getMtp()).toBe(100)
   })
 })
 

--- a/src/test/lib/chainSource.test.ts
+++ b/src/test/lib/chainSource.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest'
+import * as btc from '@scure/btc-signer'
+import { secp256k1 } from '@noble/curves/secp256k1.js'
+import { MIN_CLAIM_FEE_RATE, claimFeeRate, esploraChainSource } from '../../lib/chainSource'
+
+/**
+ * The wallet's L1 reads, which decide whether an onchain-send fill is claimable
+ * and when its window shuts. Every case here is one where a wrong answer is
+ * indistinguishable from "nothing has happened yet" — an empty UTXO list, a
+ * confirmation count that is one too high, a timestamp that is not the median —
+ * so none of them would surface as an error. They would surface as a claim that
+ * was never attempted.
+ */
+const REGTEST = { bech32: 'bcrt', pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef }
+const xOnly = secp256k1.getPublicKey(new Uint8Array(32).fill(3), true).slice(1)
+const pkScript = btc.p2tr(xOnly, undefined, REGTEST).script
+const address = btc.Address(REGTEST).encode(btc.OutScript.decode(pkScript))
+
+const ok = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+  text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+})
+
+/** A fetch that answers by path suffix, and records what it was asked. */
+const routes = (table: Record<string, unknown>) => {
+  const seen: string[] = []
+  const impl = (async (url: string, init?: { method?: string; body?: string }) => {
+    const path = url.replace('http://esplora/api', '')
+    seen.push(`${init?.method ?? 'GET'} ${path}`)
+    const key = Object.keys(table).find((candidate) => candidate === path)
+    if (key === undefined) return { ok: false, status: 404, text: async () => 'not found', json: async () => ({}) }
+    return ok(table[key])
+  }) as unknown as typeof fetch
+  return { impl, seen }
+}
+
+const source = (table: Record<string, unknown>) => {
+  const { impl, seen } = routes(table)
+  return { chain: esploraChainSource('http://esplora/api/', 'regtest', impl), seen }
+}
+
+describe('esploraChainSource', () => {
+  describe('getScriptUtxos', () => {
+    it('looks the script up by its address, never by a hand-rolled script hash', () => {
+      // A byte-reversed script hash returns an empty list rather than an error,
+      // and an empty list is exactly what "not funded yet" looks like — so this
+      // mistake would surface as a claim window that quietly expired.
+      const { chain, seen } = source({ '/blocks/tip/height': '200', [`/address/${address}/utxo`]: [] })
+      return chain.getScriptUtxos(pkScript).then(() => {
+        expect(seen).toContain(`GET /address/${address}/utxo`)
+      })
+    })
+
+    it('counts a block-height confirmation inclusively', async () => {
+      const { chain } = source({
+        '/blocks/tip/height': '200',
+        [`/address/${address}/utxo`]: [
+          { txid: 'a', vout: 0, value: 12_345, status: { confirmed: true, block_height: 200 } },
+        ],
+      })
+      const [utxo] = await chain.getScriptUtxos(pkScript)
+      // Mined into the tip is one confirmation, not zero and not two.
+      expect(utxo).toEqual({ txid: 'a', vout: 0, amount: BigInt(12_345), confirmations: 1 })
+    })
+
+    it('calls a mempool output zero deep, not one', async () => {
+      // A 1-confirmation policy must not be satisfied by a transaction that can
+      // still be replaced.
+      const { chain } = source({
+        '/blocks/tip/height': '200',
+        [`/address/${address}/utxo`]: [{ txid: 'a', vout: 1, value: 500, status: { confirmed: false } }],
+      })
+      expect((await chain.getScriptUtxos(pkScript))[0].confirmations).toBe(0)
+    })
+
+    it('reports an unfunded script as no outputs rather than throwing', async () => {
+      const { chain } = source({ '/blocks/tip/height': '200', [`/address/${address}/utxo`]: [] })
+      expect(await chain.getScriptUtxos(pkScript)).toEqual([])
+    })
+  })
+
+  describe('getSpendingTx', () => {
+    it('returns nothing while the output is unspent', async () => {
+      const { chain } = source({ '/tx/abc/outspend/0': { spent: false } })
+      expect(await chain.getSpendingTx('abc', 0)).toBeNull()
+    })
+
+    it('fetches the raw spend, which is where the preimage is read from', async () => {
+      const { chain } = source({
+        '/tx/abc/outspend/0': { spent: true, txid: 'spender' },
+        '/tx/spender/hex': '0200000000\n',
+      })
+      expect(await chain.getSpendingTx('abc', 0)).toEqual({ txHex: '0200000000' })
+    })
+  })
+
+  describe('getMtp', () => {
+    it('takes the median of the last eleven blocks, not the tip timestamp', async () => {
+      // Consensus matures a CLTV leaf against MTP, which lags the tip by about
+      // an hour. Using the tip's own timestamp would call the solver's refund
+      // leaf open while the trader's claim was in fact still available.
+      const block = (height: number, timestamp: number) => ({ height, timestamp })
+      const { chain } = source({
+        '/blocks': [
+          block(20, 2000),
+          block(19, 1900),
+          block(18, 1800),
+          block(17, 1700),
+          block(16, 1600),
+          block(15, 1500),
+          block(14, 1400),
+          block(13, 1300),
+          block(12, 1200),
+          block(11, 1100),
+        ],
+        '/blocks/10': [block(10, 1000), block(9, 900), block(8, 800)],
+      })
+      // Heights 20..10, median of the eleven timestamps is height 15's.
+      expect(await chain.getMtp()).toBe(1500)
+    })
+
+    it('takes the median of what exists on a chain shorter than eleven blocks', async () => {
+      const { chain } = source({
+        '/blocks': [
+          { height: 2, timestamp: 300 },
+          { height: 1, timestamp: 200 },
+          { height: 0, timestamp: 100 },
+        ],
+      })
+      expect(await chain.getMtp()).toBe(200)
+    })
+  })
+
+  describe('broadcast', () => {
+    it('returns the txid the node accepted', async () => {
+      const impl = vi.fn(async () => ok('deadbeef')) as unknown as typeof fetch
+      const chain = esploraChainSource('http://esplora/api', 'regtest', impl)
+      expect(await chain.broadcast('0200')).toBe('deadbeef')
+    })
+
+    it('surfaces the node’s rejection rather than a bare status', async () => {
+      const impl = (async () => ({ ok: false, status: 400, text: async () => 'min relay fee not met' })) as never
+      const chain = esploraChainSource('http://esplora/api', 'regtest', impl)
+      await expect(chain.broadcast('0200')).rejects.toThrow(/min relay fee not met/)
+    })
+  })
+})
+
+describe('claimFeeRate', () => {
+  it('takes the two-block target, rounded up', async () => {
+    const impl = (async () => ok({ '1': 12.4, '2': 8.2, '3': 4 })) as never
+    expect(await claimFeeRate('http://esplora/api', impl)).toBe(9)
+  })
+
+  it('never stops a claim it cannot price', async () => {
+    // The claim races a consensus deadline; an esplora that cannot answer must
+    // not be the reason the fill is forfeited. The floor still relays.
+    const dead = (async () => {
+      throw new Error('esplora down')
+    }) as never
+    expect(await claimFeeRate('http://esplora/api', dead)).toBe(MIN_CLAIM_FEE_RATE)
+    const empty = (async () => ok({})) as never
+    expect(await claimFeeRate('http://esplora/api', empty)).toBe(MIN_CLAIM_FEE_RATE)
+  })
+})

--- a/src/test/lib/chainSource.test.ts
+++ b/src/test/lib/chainSource.test.ts
@@ -193,6 +193,28 @@ describe('deadlines', () => {
     }
   })
 
+  it('rejects when the response arrives but its BODY never does', async () => {
+    // `fetch` resolves on the status and headers; the body is a stream that may
+    // still be running. A deadline that ends when the response object appears
+    // leaves `.json()` undeadlined, and a server that stalls mid-body hangs
+    // exactly as if there were no timeout at all.
+    const headersOnly = (async () => ({
+      ok: true,
+      status: 200,
+      json: () => new Promise<never>(() => {}),
+      text: () => new Promise<never>(() => {}),
+    })) as unknown as typeof fetch
+    vi.useFakeTimers()
+    try {
+      const chain = esploraChainSource('http://esplora/api', 'regtest', headersOnly)
+      const assertion = expect(chain.getMtp()).rejects.toThrow(/did not answer within/)
+      await vi.advanceTimersByTimeAsync(ESPLORA_TIMEOUT_MS + 1)
+      await assertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not reject a request that answers in time', async () => {
     const { chain } = source({ '/blocks': [{ height: 0, timestamp: 100 }] })
     expect(await chain.getMtp()).toBe(100)

--- a/src/test/lib/onchainSendRecords.test.ts
+++ b/src/test/lib/onchainSendRecords.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment node
 import { describe, it, expect, vi } from 'vitest'
 import { hex } from '@scure/base'
 import { rfqClaimSecretOf, rfqSignerOf, rfqSwapOriginOf } from '@arkade-os/swap'
@@ -153,6 +152,16 @@ describe('isUnfundedReservation', () => {
     const funded = vi.fn(async () => [])
     expect(await isUnfundedReservation({ ...reserved, fundingArkTxid: 'funding-txid' }, funded)).toBe(false)
     expect(funded).not.toHaveBeenCalled()
+  })
+
+  it('keeps the record when the lookup FAILS, rather than taking the failure as evidence', async () => {
+    // And, more importantly, does not throw: this runs inside the provider's
+    // `Promise.all`, so a rejection would stop `RfqSwapManager.start` running
+    // at all — every swap on both send legs, funded ones included.
+    const reading = isUnfundedReservation(reserved, async () => {
+      throw new Error('esplora down')
+    })
+    await expect(reading).resolves.toBe(false)
   })
 
   it('is false with no chain reader, so a caller without one keeps everything', async () => {

--- a/src/test/lib/onchainSendRecords.test.ts
+++ b/src/test/lib/onchainSendRecords.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest'
 import { hex } from '@scure/base'
 import { rfqClaimSecretOf, rfqSignerOf, rfqSwapOriginOf } from '@arkade-os/swap'
 import { onchainSendSwap, onchainSendSwapRecord, type OnchainSendRecordInput } from '../../lib/onchainSendRecords'
+import { claimPayoutScript } from '../../lib/onchainPayout'
 
 /**
  * The onchain-send record, read back through the package's OWN readers.
@@ -55,6 +56,7 @@ const input: OnchainSendRecordInput = {
   },
   l1Network: 'regtest',
   minConfirmations: 2,
+  payoutPkScript: hex.decode('0014610928cd26e42a6d1801e9d4718b16d67cd954b1'),
 }
 
 describe('onchainSendSwapRecord', () => {
@@ -98,6 +100,20 @@ describe('onchainSendSwapRecord', () => {
     const funded = onchainSendSwapRecord({ ...input, fundingTxid: 'funding-txid' })
     expect(funded.fundingArkTxid).toBe('funding-txid')
     expect(rfqSwapOriginOf(funded).fundingArkTxid).toBe('funding-txid')
+  })
+
+  it('carries the recipient script the claim must pay to', () => {
+    // Not on `OnchainSendProfile`: the claim transaction's output is the
+    // spender's own choice and the package records it nowhere, so a swap
+    // restored without this key has no destination but this wallet's own.
+    expect(profile().payout_pkscript).toBe('0014610928cd26e42a6d1801e9d4718b16d67cd954b1')
+    expect(claimPayoutScript(onchainSendSwapRecord(input).profile)).toEqual(input.payoutPkScript)
+  })
+
+  it('refuses to claim a record that lost its payout script', () => {
+    // Paying somewhere else is not reversible; losing the fill is. The solver
+    // takes its L1 refund and the Arkade lockup returns to the user.
+    expect(() => claimPayoutScript({})).toThrow(/refusing to claim/)
   })
 
   it('is an onchain_send from the first write, so the right handler drives it', () => {

--- a/src/test/lib/onchainSendRecords.test.ts
+++ b/src/test/lib/onchainSendRecords.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import { hex } from '@scure/base'
+import { rfqClaimSecretOf, rfqSignerOf, rfqSwapOriginOf } from '@arkade-os/swap'
+import { onchainSendSwap, onchainSendSwapRecord, type OnchainSendRecordInput } from '../../lib/onchainSendRecords'
+
+/**
+ * The onchain-send record, read back through the package's OWN readers.
+ *
+ * This corridor is the one whose contract parameters live nowhere else: the
+ * Arkade lockup has a contract row `rebuildRfqSwap` can restore from, but the
+ * L1 HTLC is a Bitcoin output — `OnchainHtlc` exposes only derived values and
+ * never the keys it was built from. A field dropped on the way into the profile
+ * is therefore not recoverable, and it does not fail loudly: the swap restores,
+ * derives a different (perfectly valid) HTLC, and watches an address nobody
+ * funded until the claim window shuts.
+ *
+ * So the assertions go through `onchainSendProfile`, `rfqSignerOf` and
+ * `rfqClaimSecretOf` rather than reading the object literally — the point is
+ * that the package can find what this file wrote, not that the keys are spelled
+ * the way this file expects.
+ */
+const PAYMENT_HASH = 'ab'.repeat(32)
+const LOCKUP_PKSCRIPT = '5120eb8a98f2d02e6fc0ea1a8802a4510dde5cafcabf1abeb0bf9cc3a568466f669a'
+const CLAIM_KEY = Uint8Array.from({ length: 32 }, (_, i) => i + 1)
+const REFUND_KEY = Uint8Array.from({ length: 32 }, (_, i) => i + 100)
+
+const input: OnchainSendRecordInput = {
+  rfqId: 'rfq-onchain-1',
+  lockupAddress:
+    'tark1qr340xg400jtxat9hdd0ungyu6s05zjtdf85uj9smyzxshf98nda' +
+    'h6u2nredqtn0cr4p4zqz53gsmhju4l9t7x47kzleesa9dprx7e56xhzlen',
+  amount: 50_000,
+  paymentHash: PAYMENT_HASH,
+  refundLocktime: 1_800_000_000,
+  secrets: {
+    descriptor: 'tr(deadbeef)',
+    pubkey: new Uint8Array(32),
+    preimage: new Uint8Array(32),
+    paymentHash: new Uint8Array(32),
+    mustPersistPreimage: false,
+  } as unknown as OnchainSendRecordInput['secrets'],
+  // Must be the address's OWN script: `createRfqSwapRecord` cross-checks the
+  // two and refuses a record whose covenant does not derive the address it
+  // claims to have funded.
+  script: { pkScript: hex.decode(LOCKUP_PKSCRIPT) } as unknown as OnchainSendRecordInput['script'],
+  htlc: { address: 'bcrt1htlcaddress' } as unknown as OnchainSendRecordInput['htlc'],
+  htlcParams: {
+    paymentHash: PAYMENT_HASH,
+    claimKey: CLAIM_KEY,
+    refundKey: REFUND_KEY,
+    // The L1 deadline, which must land under a DIFFERENT key than the Arkade
+    // lockup's `refundLocktime` — they are different clocks.
+    refundLocktime: 1_700_000_000,
+  },
+  l1Network: 'regtest',
+  minConfirmations: 2,
+}
+
+describe('onchainSendSwapRecord', () => {
+  const profile = () => onchainSendSwapRecord(input).profile as Record<string, unknown>
+
+  it('carries every L1 parameter the HTLC cannot be rebuilt without', () => {
+    expect(profile()).toMatchObject({
+      claimKey: Buffer.from(CLAIM_KEY).toString('hex'),
+      refundKey: Buffer.from(REFUND_KEY).toString('hex'),
+      network: 'regtest',
+      htlcAddress: 'bcrt1htlcaddress',
+      minConfirmations: 2,
+    })
+  })
+
+  it('keeps the two deadlines apart', () => {
+    // `htlcParams.refundLocktime` becomes `htlcLocktime` because the record
+    // already has a `refundLocktime` and it is the ARKADE lockup's. Collapsing
+    // them would arm the wrong clock on whichever leg lost.
+    const record = onchainSendSwapRecord(input)
+    expect(record.profile.htlcLocktime).toBe(1_700_000_000)
+    expect(onchainSendSwap(input).refundLocktime).toBe(1_800_000_000)
+  })
+
+  it('stores the address the rebuild checks its own derivation against', () => {
+    // The only check available on a leg with no second copy of its covenant.
+    expect(profile().htlcAddress).toBe('bcrt1htlcaddress')
+  })
+
+  it('lets the package find the signer and the claim secret it wrote', () => {
+    const record = onchainSendSwapRecord(input)
+    expect(rfqSignerOf(record)?.signingDescriptor).toBe('tr(deadbeef)')
+    expect(rfqClaimSecretOf(record)?.paymentHash).toBe(PAYMENT_HASH)
+  })
+
+  it('names the funding transaction only once there is one', () => {
+    // The record written BEFORE funding has no txid to name, and inventing an
+    // empty one would group the activity against a transaction that is not a
+    // transaction.
+    expect(onchainSendSwapRecord(input).fundingArkTxid).toBeUndefined()
+    const funded = onchainSendSwapRecord({ ...input, fundingTxid: 'funding-txid' })
+    expect(funded.fundingArkTxid).toBe('funding-txid')
+    expect(rfqSwapOriginOf(funded).fundingArkTxid).toBe('funding-txid')
+  })
+
+  it('is an onchain_send from the first write, so the right handler drives it', () => {
+    expect(onchainSendSwapRecord(input).kind).toBe('onchain_send')
+    expect(onchainSendSwap(input).kind).toBe('onchain_send')
+  })
+})

--- a/src/test/lib/onchainSendRecords.test.ts
+++ b/src/test/lib/onchainSendRecords.test.ts
@@ -1,8 +1,13 @@
 // @vitest-environment node
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { hex } from '@scure/base'
 import { rfqClaimSecretOf, rfqSignerOf, rfqSwapOriginOf } from '@arkade-os/swap'
-import { onchainSendSwap, onchainSendSwapRecord, type OnchainSendRecordInput } from '../../lib/onchainSendRecords'
+import {
+  isUnfundedReservation,
+  onchainSendSwap,
+  onchainSendSwapRecord,
+  type OnchainSendRecordInput,
+} from '../../lib/onchainSendRecords'
 import { claimPayoutScript } from '../../lib/onchainPayout'
 
 /**
@@ -119,5 +124,47 @@ describe('onchainSendSwapRecord', () => {
   it('is an onchain_send from the first write, so the right handler drives it', () => {
     expect(onchainSendSwapRecord(input).kind).toBe('onchain_send')
     expect(onchainSendSwap(input).kind).toBe('onchain_send')
+  })
+})
+
+describe('isUnfundedReservation', () => {
+  /**
+   * The one question `reserveOnchainSend`'s ordering creates. A record with no
+   * funding txid has two possible histories needing opposite treatment: the
+   * lockup WAS funded and the second write never landed (monitor it — that is
+   * the whole reason the record is written first), or it was never funded at
+   * all (drop it, or the user gets a "Pending" row for a payment they never
+   * made, watched until the refund locktime prunes it). Only the chain tells
+   * them apart.
+   */
+  const reserved = onchainSendSwapRecord(input)
+
+  it('is true for a record with no funding txid and nothing at its lockup', async () => {
+    expect(await isUnfundedReservation(reserved, async () => [])).toBe(true)
+  })
+
+  it('is false when the lockup HAS outputs — the crash the ordering exists for', async () => {
+    // Money is committed and the txid never landed. Dropping this abandons a
+    // real claim, so anything other than "no outputs" keeps the record.
+    expect(await isUnfundedReservation(reserved, async () => [{ txid: 'x' }])).toBe(false)
+  })
+
+  it('never asks the chain about a record that already names its funding tx', async () => {
+    const funded = vi.fn(async () => [])
+    expect(await isUnfundedReservation({ ...reserved, fundingArkTxid: 'funding-txid' }, funded)).toBe(false)
+    expect(funded).not.toHaveBeenCalled()
+  })
+
+  it('is false with no chain reader, so a caller without one keeps everything', async () => {
+    expect(await isUnfundedReservation(reserved)).toBe(false)
+  })
+
+  it('asks about the lockup the record actually names', async () => {
+    const seen: Uint8Array[] = []
+    await isUnfundedReservation(reserved, async (pkScript) => {
+      seen.push(pkScript)
+      return []
+    })
+    expect(hex.encode(seen[0])).toBe(LOCKUP_PKSCRIPT)
   })
 })

--- a/src/test/lib/onchainSwap.test.ts
+++ b/src/test/lib/onchainSwap.test.ts
@@ -1,0 +1,336 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest'
+import type { DiscoveredMarket } from '@arkade-os/solver-discovery'
+import {
+  ONCHAIN_ROUTE_LOG,
+  OnchainRouteUnavailable,
+  onchainRouteRefusalText,
+  onchainSendRendezvous,
+  planOnchainSend,
+  requestOnchainExit,
+} from '../../lib/onchainSwap'
+
+vi.mock('@arkade-os/swap', async () => {
+  const actual = await vi.importActual<typeof import('@arkade-os/swap')>('@arkade-os/swap')
+  return { ...actual, requestOnchainSend: (...args: unknown[]) => requestOnchainSendMock(...args) }
+})
+
+/** Swapped per test; the mock above is a stable indirection onto it. */
+let requestOnchainSendMock: (...args: any[]) => any = () => {
+  throw new Error('requestOnchainSend was not stubbed')
+}
+
+const EMULATOR = 'aa'.repeat(32)
+const SOLVER = 'bb'.repeat(32)
+
+/** A card's market as discovery hands it over. Only the fields the rendezvous
+ * reads are real; the rest is the shape `DiscoveredMarket` demands. */
+const market = (over: Partial<Record<string, unknown>> = {}): DiscoveredMarket =>
+  ({
+    pair: 'BTC/onchain:BTC',
+    base_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+    quote_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+    base_corridor: 'arkade',
+    quote_corridor: 'onchain',
+    fee_bps: 10,
+    min_base_amount: '1000',
+    max_base_amount: '1000000',
+    min_quote_amount: '1000',
+    max_quote_amount: '1000000',
+    discovery_pubkey: SOLVER,
+    emulator_pubkey: EMULATOR,
+    transports: { nostr: { relays: ['wss://relay.example'] } },
+    ...over,
+  }) as unknown as DiscoveredMarket
+
+describe('onchainSendRendezvous', () => {
+  it('selects a card whose onchain-side bounds contain the amount', () => {
+    const choice = onchainSendRendezvous([market()], 50_000)
+    expect(choice.ok).toBe(true)
+    if (!choice.ok) return
+    expect(choice.rendezvous.solverPubkey).toBe(SOLVER)
+    expect(choice.rendezvous.minSats).toBe(1000)
+    expect(choice.rendezvous.maxSats).toBe(1_000_000)
+  })
+
+  it('reads the bounds off the QUOTE side, which is what the solver pays out', () => {
+    // Base-side bounds that would accept the amount, quote-side bounds that
+    // must not. Reading the wrong side is invisible on a symmetric card, which
+    // is why this one is deliberately lopsided.
+    const choice = onchainSendRendezvous(
+      [
+        market({
+          min_base_amount: '1',
+          max_base_amount: '99999999',
+          min_quote_amount: '1000',
+          max_quote_amount: '2000',
+        }),
+      ],
+      50_000,
+    )
+    expect(choice).toEqual({ ok: false, reason: 'amount_out_of_bounds', bounds: { minSats: 1000, maxSats: 2000 } })
+  })
+
+  it('does NOT select a card that serves the pair but not the size', () => {
+    // The whole point of the size check: quoting here burns a negotiation and
+    // leaks the trade for an answer the card already gave.
+    const tooBig = onchainSendRendezvous([market()], 1_000_001)
+    expect(tooBig).toEqual({ ok: false, reason: 'amount_out_of_bounds', bounds: { minSats: 1000, maxSats: 1_000_000 } })
+    const tooSmall = onchainSendRendezvous([market()], 999)
+    expect(tooSmall.ok).toBe(false)
+  })
+
+  it('includes both bounds, so the edges are quotable', () => {
+    expect(onchainSendRendezvous([market()], 1000).ok).toBe(true)
+    expect(onchainSendRendezvous([market()], 1_000_000).ok).toBe(true)
+  })
+
+  it('skips the card that cannot take the size and picks one that can', () => {
+    const small = market({ min_quote_amount: '1', max_quote_amount: '999', discovery_pubkey: 'cc'.repeat(32) })
+    const choice = onchainSendRendezvous([small, market()], 50_000)
+    expect(choice.ok).toBe(true)
+    if (choice.ok) expect(choice.rendezvous.solverPubkey).toBe(SOLVER)
+  })
+
+  it('reports no_solver when nothing advertises the corridor', () => {
+    expect(onchainSendRendezvous([], 50_000)).toEqual({ ok: false, reason: 'no_solver' })
+    const lightning = market({ quote_corridor: 'lightning' })
+    expect(onchainSendRendezvous([lightning], 50_000)).toEqual({ ok: false, reason: 'no_solver' })
+  })
+
+  it('ignores the receive direction of the same corridor', () => {
+    // onchain -> arkade. Funding this would be a different trade entirely.
+    const receive = market({ base_corridor: 'onchain', quote_corridor: 'arkade' })
+    expect(onchainSendRendezvous([receive], 50_000)).toEqual({ ok: false, reason: 'no_solver' })
+  })
+
+  it('skips a card with no rendezvous to address', () => {
+    const noPubkey = onchainSendRendezvous([market({ discovery_pubkey: undefined })], 50_000)
+    expect(noPubkey).toEqual({ ok: false, reason: 'no_solver' })
+    const noRelays = onchainSendRendezvous([market({ transports: { nostr: { relays: [] } } })], 50_000)
+    expect(noRelays).toEqual({ ok: false, reason: 'no_solver' })
+  })
+
+  it('treats a disabled side as no corridor, not as a 0..0 range', () => {
+    // `max_quote_amount: "0"` is the registry's way of saying the solver
+    // cannot pay this side out. Parsing the strings by hand would report it to
+    // the user as "amount outside solver bounds" instead of "no solver".
+    const disabled = market({ min_quote_amount: '0', max_quote_amount: '0' })
+    expect(onchainSendRendezvous([disabled], 50_000)).toEqual({ ok: false, reason: 'no_solver' })
+  })
+
+  describe('the covenant co-signer key', () => {
+    const pinned = Uint8Array.from({ length: 32 }, () => 0xaa)
+    const other = Uint8Array.from({ length: 32 }, () => 0xcc)
+
+    it('falls back to the pin for a card that predates the field', () => {
+      const choice = onchainSendRendezvous([market({ emulator_pubkey: undefined })], 50_000, pinned)
+      expect(choice.ok && choice.rendezvous.emulatorPubkey).toBe(EMULATOR)
+    })
+
+    it('fails closed on a malformed card key even with a pin', () => {
+      const choice = onchainSendRendezvous([market({ emulator_pubkey: 'not-hex' })], 50_000, pinned)
+      expect(choice).toEqual({ ok: false, reason: 'no_solver' })
+    })
+
+    it('skips a card whose key disagrees with the pin', () => {
+      // A solver rotating its co-signer, or someone else serving the card.
+      // Either way the covenant would derive differently and the funding would
+      // pay a script this wallet never checked.
+      expect(onchainSendRendezvous([market()], 50_000, other)).toEqual({ ok: false, reason: 'no_solver' })
+    })
+
+    it('requires a key from somewhere', () => {
+      expect(onchainSendRendezvous([market({ emulator_pubkey: undefined })], 50_000)).toEqual({
+        ok: false,
+        reason: 'no_solver',
+      })
+    })
+  })
+})
+
+describe('requestOnchainExit', () => {
+  const result = (over: Record<string, unknown> = {}) => ({
+    rfqId: 'rfq-1',
+    address: 'tark1lockup',
+    fundAmount: 50_000,
+    quote: { to_amount: 49_500, valid_until: 9_999_999_999, refund_locktime: 123 },
+    swapPkScript: new Uint8Array([1]),
+    script: {} as never,
+    refundAddress: 'tark1refund',
+    htlc: { address: 'bcrt1htlc' },
+    htlcParams: { paymentHash: 'ab'.repeat(32) },
+    l1Network: 'regtest',
+    minConfirmations: 1,
+    senderPubkey: new Uint8Array([2]),
+    secrets: {} as never,
+    ...over,
+  })
+
+  const call = (over?: Record<string, unknown>) => {
+    requestOnchainSendMock = () => result(over)
+    return requestOnchainExit({
+      wallet: {} as never,
+      arkServerUrl: 'http://ark',
+      transport: {} as never,
+      amountSats: 50_000,
+      payoutPubkey: new Uint8Array(32),
+      rendezvous: {
+        solverPubkey: SOLVER,
+        transports: { nostr: { relays: [] } },
+        emulatorPubkey: EMULATOR,
+        minSats: 1,
+        maxSats: 2,
+      },
+    })
+  }
+
+  it('returns what to fund and what will land', async () => {
+    const request = await call()
+    expect(request.address).toBe('tark1lockup')
+    expect(request.fundAmount).toBe(50_000)
+    expect(request.payoutAmount).toBe(49_500)
+    expect(request.record.paymentHash).toBe('ab'.repeat(32))
+  })
+
+  it('refuses a quote that prices a different trade', async () => {
+    // The package applies `assertQuotedAmount` on the receive legs only, so
+    // without this the wallet would fund the solver's number rather than the
+    // one the user agreed to.
+    await expect(call({ fundAmount: 60_000 })).rejects.toThrow(/not the requested 50000/)
+  })
+
+  it('refuses a quote that pays out nothing, or more than it takes', async () => {
+    await expect(call({ quote: { to_amount: 0, valid_until: 1, refund_locktime: 1 } })).rejects.toThrow(/unusable/)
+    await expect(call({ quote: { to_amount: 50_000, valid_until: 1, refund_locktime: 1 } })).rejects.toThrow(/unusable/)
+    await expect(call({ quote: { to_amount: 60_000, valid_until: 1, refund_locktime: 1 } })).rejects.toThrow(/unusable/)
+  })
+})
+
+describe('planOnchainSend', () => {
+  const base = {
+    wallet: {} as never,
+    arkServerUrl: 'http://ark',
+    amountSats: 50_000,
+    payoutPubkey: new Uint8Array(32),
+    claimEndpoint: 'http://esplora/api',
+    discover: async () => [market()],
+    connect: <T>(_r: unknown, fn: (t: never) => Promise<T>) => fn({} as never),
+  }
+
+  const refusalOf = async (over: Partial<typeof base> = {}) => {
+    try {
+      await planOnchainSend({ ...base, ...over })
+      return expect.unreachable('the solver route was taken')
+    } catch (err) {
+      expect(err).toBeInstanceOf(OnchainRouteUnavailable)
+      return err as OnchainRouteUnavailable
+    }
+  }
+
+  it('takes the solver route when a card can serve the size', async () => {
+    requestOnchainSendMock = () => ({
+      rfqId: 'rfq-1',
+      address: 'tark1lockup',
+      fundAmount: 50_000,
+      quote: { to_amount: 49_500, valid_until: 9_999_999_999, refund_locktime: 1 },
+      swapPkScript: new Uint8Array(),
+      script: {} as never,
+      refundAddress: 'tark1refund',
+      htlc: { address: 'bcrt1htlc' },
+      htlcParams: { paymentHash: 'ab'.repeat(32) },
+      l1Network: 'regtest',
+      minConfirmations: 1,
+      senderPubkey: new Uint8Array(),
+      secrets: {} as never,
+    })
+    const request = await planOnchainSend(base)
+    expect(request.address).toBe('tark1lockup')
+    expect(request.rendezvous.solverPubkey).toBe(SOLVER)
+  })
+
+  it('refuses before any network call when the wallet could not claim on L1', async () => {
+    // The gate that keeps this feature from being worse than the exit it
+    // replaces: a funded HTLC nobody can open.
+    const discover = vi.fn(async () => [market()])
+    const refusal = await refusalOf({ claimEndpoint: undefined, discover })
+    expect(refusal.reason).toBe('no_l1_endpoint')
+    expect(discover).not.toHaveBeenCalled()
+  })
+
+  it('reports no_solver rather than throwing something the caller cannot branch on', async () => {
+    expect((await refusalOf({ discover: async () => [] })).reason).toBe('no_solver')
+  })
+
+  it('reports amount_out_of_bounds with the range that rejected it', async () => {
+    const refusal = await refusalOf({ amountSats: 5 })
+    expect(refusal.reason).toBe('amount_out_of_bounds')
+    expect(refusal.bounds).toEqual({ minSats: 1000, maxSats: 1_000_000 })
+  })
+
+  it('turns a discovery failure into a fallback, not an error', async () => {
+    const refusal = await refusalOf({
+      discover: async () => {
+        throw new Error('registry unreachable')
+      },
+    })
+    expect(refusal.reason).toBe('discovery_failed')
+    expect((refusal.cause as Error).message).toBe('registry unreachable')
+  })
+
+  it('turns a solver refusal into a fallback and names its reason code', async () => {
+    // The reason code is the closed contract; the message is prose.
+    requestOnchainSendMock = () => {
+      const error = new Error('solver refused: amount_out_of_range') as Error & { reason: string }
+      error.reason = 'amount_out_of_range'
+      throw error
+    }
+    const refusal = await refusalOf()
+    expect(refusal.reason).toBe('quote_failed')
+    expect(refusal.message).toBe('solver route refused: amount_out_of_range')
+  })
+
+  it('turns a timeout into a fallback', async () => {
+    requestOnchainSendMock = () => {
+      throw new Error('Solver is not responding (waited 30s) — try again later')
+    }
+    const refusal = await refusalOf()
+    expect(refusal.reason).toBe('quote_failed')
+    expect(refusal.message).toMatch(/not responding/)
+  })
+
+  it('turns an unusable quote into a fallback', async () => {
+    requestOnchainSendMock = () => ({
+      rfqId: 'rfq-1',
+      address: 'tark1lockup',
+      fundAmount: 999,
+      quote: { to_amount: 900, valid_until: 1, refund_locktime: 1 },
+      htlc: { address: 'x' },
+      htlcParams: { paymentHash: 'ab'.repeat(32) },
+      l1Network: 'regtest',
+      minConfirmations: 1,
+      script: {} as never,
+      secrets: {} as never,
+      swapPkScript: new Uint8Array(),
+      senderPubkey: new Uint8Array(),
+      refundAddress: '',
+    })
+    expect((await refusalOf()).reason).toBe('quote_failed')
+  })
+
+  it('gives every refusal a message the send screen can show', () => {
+    const reasons = ['no_solver', 'amount_out_of_bounds', 'no_l1_endpoint', 'discovery_failed', 'quote_failed'] as const
+    for (const reason of reasons) {
+      const text = onchainRouteRefusalText(new OnchainRouteUnavailable(reason, 'x'))
+      expect(text).toMatch(/collaborative exit/)
+    }
+    const withBounds = onchainRouteRefusalText(
+      new OnchainRouteUnavailable('amount_out_of_bounds', 'x', { bounds: { minSats: 10, maxSats: 20 } }),
+    )
+    expect(withBounds).toContain('10-20 sats')
+  })
+
+  it('keeps the log prefix stable, since it is the only trace of the decision', () => {
+    expect(ONCHAIN_ROUTE_LOG).toBe('onchain send:')
+  })
+})

--- a/src/test/lib/onchainSwap.test.ts
+++ b/src/test/lib/onchainSwap.test.ts
@@ -5,6 +5,7 @@ import { discover, type DiscoveredMarket } from '@arkade-os/solver-discovery'
 import { l1ScriptForAddress } from '../../lib/onchainPayout'
 import {
   ONCHAIN_ROUTE_LOG,
+  onchainQuoteMatches,
   OnchainRouteUnavailable,
   onchainRouteRefusalText,
   onchainSendRendezvous,
@@ -247,6 +248,7 @@ describe('requestOnchainExit', () => {
       amountSats: 50_000,
       payoutPubkey: new Uint8Array(32),
       payoutPkScript: RECIPIENT_SCRIPT,
+      payoutAddress: RECIPIENT,
       rendezvous: {
         solverPubkey: SOLVER,
         transports: { nostr: { relays: [] } },
@@ -285,6 +287,34 @@ describe('requestOnchainExit', () => {
     await expect(call({ quote: { to_amount: 0, valid_until: 1, refund_locktime: 1 } })).rejects.toThrow(/unusable/)
     await expect(call({ quote: { to_amount: 50_000, valid_until: 1, refund_locktime: 1 } })).rejects.toThrow(/unusable/)
     await expect(call({ quote: { to_amount: 60_000, valid_until: 1, refund_locktime: 1 } })).rejects.toThrow(/unusable/)
+  })
+})
+
+describe('onchainQuoteMatches', () => {
+  /**
+   * The guard that makes a wrong-address payment impossible rather than merely
+   * unlikely. The send flow clears a stale quote when the recipient changes,
+   * but that is two dozen `setSendInfo` call sites' worth of discipline; this
+   * is what the screen that actually moves the money asks for itself.
+   */
+  const quote = { payoutAddress: RECIPIENT, fundAmount: 5_000 }
+  const OTHER = 'bcrt1pq6gt72nxevsxk5fwl3h2sx56jeah6qfzh98mksxyakkg5l0q65gsa27khh'
+
+  it('matches the send it was quoted for', () => {
+    expect(onchainQuoteMatches(quote, { address: RECIPIENT, satoshis: 5_000 })).toBe(true)
+  })
+
+  it('does not match another address — the navigate-back-retype case', () => {
+    expect(onchainQuoteMatches(quote, { address: OTHER, satoshis: 5_000 })).toBe(false)
+  })
+
+  it('does not match another amount', () => {
+    expect(onchainQuoteMatches(quote, { address: RECIPIENT, satoshis: 50_000 })).toBe(false)
+  })
+
+  it('does not match a send with no address or amount at all', () => {
+    expect(onchainQuoteMatches(quote, {})).toBe(false)
+    expect(onchainQuoteMatches(quote, { address: RECIPIENT })).toBe(false)
   })
 })
 

--- a/src/test/lib/onchainSwap.test.ts
+++ b/src/test/lib/onchainSwap.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { hex } from '@scure/base'
 import { discover, type DiscoveredMarket } from '@arkade-os/solver-discovery'
+import { l1ScriptForAddress } from '../../lib/onchainPayout'
 import {
   ONCHAIN_ROUTE_LOG,
   OnchainRouteUnavailable,
@@ -23,6 +24,9 @@ let requestOnchainSendMock: (...args: any[]) => any = () => {
 
 const EMULATOR = 'aa'.repeat(32)
 const SOLVER = 'bb'.repeat(32)
+/** A real regtest address, so the payout script is a real one too. */
+const RECIPIENT = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+const RECIPIENT_SCRIPT = l1ScriptForAddress(RECIPIENT, 'regtest')
 
 /** A card's market as discovery hands it over. Only the fields the rendezvous
  * reads are real; the rest is the shape `DiscoveredMarket` demands. */
@@ -242,6 +246,7 @@ describe('requestOnchainExit', () => {
       transport: {} as never,
       amountSats: 50_000,
       payoutPubkey: new Uint8Array(32),
+      payoutPkScript: RECIPIENT_SCRIPT,
       rendezvous: {
         solverPubkey: SOLVER,
         transports: { nostr: { relays: [] } },
@@ -258,6 +263,15 @@ describe('requestOnchainExit', () => {
     expect(request.fundAmount).toBe(50_000)
     expect(request.payoutAmount).toBe(49_500)
     expect(request.record.paymentHash).toBe('ab'.repeat(32))
+  })
+
+  it("carries the RECIPIENT's script on the record, not the wallet's own", async () => {
+    // The HTLC's claim leaf binds a key only this wallet can sign with, so the
+    // key cannot be the recipient's. The claim's OUTPUT is a separate choice,
+    // and it is the one that has to be the recipient — otherwise the corridor
+    // pays this wallet on L1 while the receipt says the recipient was paid.
+    const request = await call()
+    expect(request.record.payoutPkScript).toEqual(RECIPIENT_SCRIPT)
   })
 
   it('refuses a quote that prices a different trade', async () => {
@@ -280,6 +294,8 @@ describe('planOnchainSend', () => {
     arkServerUrl: 'http://ark',
     amountSats: 50_000,
     payoutPubkey: new Uint8Array(32),
+    payoutAddress: RECIPIENT,
+    l1Network: 'regtest' as const,
     claimEndpoint: 'http://esplora/api',
     discover: async () => [market()],
     connect: <T>(_r: unknown, fn: (t: never) => Promise<T>) => fn({} as never),
@@ -335,6 +351,20 @@ describe('planOnchainSend', () => {
     expect(refusal.bounds).toEqual({ minSats: 1000, maxSats: 1_000_000 })
   })
 
+  it('falls back on an address the claim could not pay to, before quoting', async () => {
+    const discover = vi.fn(async () => [market()])
+    const refusal = await refusalOf({ payoutAddress: 'not-an-address', discover })
+    expect(refusal.reason).toBe('unsupported_address')
+    expect(discover).not.toHaveBeenCalled()
+  })
+
+  it('falls back on an address for another network', async () => {
+    // A mainnet address on regtest decodes to a script this chain cannot pay,
+    // and quoting it would fund a swap whose claim has nowhere to go.
+    const refusal = await refusalOf({ payoutAddress: 'bc1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytqewn5c' })
+    expect(refusal.reason).toBe('unsupported_address')
+  })
+
   it('turns a discovery failure into a fallback, not an error', async () => {
     const refusal = await refusalOf({
       discover: async () => {
@@ -386,7 +416,14 @@ describe('planOnchainSend', () => {
   })
 
   it('gives every refusal a message the send screen can show', () => {
-    const reasons = ['no_solver', 'amount_out_of_bounds', 'no_l1_endpoint', 'discovery_failed', 'quote_failed'] as const
+    const reasons = [
+      'no_solver',
+      'amount_out_of_bounds',
+      'no_l1_endpoint',
+      'unsupported_address',
+      'discovery_failed',
+      'quote_failed',
+    ] as const
     for (const reason of reasons) {
       const text = onchainRouteRefusalText(new OnchainRouteUnavailable(reason, 'x'))
       expect(text).toMatch(/collaborative exit/)

--- a/src/test/lib/onchainSwap.test.ts
+++ b/src/test/lib/onchainSwap.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, vi } from 'vitest'
-import type { DiscoveredMarket } from '@arkade-os/solver-discovery'
+import { hex } from '@scure/base'
+import { discover, type DiscoveredMarket } from '@arkade-os/solver-discovery'
 import {
   ONCHAIN_ROUTE_LOG,
   OnchainRouteUnavailable,
@@ -146,6 +147,72 @@ describe('onchainSendRendezvous', () => {
         reason: 'no_solver',
       })
     })
+  })
+})
+
+describe('a real card, through real discovery', () => {
+  /**
+   * The synthetic markets above are hand-built `DiscoveredMarket` objects, so
+   * they cannot catch a field this wallet reads under a name discovery does not
+   * emit. This one goes through `discover` — the same call `swapMarkets.ts`
+   * makes — so the corridor keys, the bounds and the rendezvous are whatever
+   * the library actually produces.
+   *
+   * It also pins the two assumptions the e2e fixture rests on: a locally pinned
+   * card needs no `sig` (pinning is the user's own trust decision, see
+   * `swapMarkets.ts`), and a card carrying no `emulator_pubkey` resolves its
+   * co-signer from the per-network pin. If either changes, the e2e's
+   * `amount_out_of_bounds` assertion silently becomes `no_solver`.
+   */
+  const card = {
+    version: 0,
+    name: 'regtest-onchain',
+    discovery_pubkey: SOLVER,
+    transports: { nostr: { relays: ['wss://localhost:10548'] } },
+    markets: [
+      {
+        pair: 'BTC/onchain:BTC',
+        base_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+        quote_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+        base_corridor: 'arkade',
+        quote_corridor: 'onchain',
+        fee_bps: 10,
+        min_base_amount: '1000',
+        max_base_amount: '1000000',
+        min_quote_amount: '1000',
+        max_quote_amount: '1000000',
+      },
+    ],
+  }
+
+  const pin = hex.decode(EMULATOR)
+
+  const markets = async (over: Record<string, unknown> = {}) => {
+    const { markets, warnings } = await discover({
+      registries: [],
+      localCards: [{ card: { ...card, ...over } as never, network: 'regtest' }],
+      network: 'regtest',
+    })
+    expect(warnings).toEqual([])
+    return markets
+  }
+
+  it('survives discovery unsigned and yields an onchain corridor market', async () => {
+    expect(await markets()).toHaveLength(1)
+  })
+
+  it('is selected for an amount inside its bounds', async () => {
+    const choice = onchainSendRendezvous(await markets(), 50_000, pin)
+    expect(choice.ok).toBe(true)
+    if (choice.ok) {
+      expect(choice.rendezvous.solverPubkey).toBe(SOLVER)
+      expect(choice.rendezvous.transports.nostr.relays).toEqual(['wss://localhost:10548'])
+    }
+  })
+
+  it('is refused on size, which is what the e2e fallback asserts', async () => {
+    const choice = onchainSendRendezvous(await markets(), 900, pin)
+    expect(choice).toEqual({ ok: false, reason: 'amount_out_of_bounds', bounds: { minSats: 1000, maxSats: 1_000_000 } })
   })
 })
 

--- a/src/test/screens/wallet/send-form.test.ts
+++ b/src/test/screens/wallet/send-form.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isPlainOnchainTypedRecipient } from '../../../screens/Wallet/Send/Form'
+import { isPlainOnchainTypedRecipient, onchainQuoteAfterAddressChange } from '../../../screens/Wallet/Send/Form'
 
 const BTC_ADDRESS = 'bcrt1pq6gt72nxevsxk5fwl3h2sx56jeah6qfzh98mksxyakkg5l0q65gsa27khh'
 const ARK_ADDRESS =
@@ -40,5 +40,42 @@ describe('isPlainOnchainTypedRecipient', () => {
 
   it('returns false for a non-BIP21, non-address value', () => {
     expect(isPlainOnchainTypedRecipient('not a recipient at all')).toBe(false)
+  })
+})
+
+describe('onchainQuoteAfterAddressChange', () => {
+  /**
+   * The navigate-back-retype bug. A negotiated quote is a fact about ONE
+   * recipient — it carries their payout script, and the L1 claim it leads to
+   * pays them — so a quote that survives an address change pays the PREVIOUS
+   * recipient while the screen shows the new one.
+   *
+   * The sequence: quote for A, back from the sign screen, type B, continue.
+   * Before this rule existed the quote stayed in `sendInfo`, the re-quote gate
+   * saw one in hand and skipped, and the claim paid A.
+   */
+  const quote = { payoutAddress: BTC_ADDRESS, fundAmount: 5_000 } as never
+  const OTHER = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+
+  it('drops the quote when the address changes', () => {
+    expect(onchainQuoteAfterAddressChange({ address: BTC_ADDRESS, pendingOnchainSend: quote }, OTHER)).toBeUndefined()
+  })
+
+  it('keeps the quote when the address is unchanged', () => {
+    // Not an unconditional clear: returning to the form without editing
+    // anything must not burn the negotiation and re-leak the trade.
+    expect(onchainQuoteAfterAddressChange({ address: BTC_ADDRESS, pendingOnchainSend: quote }, BTC_ADDRESS)).toBe(quote)
+  })
+
+  it('drops the quote when the address is cleared', () => {
+    expect(
+      onchainQuoteAfterAddressChange({ address: BTC_ADDRESS, pendingOnchainSend: quote }, undefined),
+    ).toBeUndefined()
+  })
+
+  it('has nothing to keep when there was no quote', () => {
+    expect(
+      onchainQuoteAfterAddressChange({ address: BTC_ADDRESS, pendingOnchainSend: undefined }, OTHER),
+    ).toBeUndefined()
   })
 })

--- a/src/test/screens/wallet/send-onchain-route.test.tsx
+++ b/src/test/screens/wallet/send-onchain-route.test.tsx
@@ -42,12 +42,15 @@ vi.mock('../../../lib/asp', async (importOriginal) => ({
 }))
 
 const ADDRESS = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+/** A second recipient, for the navigate-back-retype sequence. */
+const OTHER_ADDRESS = 'bcrt1pq6gt72nxevsxk5fwl3h2sx56jeah6qfzh98mksxyakkg5l0q65gsa27khh'
 const LOCKUP = 'tark1lockupcovenant'
 const FAR_FUTURE = 2_000_000_000
 
 const quote = (over: Partial<OnchainSendRequest> = {}): OnchainSendRequest =>
   ({
     rfqId: 'rfq-onchain-1',
+    payoutAddress: ADDRESS,
     address: LOCKUP,
     fundAmount: 5_000,
     payoutAmount: 4_800,
@@ -160,6 +163,35 @@ describe('sending onchain: solver route or collaborative exit', () => {
     expect(reserveOnchainSend).not.toHaveBeenCalled()
   })
 
+  it('never pays a quote negotiated for a DIFFERENT address', async () => {
+    // The navigate-back-retype sequence, at the screen that moves the money:
+    // sign screen -> back -> type another address -> continue. The quote still
+    // in hand names the FIRST recipient's payout script, and the L1 claim it
+    // leads to would pay them. The send form clears it, but this screen must
+    // not depend on that — it is the last point at which the money is still
+    // this wallet's.
+    renderSign({ address: OTHER_ADDRESS, satoshis: 5_000, pendingOnchainSend: quote() })
+    await sign()
+
+    await waitFor(() => expect(collaborativeExitWithFees).toHaveBeenCalledTimes(1))
+    // The exit goes to the address on the screen, not the one in the quote.
+    expect(collaborativeExitWithFees).toHaveBeenCalledWith(expect.anything(), 5_000, expect.any(Number), OTHER_ADDRESS)
+    expect(sendOffChain).not.toHaveBeenCalled()
+    expect(reserveOnchainSend).not.toHaveBeenCalled()
+    expect(routeLog().at(-1)?.msg).toContain('quote_mismatch')
+  })
+
+  it('never pays a quote negotiated for a different AMOUNT', async () => {
+    // Same class: the amount can be edited after the quote is stored, and the
+    // quote binds `from_amount`.
+    renderSign({ address: ADDRESS, satoshis: 9_000, pendingOnchainSend: quote() })
+    await sign()
+
+    await waitFor(() => expect(collaborativeExitWithFees).toHaveBeenCalledTimes(1))
+    expect(sendOffChain).not.toHaveBeenCalled()
+    expect(routeLog().at(-1)?.msg).toContain('quote_mismatch')
+  })
+
   it('falls back to the collaborative exit when the quote expired while the screen was open', async () => {
     renderSign({ address: ADDRESS, satoshis: 5_000, pendingOnchainSend: quote({ validUntil: 1 }) })
     await sign()
@@ -175,7 +207,7 @@ describe('sending onchain: solver route or collaborative exit', () => {
 
     await waitFor(() => expect(collaborativeExitWithFees).toHaveBeenCalledTimes(1))
     expect(sendOffChain).not.toHaveBeenCalled()
-    expect(routeLog().at(-1)?.msg).toContain('amount_mismatch')
+    expect(routeLog().at(-1)?.msg).toContain('quote_mismatch')
   })
 
   it('falls back when the swap cannot be persisted, because nothing has been funded yet', async () => {

--- a/src/test/screens/wallet/send-onchain-route.test.tsx
+++ b/src/test/screens/wallet/send-onchain-route.test.tsx
@@ -1,0 +1,215 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SendDetails from '../../../screens/Wallet/Send/Details'
+import { AspContext } from '../../../providers/asp'
+import { ConfigContext } from '../../../providers/config'
+import { FiatContext } from '../../../providers/fiat'
+import { FlowContext, type SendInfo } from '../../../providers/flow'
+import { LimitsContext } from '../../../providers/limits'
+import { LnSwapsContext } from '../../../providers/lnSwaps'
+import { NavigationContext } from '../../../providers/navigation'
+import { WalletContext } from '../../../providers/wallet'
+import { getLogs } from '../../../lib/logs'
+import type { OnchainSendRequest } from '../../../lib/onchainSwap'
+import {
+  mockAspContextValue,
+  mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockLimitsContextValue,
+  mockNavigationContextValue,
+  mockSvcWallet,
+  mockWalletContextValue,
+} from '../mocks'
+
+/**
+ * The sign screen's fork: an L1 address either goes out through a solver that
+ * quoted it, or through the collaborative exit the wallet has always done.
+ *
+ * These tests are about which of the two MOVES THE MONEY, so they mock only
+ * the two functions that do (`sendOffChain` funds the solver's lockup;
+ * `collaborativeExitWithFees` is the exit) and assert on the call, not on a
+ * rendered string. A test that watched the screen would pass just as happily
+ * with both paths wired to the same call.
+ */
+const collaborativeExitWithFees = vi.hoisted(() => vi.fn())
+const sendOffChain = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../lib/asp', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/asp')>()),
+  collaborativeExitWithFees: (...args: unknown[]) => collaborativeExitWithFees(...args),
+  sendOffChain: (...args: unknown[]) => sendOffChain(...args),
+}))
+
+const ADDRESS = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+const LOCKUP = 'tark1lockupcovenant'
+const FAR_FUTURE = 2_000_000_000
+
+const quote = (over: Partial<OnchainSendRequest> = {}): OnchainSendRequest =>
+  ({
+    rfqId: 'rfq-onchain-1',
+    address: LOCKUP,
+    fundAmount: 5_000,
+    payoutAmount: 4_800,
+    validUntil: FAR_FUTURE,
+    rendezvous: {
+      solverPubkey: 'bb'.repeat(32),
+      transports: { nostr: { relays: ['wss://relay.example'] } },
+      emulatorPubkey: 'aa'.repeat(32),
+      minSats: 1_000,
+      maxSats: 100_000,
+    },
+    htlc: { address: 'bcrt1htlc' },
+    htlcParams: { paymentHash: 'ab'.repeat(32) },
+    l1Network: 'regtest',
+    minConfirmations: 1,
+    record: {
+      paymentHash: 'ab'.repeat(32),
+      refundLocktime: FAR_FUTURE,
+      secrets: {},
+      script: {},
+      htlc: { address: 'bcrt1htlc' },
+      htlcParams: { paymentHash: 'ab'.repeat(32) },
+      l1Network: 'regtest',
+      minConfirmations: 1,
+    },
+    ...over,
+  }) as unknown as OnchainSendRequest
+
+const reserveOnchainSend = vi.fn()
+const trackOnchainSend = vi.fn()
+
+const renderSign = (sendInfo: SendInfo) =>
+  render(
+    <NavigationContext.Provider value={mockNavigationContextValue}>
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <AspContext.Provider value={mockAspContextValue}>
+            <FlowContext.Provider value={{ ...mockFlowContextValue, sendInfo }}>
+              <WalletContext.Provider
+                value={{ ...mockWalletContextValue, balance: 20_000, svcWallet: mockSvcWallet as any }}
+              >
+                <LimitsContext.Provider value={mockLimitsContextValue}>
+                  <LnSwapsContext.Provider value={{ trackLnSend: vi.fn(), reserveOnchainSend, trackOnchainSend }}>
+                    <SendDetails />
+                  </LnSwapsContext.Provider>
+                </LimitsContext.Provider>
+              </WalletContext.Provider>
+            </FlowContext.Provider>
+          </AspContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>
+    </NavigationContext.Provider>,
+  )
+
+const sign = async () => {
+  const button = await screen.findByText('Tap to Sign')
+  fireEvent.click(button)
+}
+
+/** Every routing decision the wallet made, as the log records them. */
+const routeLog = () => getLogs().filter((line) => line.msg.startsWith('onchain send:'))
+
+describe('sending onchain: solver route or collaborative exit', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    collaborativeExitWithFees.mockReset().mockResolvedValue('exit-txid')
+    sendOffChain.mockReset().mockResolvedValue('lockup-funding-txid')
+    reserveOnchainSend.mockReset().mockResolvedValue(undefined)
+    trackOnchainSend.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('funds the solver lockup when a quote is in hand, and does not exit collaboratively', async () => {
+    renderSign({ address: ADDRESS, satoshis: 5_000, pendingOnchainSend: quote() })
+    await sign()
+
+    await waitFor(() => expect(sendOffChain).toHaveBeenCalledTimes(1))
+    // The lockup the wallet derived ITSELF, for exactly what the quote said.
+    expect(sendOffChain).toHaveBeenCalledWith(expect.anything(), 5_000, LOCKUP)
+    expect(collaborativeExitWithFees).not.toHaveBeenCalled()
+  })
+
+  it('persists the swap BEFORE funding, so the L1 claim survives a crash', async () => {
+    // The one ordering this corridor cannot reverse: the HTLC's parameters are
+    // on the record and nowhere else, so a lockup funded ahead of the write is
+    // a fill nothing can claim.
+    const order: string[] = []
+    reserveOnchainSend.mockImplementation(async () => void order.push('reserve'))
+    sendOffChain.mockImplementation(async () => {
+      order.push('fund')
+      return 'lockup-funding-txid'
+    })
+    trackOnchainSend.mockImplementation(async () => void order.push('track'))
+
+    renderSign({ address: ADDRESS, satoshis: 5_000, pendingOnchainSend: quote() })
+    await sign()
+
+    await waitFor(() => expect(order).toEqual(['reserve', 'fund', 'track']))
+    expect(trackOnchainSend).toHaveBeenCalledWith(expect.objectContaining({ fundingTxid: 'lockup-funding-txid' }))
+  })
+
+  it('does exactly what it always did when no solver could take the send', async () => {
+    // The no-regression case: a wallet with no matching card gets the same
+    // collaborative exit, with the same arguments.
+    renderSign({ address: ADDRESS, satoshis: 5_000 })
+    await sign()
+
+    await waitFor(() => expect(collaborativeExitWithFees).toHaveBeenCalledTimes(1))
+    expect(collaborativeExitWithFees).toHaveBeenCalledWith(expect.anything(), 5_000, expect.any(Number), ADDRESS)
+    expect(sendOffChain).not.toHaveBeenCalled()
+    expect(reserveOnchainSend).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the collaborative exit when the quote expired while the screen was open', async () => {
+    renderSign({ address: ADDRESS, satoshis: 5_000, pendingOnchainSend: quote({ validUntil: 1 }) })
+    await sign()
+
+    await waitFor(() => expect(collaborativeExitWithFees).toHaveBeenCalledTimes(1))
+    expect(sendOffChain).not.toHaveBeenCalled()
+    expect(routeLog().at(-1)?.msg).toContain('quote_expired')
+  })
+
+  it('falls back rather than spending an amount the screen never showed', async () => {
+    renderSign({ address: ADDRESS, satoshis: 5_000, pendingOnchainSend: quote({ fundAmount: 9_000 }) })
+    await sign()
+
+    await waitFor(() => expect(collaborativeExitWithFees).toHaveBeenCalledTimes(1))
+    expect(sendOffChain).not.toHaveBeenCalled()
+    expect(routeLog().at(-1)?.msg).toContain('amount_mismatch')
+  })
+
+  it('falls back when the swap cannot be persisted, because nothing has been funded yet', async () => {
+    reserveOnchainSend.mockRejectedValue(new Error('quota exceeded'))
+    renderSign({ address: ADDRESS, satoshis: 5_000, pendingOnchainSend: quote() })
+    await sign()
+
+    await waitFor(() => expect(collaborativeExitWithFees).toHaveBeenCalledTimes(1))
+    expect(sendOffChain).not.toHaveBeenCalled()
+    expect(routeLog().at(-1)?.msg).toContain('record_failed')
+  })
+
+  it('names a reason on every fallback, so a route not taken is never silent', async () => {
+    renderSign({ address: ADDRESS, satoshis: 5_000, pendingOnchainSend: quote({ validUntil: 1 }) })
+    await sign()
+
+    await waitFor(() => expect(routeLog()).toHaveLength(1))
+    expect(routeLog()[0].msg).toMatch(/^onchain send: collaborative exit \(\w+\)/)
+  })
+
+  it('shows the solver payout, not the collaborative exit fee', async () => {
+    // The screen quotes what will actually land. Showing arkd's onchain-output
+    // fee beside a solver quote would name a number nobody is going to charge —
+    // and here the two differ: the mocked collaborative-exit fee is zero, the
+    // quote's spread is 200 sats. (Amounts render in the mock's currency of
+    // account at 1:1, so the figures below are the sat amounts.)
+    renderSign({ address: ADDRESS, satoshis: 5_000, pendingOnchainSend: quote() })
+    await waitFor(() => expect(screen.getByTestId('Network fees')).toHaveTextContent('200'))
+    expect(screen.getByTestId('Total')).toHaveTextContent('5,000')
+  })
+
+  it('leaves the collaborative-exit figures untouched when there is no quote', async () => {
+    renderSign({ address: ADDRESS, satoshis: 5_000 })
+    await waitFor(() => expect(screen.getByTestId('Total')).toHaveTextContent('5,000'))
+    expect(screen.getByTestId('Network fees')).toHaveTextContent('0')
+  })
+})


### PR DESCRIPTION
Sending to an L1 address went straight to `collaborativeExitWithFees`. It now asks the discovered solver cards first, and falls back to that exit whenever they cannot help.

## What it does

1. **Selects a card by pair *and* size.** `onchainSendRendezvous` looks for a market whose base side is `arkade` and quote side is `onchain`, then checks the amount against the **quote-side** bounds — that side is what the solver pays out, so it is the send leg's range (the same rule `lnSendRendezvous` uses for Lightning). A card that serves the pair but not the size is skipped, not selected; if another card can take the size it wins, and only when none can is `amount_out_of_bounds` reported, carrying the widest range seen. `sideLimits` is the registry's own parser, so a disabled side (`max: "0"`) reads as *no corridor* rather than a `0..0` range.
2. **Negotiates through `requestOnchainSend`**, which derives both contracts locally, refuses a lockup address it did not derive, and applies `assertFundable`'s L1 gates (claim window, timelock order, confirmation range).
3. **Funds the Arkade lockup** and hands the swap to `RfqSwapManager`, which drives the L1 claim **to the recipient's script**. The HTLC's claim leaf binds a key only this wallet can sign with — the recipient cannot sign for us — but the claim transaction's *output* is a separate choice, and that is where the recipient belongs. Their script is resolved at quote time and persisted with the record before funding, because the claim runs later and nothing in the quote, the HTLC or `OnchainSendProfile` records where a claim pays.
4. **Falls back to the collaborative exit for any other outcome**, naming the reason.

## The fallback is the contract

`planOnchainSend` rejects with `OnchainRouteUnavailable` and nothing else. Every step inside — discovery, selection, the size check, the negotiation, the client's own address and gate checks — is a way for the answer to be "no", and the caller's response to all of them is identical. Collapsing them to one rejection type is what stops a new failure mode inside `@arkade-os/swap` from escaping as an unhandled error and taking down a payment the wallet could always have made. The original is kept as `cause`; the closed `reason` set says which step.

Never silent: every fallback writes `onchain send: collaborative exit (<reason>) — <detail>` to the wallet's own log (Settings → Logs). A send that fell back looks on screen exactly like one that was never going to be routed, and that invisibility is what the log line exists to fix.

**A wallet with no matching card is unaffected.** It reaches the same `collaborativeExitWithFees` call with the same arguments; there is a test asserting exactly that.

## Two things that make funding safe

- **No L1 endpoint, no solver route.** This corridor's claim is the user's own — the solver fills a Bitcoin HTLC only they can open, before a consensus deadline — so a wallet that could not watch or broadcast on L1 would fund it and then sit there. `RfqSwapManager` fails such a swap on its first pass rather than watching it blind, so the check is made *before any network call* and the exit is taken instead. In practice this means mainnet has no solver route today: `explorers.ts` carries no `api` URL for `bitcoin`.
- **The record is written before the lockup is funded.** The Arkade lockup has a contract row that `rebuildRfqSwap` can restore from; the L1 HTLC's parameters exist on the record and nowhere else — `OnchainHtlc` exposes only derived values, and it is a Bitcoin output, not an Arkade artifact. A lockup funded ahead of that write is a fill nothing can claim. `reserveOnchainSend` runs first and, because nothing has moved yet, a store that refuses it is still a fallback.

Two more gates run before funding and can still fall back: a quote that expired while the sign screen was open, and — the important one — a quote that is not for **this** send. A quote binds one destination and one amount, and the sign screen can be left, edited and returned to; `onchainQuoteMatches` is asked both in the send form (to decide whether to re-quote) and again by the sign screen before it funds, so a quote naming a previous recipient cannot be spent even if a future `setSendInfo` forgets to clear it. A destination this wallet cannot build an L1 output for is refused before any network call (`unsupported_address`), so the record always carries somewhere for the claim to pay — and `claimPayoutScript` throws on a record that lost it rather than substituting one. Losing the fill is recoverable (the solver takes its L1 refund, the Arkade lockup returns to the user); paying somewhere nobody asked for is not.

Esplora requests carry a deadline, aborted at the socket and raced at the caller: `RfqSwapManager` awaits these reads before scheduling its next pass, so one request that never settles would stop the swap being driven on the one corridor whose claim has a consensus deadline.

## SDK check

`@arkade-os/swap` 0.0.11 (this repo's pin, and the version `origin/master` released) supports this corridor end to end — **nothing was missing and no SDK change was needed**:

- corridor bounds: `Market.min_quote_amount` / `max_quote_amount` with `marketCorridor` and `sideLimits` (`solver-discovery` `types.d.ts`, `pricing.d.ts`);
- the quote path: `onchainSendRequest`, `deriveOnchainSend`, `requestOnchainSend` (`packages/swap/src/rfq.ts:1064`, `:1164`, `:1278`);
- the refusal to branch on: `assertFundable` (`rfq.ts:432`) throws via `gateError` (`rfq.ts:295`), which builds `Error & { reason: string }` — the reason code is the closed contract, the message is prose. `SwapRefusal` (`rfq.ts:153`) carries the solver's own closed-set reason the same way. `planOnchainSend` reads `reason` first and falls back to the message only when there is none;
- no Lightning assumption in the funding path: `requestOnchainSend` takes an amount and a payout pubkey, never an invoice; `assertFundable`'s `invoiceExpiresAt` is optional and is not passed on this leg; the Arkade lockup reuses `lightningSendVtxoScript` but only the *source of the payment hash* differs (user-generated `P` rather than a BOLT11), which the SDK documents at `rfq.ts:1055`.

The wallet-side gaps were on this side and are filled here: a `ChainSource` (esplora) and a `claimOnchain` callback, which `providers/lnSwaps.tsx` previously declared as `notWired`.

## Display

On this route the solver's spread decides what lands, so the sign screen reads the payout off the quote instead of arkd's onchain-output fee. Showing the exit's fee beside a solver quote would name a number nobody is going to charge. The collaborative-exit figures are untouched when there is no quote.

One honest limitation: the figure shown is what the solver puts **into** the L1 HTLC. `buildHtlcClaim` pays the claim transaction's fee out of that output, so the recipient nets it less the fee rate at claim time — which can be hours away and is not knowable now. I have left it as the quote's number rather than subtract a guess; happy to show a range or a "less network fees" caveat if that reads better.

## Tests

`pnpm test:unit` — **baseline 88 files / 758 passed + 1 skipped, to 92 files / 839 passed + 1 skipped**. +81 tests, no failures.

- `src/test/lib/onchainSwap.test.ts` (32) — card selection, both size edges, the wrong-side-bounds trap, disabled sides, the co-signer-key rules, and every fallback reason. Three of them go through the real `discover` call rather than a hand-built market, so a field read under a name discovery does not emit would fail here.
- `src/test/screens/wallet/send-onchain-route.test.tsx` (9) — the fork that moves the money: solver route funds the lockup and does not exit; no quote takes the same exit with the same arguments; the persist-before-fund ordering; and the three pre-funding fallbacks.
- `src/test/lib/onchainSendRecords.test.ts` (14) — the stored profile read back through the package's own readers (`rfqSignerOf`, `rfqClaimSecretOf`), the two deadlines kept apart, and the funding txid named only once there is one. This corridor's L1 parameters exist on the record and nowhere else, and a field dropped on the way in does not fail loudly.
- `src/test/lib/chainSource.test.ts` (16) — address lookup rather than a hand-rolled script hash, inclusive confirmation counting, a mempool output as zero deep, and MTP as the eleven-block median rather than the tip timestamp.
- `src/test/e2e/onchainsend.test.ts` — Playwright, **added to `.github/workflows/playwright.yml`** (that workflow enumerates e2e files by name, so a new file otherwise runs nowhere). Two tests run against the regtest stack with no solver required: a card that serves the pair and refuses the size, and no card at all — both assert the exit completes *and* that the log names `amount_out_of_bounds` / `no_solver`. The solver-route test skips loudly without a real card, following `lnsend.test.ts`.

  Confirmed these actually ran rather than merely not failing — from the `E2E (assets-send / Google Chrome)` log:

  ```
  ✓  8 › onchainsend.test.ts:81:7 › sending onchain › falls back to a collaborative exit when no card can take the amount (7.1s)
  ✓  9 › onchainsend.test.ts:112:7 › sending onchain › falls back, and says so, when no card serves the corridor at all (6.7s)
  -  10 › onchainsend.test.ts:143:7 › sending onchain through a solver › routes the exit through the solver that quoted it
  ```

Mutation-tested; each of these was introduced and killed:

| mutation | tests failed |
|---|---|
| size bound always passes | 4 |
| bounds read off the base side | 3 |
| quote failures rethrown instead of becoming a fallback | 3 |
| L1-capability gate removed | 1 |
| `from_amount` mismatch check removed | 2 |
| fallback never triggers (always solver) | 1 |
| solver route never taken (always exit) | 6 |
| fund before persisting | 2 |
| quote-expiry gate removed | 2 |
| amount-mismatch gate removed | 1 |
| MTP reads the tip timestamp | 2 |
| mempool output counted as 1 confirmation | 1 |
| claim paid to the wallet's own script instead of the recipient's | 1 |
| recipient script dropped from the stored profile | 1 |
| esplora request deadline removed | 2 (suite times out) |
| every reserved record dropped, funded or not | 2 |
| a known funding txid ignored when deciding to drop | 1 |
| deadline ends at the response instead of covering the body read | 1 (suite times out) |
| a failed funding lookup allowed to propagate | 1 |
| clear rule always keeps the quote (the stale-quote bug) | 2 |
| sign screen stops checking quote identity | 3 |
| quote-matches predicate ignores the address | 2 |

## What I could not verify at runtime

The L1 claim leg has unit coverage for its reads but has never been exercised against a real solver — there is no `arkade:BTC -> onchain:BTC` service in this repo's regtest stack, so `claimOnchainFill` broadcasting a real spend is the one part of this change that has not run. The claim is driven entirely by `RfqSwapManager`; what is new here is the esplora `ChainSource` under it and the signer wiring.

## Review

CodeRabbit found a real one: `claimOnchain` derived the claim output from the wallet identity, so a solver-routed send would have paid this wallet on L1 while the receipt said the recipient was paid. Fixed in 4ddfd98 (see the payout-script threading above). It also asked for esplora request deadlines and for the funding-txid write to stop blocking monitoring; both are in.

arkana-ai-bot found no blocking issues and four smaller ones, all addressed in 67fbbef: a leaked race timer in `withDeadline`, a duplicated L1 network table, a misleading default-context message, and — the useful one — a reserved record left behind when `sendOffChain` throws, which would have shown a "Pending" row for a payment the user never made. `isUnfundedReservation` now asks the chain whether the lockup was ever funded, and only for a record that does not already name its funding transaction.

arkana then found a blocking one across two reviews, fixed in 1b3481b: a negotiated quote survived an address change, so navigate-to-sign → back → retype → continue paid the FIRST recipient. Cleared at the source (mirroring `pendingLnSend`) and refused at the point of spending. The amount was the same class of bug and is covered by the same check.

A second CodeRabbit pass found two more, fixed in f6de1d6: the request deadline ended when `fetch` resolved rather than covering the body read (so a server stalling mid-body hung as if there were no timeout), and a rejecting funding lookup propagated out of `restoreOnchainSendSwaps` — which runs inside the provider's `Promise.all`, so an esplora blip at startup would have stopped `RfqSwapManager.start` running at all, leaving every swap on both send legs unmonitored. A failed lookup is now logged and the record kept.

## Not fixed here, but worth knowing

`.github/workflows/playwright.yml`'s `core` group lists `src/test/e2e/restore.test.ts` (does not exist) and `src/test/e2e/swap.test.ts` (the file is `swaps.test.ts`). Playwright treats those arguments as filters, so both match nothing and **`swaps.test.ts` never runs in CI**. Confirmed with `playwright test --list` on those two filters: `Total: 0 tests in 0 files`. Left alone deliberately — enabling a file that has not run in a while is a separate change with its own risk. Tracked in #943.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added solver-routed Bitcoin on-chain payments for compatible recipients.
  * Preserves recipient-specific quotes and safely falls back to collaborative exit when quotes are unavailable, expired, or mismatched.
  * Added on-chain payment recovery and tracking across wallet sessions.
  * Added address validation and clearer fallback handling for unsupported destinations.

* **Bug Fixes**
  * Network requests now time out after 15 seconds, with safer fee-rate fallback behavior.

* **Tests**
  * Added end-to-end and automated coverage for routing, persistence, quote validation, fallback behavior, and request timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->