### PR TITLE
feat(send): route lightning and asset sends through PaymentRouter too

### DIFF
--- a/src/lib/sendRouter.ts
+++ b/src/lib/sendRouter.ts
@@ -7,8 +7,11 @@
  */
 import {
   PaymentRouter,
+  arkTarget,
   btcTarget,
+  invoiceTarget,
   makeHandle,
+  type Asset,
   type IWallet,
   type NetworkName,
   type PaymentRail,
@@ -16,13 +19,21 @@ import {
 } from '@arkade-os/sdk'
 import { SOLVER_ONCHAIN_RAIL, solverOnchainRail, type OnchainNetwork, type SolverOnchainSend } from '@arkade-os/swap'
 import type { DiscoveredMarket } from '@arkade-os/solver-discovery'
-import { collaborativeExitWithFees } from './asp'
+import { collaborativeExitWithFees, sendAssets, sendOffChain } from './asp'
 import { l1NetworkOf, l1PayoutPubkey } from './onchainPayout'
+import { lnSendRendezvous, requestLnSend } from './lnSwap'
+import type { LnSendRecordInput } from './lnSendRecords'
 import { withRfqTransport } from './nostrRfq'
+import { prettyNumber } from './format'
+import { consoleError } from './logs'
 import { discoverMarkets } from './swapMarkets'
-import { getEmulatorPubkeyForNetwork, getEmulatorPubkeyOverrideForNetwork } from './constants'
+import { defaultFee, getEmulatorPubkeyForNetwork, getEmulatorPubkeyOverrideForNetwork } from './constants'
 
 export const WALLET_EXIT_RAIL = 'onchain'
+
+export const LIGHTNING_RAIL = 'lightning'
+
+export const ASSET_RAIL = 'asset'
 
 export const ONCHAIN_ROUTE_LOG = 'onchain send:'
 
@@ -53,44 +64,168 @@ export const walletExitRail = (deps: { outputFee: () => number }): PaymentRail =
   },
 })
 
+export interface LightningRailDeps {
+  arkServerUrl: string
+  network: NetworkName
+  discover: () => Promise<DiscoveredMarket[]>
+  track: (input: LnSendRecordInput) => Promise<void>
+}
+
+/** Not the SDK's `solverLightningRail`: that persists BEFORE funding and its
+ *  result carries no txid, and the funding txid is what the history row and the
+ *  activity grouping key on. Picks the solver with the same `lnSendRendezvous`
+ *  the send form used before routing. */
+export const lightningRail = (deps: LightningRailDeps): PaymentRail => {
+  const rendezvousFor = async (sats: number) => {
+    const found = lnSendRendezvous(await deps.discover(), getEmulatorPubkeyForNetwork(deps.network))
+    return found && sats >= found.minSats && sats <= found.maxSats ? found : undefined
+  }
+  return {
+    id: LIGHTNING_RAIL,
+    match: (req) => invoiceTarget(req.raw) !== undefined,
+    // Deliberately no decode: an expired or wrong-chain invoice must reach
+    // `requestLnSend`, whose `InvoiceRejected` names the reason. A rail that
+    // dropped itself here would report every one of them as "no solver".
+    available: async (req) => ((req.amount ?? 0) > 0 ? (await rendezvousFor(req.amount!)) !== undefined : false),
+    quote: async (req, ctx) => {
+      const invoice = invoiceTarget(req.raw)!
+      const rendezvous = await rendezvousFor(req.amount!)
+      if (!rendezvous) throw new Error(`${LIGHTNING_RAIL}: no solver serves arkade:BTC -> lightning:BTC`)
+      const request = await withRfqTransport(rendezvous, (transport) =>
+        requestLnSend({
+          wallet: ctx.wallet as unknown as IWallet,
+          arkServerUrl: deps.arkServerUrl,
+          transport,
+          invoice,
+          network: deps.network,
+          rendezvous,
+        }),
+      )
+      return {
+        railId: LIGHTNING_RAIL,
+        amount: req.amount!,
+        fee: request.fundAmount - req.amount!,
+        total: request.fundAmount,
+        meta: { rfqId: request.rfqId, invoice, validUntil: request.validUntil },
+        send: async () =>
+          makeHandle(LIGHTNING_RAIL, async (emit) => {
+            if (Math.floor(Date.now() / 1000) >= request.validUntil) {
+              throw new Error('Quote expired — go back and try again')
+            }
+            const txid = await sendOffChain(ctx.wallet as unknown as IWallet, request.fundAmount, request.address)
+            if (!txid) throw new Error('Error sending transaction')
+            emit({ status: 'sent' })
+            // Reported, not raised: funding IS acceptance, so a store that
+            // refuses leaves the payment committed either way.
+            await deps
+              .track({
+                rfqId: request.rfqId,
+                lockupAddress: request.address,
+                amount: request.fundAmount,
+                fundingTxid: txid,
+                ...request.record,
+              })
+              .catch((err) => consoleError(err, 'error tracking lightning send'))
+            const result = { railId: LIGHTNING_RAIL, txid, swapId: request.rfqId }
+            emit({ status: 'settled', result })
+            return result
+          }),
+      }
+    },
+  }
+}
+
+/** Assets ride the deps, not the request: a `PaymentRequest` carries sats. */
+export const assetRail = (deps: { assets: Asset[] }): PaymentRail => ({
+  id: ASSET_RAIL,
+  match: (req) => arkTarget(req.raw) !== undefined,
+  available: () => deps.assets.length > 0,
+  quote: async (req, ctx) => ({
+    railId: ASSET_RAIL,
+    amount: 0,
+    fee: defaultFee,
+    total: defaultFee,
+    send: async () =>
+      makeHandle(ASSET_RAIL, async (emit) => {
+        const txid = await sendAssets(ctx.wallet as unknown as IWallet, arkTarget(req.raw)!, deps.assets)
+        const result = { railId: ASSET_RAIL, txid }
+        emit({ status: 'settled', result })
+        return result
+      }),
+  }),
+})
+
+/** Optional per-corridor deps: a rail whose deps are absent is not registered,
+ *  which is the drop `available()` performs, one step earlier. */
 export interface SendRouterDeps {
   wallet: IWallet
   arkServerUrl: string
   network: NetworkName
-  outputFee: () => number
-  persist: (swap: SolverOnchainSend) => Promise<void>
-  payoutPubkey: Uint8Array
+  outputFee?: () => number
+  persist?: (swap: SolverOnchainSend) => Promise<void>
+  payoutPubkey?: Uint8Array
+  track?: LightningRailDeps['track']
+  assets?: Asset[]
   discover?: (network: NetworkName) => Promise<DiscoveredMarket[]>
 }
 
-/** Registered on every network now `ESPLORA_URL` is total; `available()` drops it. */
+/** The solver rail is registered on every network now `ESPLORA_URL` is total;
+ *  `available()` drops it. */
 export const createSendRouter = (deps: SendRouterDeps): PaymentRouter => {
   const router = new PaymentRouter({
     // Typed as concrete `Wallet`; an `IWallet` satisfies what the rails call.
     wallet: deps.wallet as unknown as ConstructorParameters<typeof PaymentRouter>[0]['wallet'],
-    prefs: { priority: [SOLVER_ONCHAIN_RAIL, WALLET_EXIT_RAIL] },
+    prefs: { priority: [SOLVER_ONCHAIN_RAIL, WALLET_EXIT_RAIL, LIGHTNING_RAIL, ASSET_RAIL] },
   })
 
   const discover = deps.discover ?? discoverMarkets
-  router.use(
-    solverOnchainRail({
-      arkServerUrl: deps.arkServerUrl,
-      l1Network: l1NetworkOf(deps.network) as OnchainNetwork,
-      payoutPubkey: deps.payoutPubkey,
-      discover: () => discover(deps.network),
-      connect: (rendezvous, fn) => withRfqTransport(rendezvous, fn),
-      persist: deps.persist,
-      ...(getEmulatorPubkeyOverrideForNetwork(deps.network)
-        ? { emulatorPubkey: getEmulatorPubkeyOverrideForNetwork(deps.network)! }
-        : {}),
-      ...(getEmulatorPubkeyForNetwork(deps.network)
-        ? { fallbackEmulatorPubkey: getEmulatorPubkeyForNetwork(deps.network)! }
-        : {}),
-    }),
-  )
-
-  return router.use(walletExitRail({ outputFee: deps.outputFee }))
+  if (deps.payoutPubkey && deps.persist) {
+    const payoutPubkey = deps.payoutPubkey
+    const persist = deps.persist
+    router.use(
+      solverOnchainRail({
+        arkServerUrl: deps.arkServerUrl,
+        l1Network: l1NetworkOf(deps.network) as OnchainNetwork,
+        payoutPubkey,
+        discover: () => discover(deps.network),
+        connect: (rendezvous, fn) => withRfqTransport(rendezvous, fn),
+        persist,
+        ...(getEmulatorPubkeyOverrideForNetwork(deps.network)
+          ? { emulatorPubkey: getEmulatorPubkeyOverrideForNetwork(deps.network)! }
+          : {}),
+        ...(getEmulatorPubkeyForNetwork(deps.network)
+          ? { fallbackEmulatorPubkey: getEmulatorPubkeyForNetwork(deps.network)! }
+          : {}),
+      }),
+    )
+  }
+  if (deps.outputFee) router.use(walletExitRail({ outputFee: deps.outputFee }))
+  if (deps.track) {
+    router.use(
+      lightningRail({
+        arkServerUrl: deps.arkServerUrl,
+        network: deps.network,
+        discover: () => discover(deps.network),
+        track: deps.track,
+      }),
+    )
+  }
+  if (deps.assets) router.use(assetRail({ assets: deps.assets }))
+  return router
 }
+
+/** Why the Lightning rail dropped itself: `options()` reports absence, not
+ *  cause, and the send form told these two apart before routing. */
+export const lnSendRefusal = (markets: DiscoveredMarket[], network: NetworkName): string => {
+  const found = lnSendRendezvous(markets, getEmulatorPubkeyForNetwork(network))
+  return found
+    ? `Amount outside solver bounds (${prettyNumber(found.minSats)}-${prettyNumber(found.maxSats)} sats)`
+    : 'No Lightning solver available'
+}
+
+/** The Lightning analogue of {@link quoteIsForThisSend}. */
+export const quoteIsForThisInvoice = (quote: Pick<RouteQuote, 'meta'>, invoice: string): boolean =>
+  quote.meta?.invoice === invoice
 
 /** Quoting lazily already removes the stale quote behind the wrong-address bug.
  *  This is the belt to that braces — a rail may quote worse than advertised. */

--- a/src/lib/sendRouter.ts
+++ b/src/lib/sendRouter.ts
@@ -148,6 +148,8 @@ export const assetRail = (deps: { assets: Asset[] }): PaymentRail => ({
     send: async () =>
       makeHandle(ASSET_RAIL, async (emit) => {
         const txid = await sendAssets(ctx.wallet as unknown as IWallet, arkTarget(req.raw)!, deps.assets)
+        // Terminal in one step, unlike the lightning rail: no counterparty has
+        // to act, so the txid IS settlement and a `sent` would name nothing.
         const result = { railId: ASSET_RAIL, txid }
         emit({ status: 'settled', result })
         return result

--- a/src/lib/sendRouter.ts
+++ b/src/lib/sendRouter.ts
@@ -223,9 +223,13 @@ export const lnSendRefusal = (markets: DiscoveredMarket[], network: NetworkName)
     : 'No Lightning solver available'
 }
 
-/** The Lightning analogue of {@link quoteIsForThisSend}. */
-export const quoteIsForThisInvoice = (quote: Pick<RouteQuote, 'meta'>, invoice: string): boolean =>
-  quote.meta?.invoice === invoice
+/** The Lightning analogue of {@link quoteIsForThisSend}. Compared through
+ *  `invoiceTarget`, as the rail routed it: a `lightning:` prefix or a whole
+ *  BIP21 URI is the same payment, and only a DIFFERENT invoice is refused. */
+export const quoteIsForThisInvoice = (quote: Pick<RouteQuote, 'meta'>, invoice: string): boolean => {
+  const target = invoiceTarget(invoice)
+  return target !== undefined && quote.meta?.invoice === target
+}
 
 /** Quoting lazily already removes the stale quote behind the wrong-address bug.
  *  This is the belt to that braces — a rail may quote worse than advertised. */

--- a/src/providers/flow.tsx
+++ b/src/providers/flow.tsx
@@ -1,6 +1,5 @@
-import type { LnSendRequest } from '../lib/lnSwap'
 import { ReactNode, SetStateAction, createContext, useState } from 'react'
-import type { Asset, AssetDetails, ServiceWorkerWalletMode } from '@arkade-os/sdk'
+import type { Asset, AssetDetails, RouteQuote, ServiceWorkerWalletMode } from '@arkade-os/sdk'
 import { Tx } from '../lib/types'
 import type { FiatAccountSend } from '../lib/accountAssets'
 
@@ -63,7 +62,9 @@ export type SendInfo = {
   arkAddress?: string
   invoice?: string
   lnUrl?: string
-  pendingLnSend?: LnSendRequest
+  /** The negotiated Lightning route: quoted on the form so the fee is on screen
+   *  before the user signs, and `send()` is what the sign screen calls. */
+  pendingLnSend?: RouteQuote
   recipient?: string
   satoshis?: number
   scan?: boolean

--- a/src/screens/Wallet/Send/Details.tsx
+++ b/src/screens/Wallet/Send/Details.tsx
@@ -13,14 +13,20 @@ import { defaultFee } from '../../../lib/constants'
 import { prettyNumber } from '../../../lib/format'
 import Content from '../../../components/Content'
 import FlexCol from '../../../components/FlexCol'
-import { sendAssets, sendOffChain } from '../../../lib/asp'
-import { type LnSendRequest } from '../../../lib/lnSwap'
-import { createSendRouter, l1PayoutPubkey, ONCHAIN_ROUTE_LOG, quoteIsForThisSend } from '../../../lib/sendRouter'
+import { sendOffChain } from '../../../lib/asp'
+import {
+  ASSET_RAIL,
+  createSendRouter,
+  l1PayoutPubkey,
+  ONCHAIN_ROUTE_LOG,
+  quoteIsForThisInvoice,
+  quoteIsForThisSend,
+} from '../../../lib/sendRouter'
 import { extractError } from '../../../lib/error'
 import LoadingLogo from '../../../components/LoadingLogo'
 import { consoleError, consoleLog } from '../../../lib/logs'
 import { AspContext } from '../../../providers/asp'
-import type { NetworkName } from '@arkade-os/sdk'
+import type { NetworkName, RouteQuote } from '@arkade-os/sdk'
 import { LimitsContext } from '../../../providers/limits'
 import { FeesContext } from '../../../providers/fees'
 import { buildTransactionAmountDisplay } from '../../../lib/transactionAmountDisplay'
@@ -36,7 +42,7 @@ export default function SendDetails() {
   const isAssetSend = Boolean(sendInfo.account || sendInfo.assets?.length)
   const { utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { assetMetadataCache, balance, reloadWallet, svcWallet } = useContext(WalletContext)
-  const { trackLnSend, reserveOnchainSend } = useContext(LnSwapsContext)
+  const { reserveOnchainSend } = useContext(LnSwapsContext)
   const { aspInfo } = useContext(AspContext)
 
   const assetId = sendInfo.account?.assetId ?? sendInfo.assets?.[0]?.assetId
@@ -99,7 +105,7 @@ export default function SendDetails() {
             : ''
     // The RFQ lockup carries exactly the invoice amount (exact-out, fee_bps
     // from the card; 0 today), so total == satoshis on the Lightning path.
-    const total = pendingLnSend ? pendingLnSend.fundAmount : satoshis
+    const total = pendingLnSend ? pendingLnSend.total : satoshis
     const amount = direction === 'Paying to mainnet' ? satoshis - calcOnchainOutputFee() : satoshis
     const fees = total - amount > 0 ? total - amount : 0
     setDetails({
@@ -172,24 +178,30 @@ export default function SendDetails() {
    * The success screen says "on the way" rather than "sent" for exactly this
    * reason: at this instant the invoice is not paid yet, and the wording has to
    * match what is actually true.
+   *
+   * The invoice is re-checked because the quote came from the previous screen —
+   * the same reason the on-chain path re-checks its address.
    */
-  const payLightning = async (request: LnSendRequest) => {
-    const txid = await sendOffChain(svcWallet!, request.fundAmount, request.address)
-    if (!txid) return handleError('Error sending transaction')
-    // Hand the swap over before `handleTxid` triggers the refresh that rebuilds
-    // history: the record is what makes this row a Lightning send rather than a
-    // bare outgoing payment, and it is what the manager drives from here on —
-    // including the refund, which nothing else in the wallet will push. A store
-    // that refuses leaves the payment committed and unmonitored, so it is
-    // reported and not raised: the covenant is funded either way.
-    await trackLnSend({
-      rfqId: request.rfqId,
-      lockupAddress: request.address,
-      amount: request.fundAmount,
-      fundingTxid: txid,
-      ...request.record,
-    }).catch((err) => consoleError(err, 'error tracking lightning send'))
-    handleTxid(txid)
+  const payLightning = async (quote: RouteQuote, shownInvoice: string) => {
+    if (!quoteIsForThisInvoice(quote, shownInvoice)) return handleError('Quote is for a different invoice')
+    const result = await (await quote.send()).settled()
+    handleSent(result.txid, quote.total, quote.fee)
+  }
+
+  /** One rail and no counterparty; routed so every branch here has one shape. */
+  const payAssets = async (arkAddress: string, assets: NonNullable<typeof sendInfo.assets>) => {
+    const router = createSendRouter({
+      wallet: svcWallet!,
+      arkServerUrl: aspInfo.url,
+      network: aspInfo.network as NetworkName,
+      assets,
+    })
+    const options = await router.options({ raw: arkAddress })
+    const route = options.find((option) => option.railId === ASSET_RAIL)
+    if (!route) throw new Error('No route for this payment')
+    const quote = await route.quote()
+    const result = await (await quote.send()).settled()
+    handleTxid(result.txid ?? '')
   }
 
   /** Pay an L1 address through the router. The request is built from `address` —
@@ -244,26 +256,18 @@ export default function SendDetails() {
     setSending(true)
 
     if (isAssetSend && arkAddress) {
-      // Asset send via wallet.send()
       if (!sendInfo.assets || sendInfo.assets.length === 0) return handleError('Missing assets list')
-      sendAssets(svcWallet, arkAddress, sendInfo.assets)
-        .then((txId: string) => handleTxid(txId))
-        .catch(handleError)
+      payAssets(arkAddress, sendInfo.assets).catch(handleError)
     } else if (arkAddress) {
       if (!details.total) return handleError('Missing total amount')
       sendOffChain(svcWallet, details.total, arkAddress)
         .then((txId: string) => handleTxid(txId))
         .catch(handleError)
     } else if (invoice && pendingLnSend) {
-      // RFQ Lightning send. The address below is the wallet's OWN derivation
-      // of the lockup covenant (the client refuses a mismatched quote), so
-      // funding it IS the acceptance — no further message exists. The solver
-      // observes the funding, pays the invoice, and claims with the preimage;
-      // a failed swap refunds by covenant.
-      if (Math.floor(Date.now() / 1000) >= pendingLnSend.validUntil) {
-        return handleError('Quote expired — go back and try again')
-      }
-      payLightning(pendingLnSend).catch(handleError)
+      // RFQ Lightning send. The address the rail funds is the wallet's OWN
+      // derivation of the lockup covenant (the client refuses a mismatched
+      // quote), so funding it IS the acceptance — no further message exists.
+      payLightning(pendingLnSend, invoice).catch(handleError)
     } else if (address) {
       if (!details.total) return handleError('Missing total amount')
       if (!details.satoshis) return handleError('Missing satoshis amount')

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -623,16 +623,21 @@ export default function SendForm() {
       const negotiate = async () => {
         if (!svcWallet) return handleError('Wallet not ready')
         const network = aspInfo.network as NetworkName
+        // Discovered once and handed to the router, so the rail ranks and the
+        // refusal explains off the SAME cards. Asking twice let a cold cache
+        // with an unreachable registry throw on the error path, replacing the
+        // message with the registry's own.
+        const markets = await discoverMarkets(network)
         const router = createSendRouter({
           wallet: svcWallet,
           arkServerUrl: aspInfo.url,
           network,
           track: trackLnSend,
+          discover: async () => markets,
         })
         const options = await router.options({ raw: sendInfo.invoice!, amount: sendInfo.satoshis ?? 0 })
         const route = options.find((option) => option.railId === LIGHTNING_RAIL)
-        // `options()` reports absence; the card says why. Discovery is cached.
-        if (!route) return handleError(lnSendRefusal(await discoverMarkets(network), network))
+        if (!route) return handleError(lnSendRefusal(markets, network))
         // Unguarded: a quote that throws names an unpayable invoice or a
         // covenant that did not match, and neither reads as "no route".
         const pendingLnSend = await route.quote()

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -4,6 +4,7 @@ import Button from '../../../components/Button'
 import ErrorMessage from '../../../components/Error'
 import ButtonsOnBottom from '../../../components/ButtonsOnBottom'
 import { NavigationContext, Pages } from '../../../providers/navigation'
+import { LnSwapsContext } from '../../../providers/lnSwaps'
 import { FlowContext } from '../../../providers/flow'
 import Padded from '../../../components/Padded'
 import { isBTCAddress, decodeArkAddress, isLightningInvoice, isURLWithLightningQueryString } from '../../../lib/address'
@@ -33,8 +34,7 @@ import { LimitsContext } from '../../../providers/limits'
 import { checkLnUrlConditions, fetchInvoice, fetchArkAddress, isValidLnUrl, LnUrlResponse } from '../../../lib/lnurl'
 import { extractError } from '../../../lib/error'
 import { decodeInvoice } from '../../../lib/bolt11'
-import { lnSendRendezvous, requestLnSend } from '../../../lib/lnSwap'
-import { withRfqTransport } from '../../../lib/nostrRfq'
+import { createSendRouter, LIGHTNING_RAIL, lnSendRefusal } from '../../../lib/sendRouter'
 import { discoverMarkets } from '../../../lib/swapMarkets'
 import { decodeBip21, isBip21 } from '../../../lib/bip21'
 import { InfoLine } from '../../../components/Info'
@@ -58,7 +58,7 @@ import {
   DropdownMenuTrigger,
 } from '../../../components/ui/dropdown-menu'
 import { hapticLight } from '../../../lib/haptics'
-import { getEmulatorPubkeyForNetwork, testDomains } from '../../../lib/constants'
+import { testDomains } from '../../../lib/constants'
 import UnverifiedBadge from '../../../components/UnverifiedBadge'
 
 const isProductionEnv = !testDomains.some((d) => window.location.hostname.includes(d))
@@ -129,6 +129,7 @@ export default function SendForm() {
   const { sendInfo, setNoteInfo, setSendInfo } = useContext(FlowContext)
   const { amountIsAboveMaxLimit, amountIsBelowMinLimit, utxoTxsAllowed, vtxoTxsAllowed } = useContext(LimitsContext)
   const { navigate } = useContext(NavigationContext)
+  const { trackLnSend } = useContext(LnSwapsContext)
   const {
     assetBalances,
     availableAssetBalances,
@@ -622,30 +623,20 @@ export default function SendForm() {
       const negotiate = async () => {
         if (!svcWallet) return handleError('Wallet not ready')
         const network = aspInfo.network as NetworkName
-        // No emulator URL is looked up here: this corridor needs the co-signer's
-        // x-only KEY, never an endpoint. It rides the solver's own card; the
-        // per-network pin is passed as the fallback for cards that predate the
-        // field (see lnSendRendezvous). Neither available yields no rendezvous,
-        // which the line below already reports.
-        const rendezvous = lnSendRendezvous(await discoverMarkets(network), getEmulatorPubkeyForNetwork(network))
-        if (!rendezvous) return handleError('No Lightning solver available')
-        const sats = sendInfo.satoshis ?? 0
-        if (sats < rendezvous.minSats || sats > rendezvous.maxSats) {
-          return handleError(
-            `Amount outside solver bounds (${prettyNumber(rendezvous.minSats)}-${prettyNumber(rendezvous.maxSats)} sats)`,
-          )
-        }
-        await withRfqTransport(rendezvous, async (transport) => {
-          const pendingLnSend = await requestLnSend({
-            wallet: svcWallet,
-            arkServerUrl: aspInfo.url,
-            transport,
-            invoice: sendInfo.invoice!,
-            network,
-            rendezvous,
-          })
-          setSendInfo((prev) => ({ ...prev, pendingLnSend }))
+        const router = createSendRouter({
+          wallet: svcWallet,
+          arkServerUrl: aspInfo.url,
+          network,
+          track: trackLnSend,
         })
+        const options = await router.options({ raw: sendInfo.invoice!, amount: sendInfo.satoshis ?? 0 })
+        const route = options.find((option) => option.railId === LIGHTNING_RAIL)
+        // `options()` reports absence; the card says why. Discovery is cached.
+        if (!route) return handleError(lnSendRefusal(await discoverMarkets(network), network))
+        // Unguarded: a quote that throws names an unpayable invoice or a
+        // covenant that did not match, and neither reads as "no route".
+        const pendingLnSend = await route.quote()
+        setSendInfo((prev) => ({ ...prev, pendingLnSend }))
       }
       negotiate().catch(handleError)
     }

--- a/src/test/lib/sendRouter.test.ts
+++ b/src/test/lib/sendRouter.test.ts
@@ -1,17 +1,57 @@
 // @vitest-environment node
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { hex } from '@scure/base'
 import type { DiscoveredMarket } from '@arkade-os/solver-discovery'
 import { SOLVER_ONCHAIN_RAIL } from '@arkade-os/swap'
-import { createSendRouter, quoteIsForThisSend, WALLET_EXIT_RAIL } from '../../lib/sendRouter'
+import {
+  ASSET_RAIL,
+  createSendRouter,
+  LIGHTNING_RAIL,
+  lnSendRefusal,
+  quoteIsForThisInvoice,
+  quoteIsForThisSend,
+  WALLET_EXIT_RAIL,
+} from '../../lib/sendRouter'
 import { onchainClaimEndpoint } from '../../lib/onchainPayout'
 import { getEmulatorPubkeyForNetwork } from '../../lib/constants'
 import fixtures from '../fixtures.json'
 
 const collaborativeExitWithFees = vi.fn(async () => 'exit-txid')
+const sendOffChain = vi.fn(async () => 'funding-txid')
+const sendAssets = vi.fn(async () => 'asset-txid')
 vi.mock('../../lib/asp', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../lib/asp')>()),
   collaborativeExitWithFees: (...args: unknown[]) => collaborativeExitWithFees(...(args as [])),
+  sendOffChain: (...args: unknown[]) => sendOffChain(...(args as [])),
+  sendAssets: (...args: unknown[]) => sendAssets(...(args as [])),
+}))
+
+const negotiated = () => ({
+  rfqId: 'rfq-1',
+  address: 'ark1lockup',
+  fundAmount: 2_100,
+  validUntil: Math.floor(Date.now() / 1000) + 60,
+  rendezvous: {} as never,
+  record: { paymentHash: 'ph', refundLocktime: 7, secrets: {} as never, script: {} as never },
+})
+
+/** The negotiation itself, stubbed — `lnSendRendezvous` is left real, since
+ *  which solver it picks is the behaviour under test. */
+const requestLnSend = vi.fn(async () => negotiated())
+vi.mock('../../lib/lnSwap', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/lnSwap')>()),
+  requestLnSend: (...args: unknown[]) => requestLnSend(...(args as [])),
+}))
+
+/** `consoleError` persists to localStorage, which this environment has not. */
+vi.mock('../../lib/logs', () => ({ consoleError: vi.fn(), consoleLog: vi.fn() }))
+
+const connected = vi.fn()
+vi.mock('../../lib/nostrRfq', () => ({
+  withRfqTransport: async (rendezvous: unknown, fn: (t: unknown) => Promise<unknown>) => {
+    connected(rendezvous)
+    return fn({} as never)
+  },
 }))
 
 const SOLVER = 'bb'.repeat(32)
@@ -147,5 +187,191 @@ describe('the collaborative exit rail', () => {
     await quote.send()
     // 10_000 leaves, the recipient gets 9_500 — exactly as before the router.
     expect(collaborativeExitWithFees).toHaveBeenCalledWith(expect.anything(), 10_000, 9_500, RECIPIENT)
+  })
+})
+
+const INVOICE = fixtures.lib.bolt11.invoice
+const INVOICE_SATS = fixtures.lib.bolt11.amountSats
+const ARK_ADDRESS = fixtures.lib.address.ark[0].address
+
+const lnMarket = (over: Record<string, unknown> = {}) =>
+  market({ pair: 'BTC/lightning:BTC', quote_corridor: 'lightning', ...over })
+
+const track = vi.fn(async () => {})
+
+const lnRouter = (over: Partial<Parameters<typeof createSendRouter>[0]> = {}) =>
+  createSendRouter({
+    wallet: {} as never,
+    arkServerUrl: 'http://ark.example',
+    network: 'regtest',
+    track,
+    discover: async () => [lnMarket()],
+    ...over,
+  })
+
+const lnQuote = async (over: Partial<Parameters<typeof createSendRouter>[0]> = {}) => {
+  const options = await lnRouter(over).options({ raw: INVOICE, amount: INVOICE_SATS })
+  return options[0].quote()
+}
+
+describe('the lightning rail replaces the send form’s own solver pick', () => {
+  beforeEach(() => {
+    requestLnSend.mockClear()
+    sendOffChain.mockClear()
+    track.mockClear()
+    connected.mockClear()
+  })
+
+  it('takes an invoice and leaves the other targets alone', async () => {
+    expect((await lnRouter().options({ raw: INVOICE, amount: INVOICE_SATS })).map((o) => o.railId)).toEqual([
+      LIGHTNING_RAIL,
+    ])
+    expect(await lnRouter().options({ raw: RECIPIENT, amount: INVOICE_SATS })).toEqual([])
+    expect(await lnRouter().options({ raw: ARK_ADDRESS, amount: INVOICE_SATS })).toEqual([])
+  })
+
+  it('drops itself when no card serves the corridor (was: no solver)', async () => {
+    expect(await lnRouter({ discover: async () => [] }).options({ raw: INVOICE, amount: INVOICE_SATS })).toEqual([])
+    // The on-chain corridor is not the Lightning one, however well it quotes.
+    expect(
+      await lnRouter({ discover: async () => [market()] }).options({ raw: INVOICE, amount: INVOICE_SATS }),
+    ).toEqual([])
+  })
+
+  it('drops itself for a size the one solver will not take (was: outside solver bounds)', async () => {
+    expect(await lnRouter().options({ raw: INVOICE, amount: 999 })).toEqual([])
+    expect(await lnRouter().options({ raw: INVOICE, amount: 1_000_001 })).toEqual([])
+  })
+
+  it('drops itself when discovery throws, and does NOT take the router down', async () => {
+    const r = lnRouter({
+      discover: async () => {
+        throw new Error('registry unreachable')
+      },
+    })
+    expect(await r.options({ raw: INVOICE, amount: INVOICE_SATS })).toEqual([])
+  })
+
+  it('skips a card whose co-signer key disagrees with the pin — the rule the form applied', async () => {
+    const r = lnRouter({ discover: async () => [lnMarket({ emulator_pubkey: 'cc'.repeat(32) })] })
+    expect(await r.options({ raw: INVOICE, amount: INVOICE_SATS })).toEqual([])
+  })
+
+  it('negotiates with the card’s own solver, over the card’s own relays', async () => {
+    await lnQuote()
+    expect(connected).toHaveBeenCalledWith(
+      expect.objectContaining({ solverPubkey: SOLVER, transports: { nostr: { relays: ['wss://relay.example'] } } }),
+    )
+    expect(requestLnSend).toHaveBeenCalledWith(expect.objectContaining({ invoice: INVOICE, network: 'regtest' }))
+  })
+
+  it('quotes the invoice amount, with the solver’s spread as the fee on top', async () => {
+    expect(await lnQuote()).toMatchObject({
+      railId: LIGHTNING_RAIL,
+      amount: INVOICE_SATS,
+      fee: 2_100 - INVOICE_SATS,
+      total: 2_100,
+      meta: { rfqId: 'rfq-1', invoice: INVOICE },
+    })
+  })
+
+  it('funds the lockup and records the swap WITH its funding txid', async () => {
+    const quote = await lnQuote()
+    const result = await (await quote.send()).settled()
+
+    expect(sendOffChain).toHaveBeenCalledWith(expect.anything(), 2_100, 'ark1lockup')
+    expect(track).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rfqId: 'rfq-1',
+        lockupAddress: 'ark1lockup',
+        amount: 2_100,
+        fundingTxid: 'funding-txid',
+        paymentHash: 'ph',
+        refundLocktime: 7,
+      }),
+    )
+    expect(result).toMatchObject({ railId: LIGHTNING_RAIL, txid: 'funding-txid', swapId: 'rfq-1' })
+  })
+
+  it('records the swap only once the covenant is funded', async () => {
+    const order: string[] = []
+    sendOffChain.mockImplementationOnce(async () => {
+      order.push('fund')
+      return 'funding-txid'
+    })
+    track.mockImplementationOnce(async () => {
+      order.push('track')
+    })
+    await (await (await lnQuote()).send()).settled()
+    expect(order).toEqual(['fund', 'track'])
+  })
+
+  it('does not fail a funded send because the store refused the record', async () => {
+    track.mockRejectedValueOnce(new Error('quota exceeded'))
+    const result = await (await (await lnQuote()).send()).settled()
+    expect(result).toMatchObject({ txid: 'funding-txid' })
+  })
+
+  it('refuses to fund an expired quote, and funds nothing', async () => {
+    requestLnSend.mockResolvedValueOnce({ ...negotiated(), validUntil: Math.floor(Date.now() / 1000) - 1 })
+    const quote = await lnQuote()
+    await expect((await quote.send()).settled()).rejects.toThrow(/Quote expired/)
+    expect(sendOffChain).not.toHaveBeenCalled()
+  })
+})
+
+describe('lnSendRefusal names which of the two refusals it was', () => {
+  it('says no solver when nothing serves the corridor', () => {
+    expect(lnSendRefusal([], 'regtest')).toBe('No Lightning solver available')
+    expect(lnSendRefusal([market()], 'regtest')).toBe('No Lightning solver available')
+  })
+
+  it('quotes the card’s own bounds when a solver serves it at another size', () => {
+    expect(lnSendRefusal([lnMarket()], 'regtest')).toBe('Amount outside solver bounds (1,000-1,000,000 sats)')
+  })
+})
+
+describe('quoteIsForThisInvoice: the wrong-invoice guard', () => {
+  it('funds a quote negotiated for the invoice on screen', () => {
+    expect(quoteIsForThisInvoice({ meta: { invoice: INVOICE } }, INVOICE)).toBe(true)
+  })
+
+  it('refuses a quote negotiated for another invoice, or for none at all', () => {
+    expect(quoteIsForThisInvoice({ meta: { invoice: 'lnbc1other' } }, INVOICE)).toBe(false)
+    expect(quoteIsForThisInvoice({ meta: undefined }, INVOICE)).toBe(false)
+  })
+})
+
+describe('the asset rail', () => {
+  const assets = [{ assetId: 'usdt', amount: BigInt(500) }]
+
+  const assetRouter = (over: Partial<Parameters<typeof createSendRouter>[0]> = {}) =>
+    createSendRouter({
+      wallet: {} as never,
+      arkServerUrl: 'http://ark.example',
+      network: 'regtest',
+      assets,
+      ...over,
+    })
+
+  beforeEach(() => sendAssets.mockClear())
+
+  it('takes an ark address and nothing else', async () => {
+    expect((await assetRouter().options({ raw: ARK_ADDRESS })).map((o) => o.railId)).toEqual([ASSET_RAIL])
+    expect(await assetRouter().options({ raw: RECIPIENT })).toEqual([])
+    expect(await assetRouter().options({ raw: INVOICE })).toEqual([])
+  })
+
+  it('drops itself when there is nothing to send', async () => {
+    expect(await assetRouter({ assets: [] }).options({ raw: ARK_ADDRESS })).toEqual([])
+  })
+
+  it('sends what the old call sent: the whole list, to the ark address', async () => {
+    const quote = await (await assetRouter().options({ raw: ARK_ADDRESS }))[0].quote()
+    expect(quote).toMatchObject({ railId: ASSET_RAIL, amount: 0 })
+
+    const result = await (await quote.send()).settled()
+    expect(sendAssets).toHaveBeenCalledWith(expect.anything(), ARK_ADDRESS, assets)
+    expect(result).toMatchObject({ railId: ASSET_RAIL, txid: 'asset-txid' })
   })
 })

--- a/src/test/lib/sendRouter.test.ts
+++ b/src/test/lib/sendRouter.test.ts
@@ -340,6 +340,18 @@ describe('quoteIsForThisInvoice: the wrong-invoice guard', () => {
     expect(quoteIsForThisInvoice({ meta: { invoice: 'lnbc1other' } }, INVOICE)).toBe(false)
     expect(quoteIsForThisInvoice({ meta: undefined }, INVOICE)).toBe(false)
   })
+
+  // A BIP21 `lightning=` param keeps whatever it was handed; the rail routed
+  // the stripped invoice, so an unstripped screen value is the same payment.
+  it('funds the same invoice however the screen is carrying it', () => {
+    expect(quoteIsForThisInvoice({ meta: { invoice: INVOICE } }, `lightning:${INVOICE}`)).toBe(true)
+    expect(quoteIsForThisInvoice({ meta: { invoice: INVOICE } }, `bitcoin:bcrt1q?lightning=${INVOICE}`)).toBe(true)
+  })
+
+  it('refuses when the screen carries no invoice at all', () => {
+    expect(quoteIsForThisInvoice({ meta: { invoice: INVOICE } }, '')).toBe(false)
+    expect(quoteIsForThisInvoice({ meta: undefined }, '')).toBe(false)
+  })
 })
 
 describe('the asset rail', () => {

--- a/src/test/screens/wallet/send-lightning-route.test.tsx
+++ b/src/test/screens/wallet/send-lightning-route.test.tsx
@@ -1,0 +1,305 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { hex } from '@scure/base'
+import { getEmulatorPubkeyForNetwork } from '../../../lib/constants'
+import SendDetails from '../../../screens/Wallet/Send/Details'
+import SendForm from '../../../screens/Wallet/Send/Form'
+import { AspContext } from '../../../providers/asp'
+import { ConfigContext } from '../../../providers/config'
+import { FeesContext } from '../../../providers/fees'
+import { FiatContext } from '../../../providers/fiat'
+import { FlowContext, type SendInfo } from '../../../providers/flow'
+import { LimitsContext } from '../../../providers/limits'
+import { LnSwapsContext } from '../../../providers/lnSwaps'
+import { NavigationContext } from '../../../providers/navigation'
+import { OptionsContext } from '../../../providers/options'
+import { WalletContext } from '../../../providers/wallet'
+import fixtures from '../../fixtures.json'
+import {
+  mockAspContextValue,
+  mockConfigContextValue,
+  mockFiatContextValue,
+  mockFlowContextValue,
+  mockLimitsContextValue,
+  mockNavigationContextValue,
+  mockOptionsContextValue,
+  mockSvcWallet,
+  mockWalletContextValue,
+} from '../mocks'
+
+const consoleError = vi.fn()
+vi.mock('../../../lib/logs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../lib/logs')>()),
+  consoleError: (...args: unknown[]) => consoleError(...args),
+}))
+
+let optionsFor: (req: { raw: string; amount?: number }) => unknown[] = () => []
+vi.mock('../../../lib/sendRouter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/sendRouter')>()
+  return { ...actual, createSendRouter: () => ({ options: async (req: any) => optionsFor(req) }) }
+})
+
+/** Only what `lnSendRefusal` reads on the form's error path. */
+let markets: unknown[] = []
+vi.mock('../../../lib/swapMarkets', () => ({ discoverMarkets: async () => markets }))
+
+const INVOICE = fixtures.lib.bolt11.invoice
+const ARK_ADDRESS = fixtures.lib.address.ark[0].address
+const INVOICE_SATS = fixtures.lib.bolt11.amountSats
+
+/** A negotiated Lightning route, as the send form hands it to the sign screen. */
+const lnQuote = (over: { invoice?: string; total?: number } = {}, sent = vi.fn()) => ({
+  railId: 'lightning',
+  amount: INVOICE_SATS,
+  fee: (over.total ?? INVOICE_SATS) - INVOICE_SATS,
+  total: over.total ?? INVOICE_SATS,
+  meta: { rfqId: 'rfq-1', invoice: over.invoice ?? INVOICE, validUntil: 2_000_000_000 },
+  send: async () => {
+    sent()
+    return { settled: async () => ({ railId: 'lightning', txid: 'funding-txid', swapId: 'rfq-1' }) }
+  },
+})
+
+const setSendInfo = vi.fn()
+
+const renderSign = (sendInfo: SendInfo) =>
+  render(
+    <NavigationContext.Provider value={mockNavigationContextValue}>
+      <ConfigContext.Provider value={mockConfigContextValue}>
+        <FiatContext.Provider value={mockFiatContextValue}>
+          <AspContext.Provider value={mockAspContextValue}>
+            <FeesContext.Provider value={{ calcOnchainOutputFee: () => 500 } as never}>
+              <FlowContext.Provider value={{ ...mockFlowContextValue, sendInfo, setSendInfo }}>
+                <WalletContext.Provider
+                  value={{ ...mockWalletContextValue, balance: 1_000_000, svcWallet: mockSvcWallet as never }}
+                >
+                  <LnSwapsContext.Provider value={{ trackLnSend: async () => {}, reserveOnchainSend: async () => {} }}>
+                    <LimitsContext.Provider value={mockLimitsContextValue}>
+                      <SendDetails />
+                    </LimitsContext.Provider>
+                  </LnSwapsContext.Provider>
+                </WalletContext.Provider>
+              </FlowContext.Provider>
+            </FeesContext.Provider>
+          </AspContext.Provider>
+        </FiatContext.Provider>
+      </ConfigContext.Provider>
+    </NavigationContext.Provider>,
+  )
+
+const sign = async () => fireEvent.click(await screen.findByText('Tap to Sign'))
+
+const sendFailure = () => consoleError.mock.calls.find((c) => c[1] === 'error sending payment')?.[0]
+
+describe('signing a Lightning send', () => {
+  beforeEach(() => {
+    consoleError.mockClear()
+    setSendInfo.mockClear()
+    optionsFor = () => []
+  })
+
+  it('funds the route negotiated for the invoice on screen', async () => {
+    const sent = vi.fn()
+    const quote = lnQuote({}, sent)
+    renderSign({ invoice: INVOICE, satoshis: INVOICE_SATS, pendingLnSend: quote as never })
+    await sign()
+
+    await waitFor(() => expect(sent).toHaveBeenCalledTimes(1))
+    // The rail's own txid reaches the flow, which is what the receipt renders.
+    await waitFor(() => expect(setSendInfo).toHaveBeenCalledWith(expect.objectContaining({ txid: 'funding-txid' })))
+  })
+
+  it('carries the quote’s total, not the amount typed', async () => {
+    renderSign({ invoice: INVOICE, satoshis: INVOICE_SATS, pendingLnSend: lnQuote({ total: 2_200 }) as never })
+    await sign()
+
+    await waitFor(() => expect(setSendInfo).toHaveBeenCalledWith(expect.objectContaining({ total: 2_200 })))
+  })
+
+  it('never funds a route negotiated for a DIFFERENT invoice', async () => {
+    const sent = vi.fn()
+    const stale = lnQuote({ invoice: 'lnbc1someoneelse' }, sent)
+    renderSign({ invoice: INVOICE, satoshis: INVOICE_SATS, pendingLnSend: stale as never })
+    await sign()
+
+    await waitFor(() => expect(sendFailure()).toBeDefined())
+    expect(String(sendFailure())).toMatch(/different invoice/i)
+    expect(sent).not.toHaveBeenCalled()
+  })
+
+  it('reports a rail that refused to fund rather than reporting a sent payment', async () => {
+    const quote = {
+      ...lnQuote(),
+      send: async () => ({
+        settled: async () => {
+          throw new Error('Quote expired — go back and try again')
+        },
+      }),
+    }
+    renderSign({ invoice: INVOICE, satoshis: INVOICE_SATS, pendingLnSend: quote as never })
+    await sign()
+
+    await waitFor(() => expect(sendFailure()).toBeDefined())
+    expect(String(sendFailure())).toMatch(/Quote expired/)
+  })
+})
+
+describe('signing an asset send', () => {
+  const assets = [{ assetId: 'usdt', amount: BigInt(500) }]
+
+  const assetOption = (sent: (address: string) => void) => (req: { raw: string }) => [
+    {
+      railId: 'asset',
+      quote: async () => ({
+        railId: 'asset',
+        amount: 0,
+        fee: 0,
+        total: 0,
+        send: async () => {
+          sent(req.raw)
+          return { settled: async () => ({ railId: 'asset', txid: 'asset-txid' }) }
+        },
+      }),
+    },
+  ]
+
+  beforeEach(() => {
+    consoleError.mockClear()
+    setSendInfo.mockClear()
+    optionsFor = () => []
+  })
+
+  it('routes to the ark address the screen is showing', async () => {
+    const sent = vi.fn()
+    optionsFor = assetOption(sent)
+    renderSign({ arkAddress: ARK_ADDRESS, assets })
+    await sign()
+
+    await waitFor(() => expect(sent).toHaveBeenCalledWith(ARK_ADDRESS))
+    await waitFor(() => expect(setSendInfo).toHaveBeenCalledWith(expect.objectContaining({ txid: 'asset-txid' })))
+  })
+
+  it('reports a failure rather than a send when no rail took it', async () => {
+    optionsFor = () => []
+    renderSign({ arkAddress: ARK_ADDRESS, assets })
+    await sign()
+
+    await waitFor(() => expect(sendFailure()).toBeDefined())
+    expect(String(sendFailure())).toMatch(/No route/i)
+  })
+})
+
+/** Addresses that resolve: the form white-screens on a receiving-address
+ *  failure, which `mockSvcWallet`'s empty strings trigger. */
+const formWallet = { ...mockSvcWallet, getAddress: async () => 'ark1self', getBoardingAddress: async () => 'bcrt1self' }
+
+const renderForm = (sendInfo: SendInfo) =>
+  render(
+    <NavigationContext.Provider value={mockNavigationContextValue}>
+      <AspContext.Provider value={mockAspContextValue}>
+        <ConfigContext.Provider value={mockConfigContextValue as never}>
+          <FiatContext.Provider value={mockFiatContextValue as never}>
+            <OptionsContext.Provider value={mockOptionsContextValue as never}>
+              <FlowContext.Provider value={{ ...mockFlowContextValue, sendInfo, setSendInfo } as never}>
+                <WalletContext.Provider
+                  value={{
+                    ...mockWalletContextValue,
+                    balance: 1_000_000,
+                    availableBalance: 1_000_000,
+                    svcWallet: formWallet as never,
+                  }}
+                >
+                  <LnSwapsContext.Provider value={{ trackLnSend: async () => {}, reserveOnchainSend: async () => {} }}>
+                    <LimitsContext.Provider value={mockLimitsContextValue}>
+                      <FeesContext.Provider value={{ calcOnchainOutputFee: () => 500 } as never}>
+                        <SendForm />
+                      </FeesContext.Provider>
+                    </LimitsContext.Provider>
+                  </LnSwapsContext.Provider>
+                </WalletContext.Provider>
+              </FlowContext.Provider>
+            </OptionsContext.Provider>
+          </FiatContext.Provider>
+        </ConfigContext.Provider>
+      </AspContext.Provider>
+    </NavigationContext.Provider>,
+  )
+
+const cont = async () => fireEvent.click(await screen.findByText('Continue'))
+
+describe('negotiating a Lightning send', () => {
+  const lnMarket = {
+    pair: 'BTC/lightning:BTC',
+    base_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+    quote_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+    base_corridor: 'arkade',
+    quote_corridor: 'lightning',
+    fee_bps: 0,
+    min_base_amount: '1000',
+    max_base_amount: '1000000',
+    min_quote_amount: '1000',
+    max_quote_amount: '1000000',
+    discovery_pubkey: 'bb'.repeat(32),
+    emulator_pubkey: hex.encode(getEmulatorPubkeyForNetwork('regtest')!),
+    transports: { nostr: { relays: ['wss://relay.example'] } },
+  }
+
+  beforeEach(() => {
+    consoleError.mockClear()
+    setSendInfo.mockClear()
+    optionsFor = () => []
+    markets = []
+  })
+
+  it('carries the route the Lightning rail quoted to the sign screen', async () => {
+    const quote = lnQuote()
+    optionsFor = () => [{ railId: 'lightning', quote: async () => quote }]
+    renderForm({ invoice: INVOICE, satoshis: INVOICE_SATS })
+    await cont()
+
+    await waitFor(() => expect(setSendInfo).toHaveBeenCalled())
+    const update = setSendInfo.mock.calls.at(-1)![0] as (prev: SendInfo) => SendInfo
+    expect(update({} as SendInfo).pendingLnSend).toBe(quote)
+  })
+
+  it('asks the router with the invoice and its amount, not the raw text', async () => {
+    const consulted = vi.fn(() => [{ railId: 'lightning', quote: async () => lnQuote() }])
+    optionsFor = consulted
+    renderForm({ invoice: INVOICE, satoshis: INVOICE_SATS })
+    await cont()
+
+    await waitFor(() => expect(consulted).toHaveBeenCalledWith({ raw: INVOICE, amount: INVOICE_SATS }))
+  })
+
+  it('says no solver when the rail dropped itself and no card serves the corridor', async () => {
+    optionsFor = () => []
+    renderForm({ invoice: INVOICE, satoshis: INVOICE_SATS })
+    await cont()
+
+    expect(await screen.findByText('No Lightning solver available')).toBeInTheDocument()
+  })
+
+  it('names the card’s bounds when the rail dropped itself over the size', async () => {
+    optionsFor = () => []
+    markets = [lnMarket]
+    renderForm({ invoice: INVOICE, satoshis: INVOICE_SATS })
+    await cont()
+
+    expect(await screen.findByText(/Amount outside solver bounds/)).toBeInTheDocument()
+  })
+
+  it('surfaces a refused negotiation verbatim rather than as a routing failure', async () => {
+    optionsFor = () => [
+      {
+        railId: 'lightning',
+        quote: async () => {
+          throw new Error('invoice has expired')
+        },
+      },
+    ]
+    renderForm({ invoice: INVOICE, satoshis: INVOICE_SATS })
+    await cont()
+
+    expect(await screen.findByText('invoice has expired')).toBeInTheDocument()
+  })
+})

--- a/src/test/screens/wallet/send-lightning-route.test.tsx
+++ b/src/test/screens/wallet/send-lightning-route.test.tsx
@@ -34,14 +34,31 @@ vi.mock('../../../lib/logs', async (importOriginal) => ({
 }))
 
 let optionsFor: (req: { raw: string; amount?: number }) => unknown[] = () => []
+let routerDeps: any
 vi.mock('../../../lib/sendRouter', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../lib/sendRouter')>()
-  return { ...actual, createSendRouter: () => ({ options: async (req: any) => optionsFor(req) }) }
+  return {
+    ...actual,
+    createSendRouter: (deps: any) => {
+      routerDeps = deps
+      return { options: async (req: any) => optionsFor(req) }
+    },
+  }
 })
 
-/** Only what `lnSendRefusal` reads on the form's error path. */
+/** The cards the form discovers once and hands to both the router and the
+ *  refusal. `discovered` counts the calls; `marketsThrow` is the cold-cache
+ *  registry failure. */
 let markets: unknown[] = []
-vi.mock('../../../lib/swapMarkets', () => ({ discoverMarkets: async () => markets }))
+let marketsThrow = false
+const discovered = vi.fn()
+vi.mock('../../../lib/swapMarkets', () => ({
+  discoverMarkets: async () => {
+    discovered()
+    if (marketsThrow) throw new Error('registry unreachable')
+    return markets
+  },
+}))
 
 const INVOICE = fixtures.lib.bolt11.invoice
 const ARK_ADDRESS = fixtures.lib.address.ark[0].address
@@ -247,8 +264,11 @@ describe('negotiating a Lightning send', () => {
   beforeEach(() => {
     consoleError.mockClear()
     setSendInfo.mockClear()
+    discovered.mockClear()
     optionsFor = () => []
     markets = []
+    marketsThrow = false
+    routerDeps = undefined
   })
 
   it('carries the route the Lightning rail quoted to the sign screen', async () => {
@@ -286,6 +306,45 @@ describe('negotiating a Lightning send', () => {
     await cont()
 
     expect(await screen.findByText(/Amount outside solver bounds/)).toBeInTheDocument()
+  })
+
+  it('discovers the cards once, and explains the refusal off that same list', async () => {
+    optionsFor = () => []
+    markets = [lnMarket]
+    renderForm({ invoice: INVOICE, satoshis: INVOICE_SATS })
+    await cont()
+
+    // The refusal message proves the list reached `lnSendRefusal`; the count
+    // proves the rail was not sent to fetch its own.
+    expect(await screen.findByText(/Amount outside solver bounds/)).toBeInTheDocument()
+    expect(discovered).toHaveBeenCalledTimes(1)
+  })
+
+  // A cold cache with an unreachable registry used to replace the intended
+  // message with the registry's own, because the error path asked again.
+  it('still names the refusal when the registry is unreachable mid-flight', async () => {
+    optionsFor = () => {
+      marketsThrow = true
+      return []
+    }
+    renderForm({ invoice: INVOICE, satoshis: INVOICE_SATS })
+    await cont()
+
+    expect(await screen.findByText('No Lightning solver available')).toBeInTheDocument()
+    expect(discovered).toHaveBeenCalledTimes(1)
+  })
+
+  it('hands the rail the cards it already fetched, not a fresh lookup', async () => {
+    markets = [lnMarket]
+    optionsFor = () => [{ railId: 'lightning', quote: async () => lnQuote() }]
+    renderForm({ invoice: INVOICE, satoshis: INVOICE_SATS })
+    await cont()
+
+    await waitFor(() => expect(routerDeps).toBeDefined())
+    discovered.mockClear()
+    // Same list, and asking for it costs no second round trip.
+    await expect(routerDeps.discover()).resolves.toBe(markets)
+    expect(discovered).not.toHaveBeenCalled()
   })
 
   it('surfaces a refused negotiation verbatim rather than as a routing failure', async () => {


### PR DESCRIPTION
Stacked on #944 — base is `feat/payment-router-send`, so the diff here is only the second step. Merge #944 first.

#944 put the on-chain send behind `PaymentRouter`. The other two send paths still chose their provider by hand, so the sign screen had three shapes and the UI had nowhere uniform to read options from. This routes Lightning and asset sends through the same engine.

## What routes now

| path | before | after |
| --- | --- | --- |
| on-chain BTC | `solver-onchain` / `onchain` (#944) | unchanged |
| lightning | `lnSendRendezvous` + `requestLnSend` inline in the send form | `lightning` rail, picked by `options()` |
| assets | `sendAssets()` called directly on the sign screen | `asset` rail, picked by `options()` |
| ark sats send | `sendOffChain()` | still direct — see below |

## Both rails are wallet-local, deliberately

`@arkade-os/swap` ships `solverLightningRail` for exactly this corridor. It was the obvious candidate and it was rejected, for the same class of reason `walletExitRail` exists rather than the SDK's `onchainRail`:

- it calls `persist` **before** funding and its `RouteResult` carries no txid, so the record would be written without `fundingArkTxid`. `viewOf` in `lnSendRecords.ts` returns `undefined` for such a record, so it never reaches `lnSendViews` — and `ungroupedLnSendTx` is the *only* source of the row for a send Arkade's own history does not report, keyed on `send.fundingTxid` as its `redeemTxid`. The Lightning row would vanish.

  (To be exact about the neighbouring claim: `rfqSwapActivityInputs` *prefers* `record.fundingArkTxid` but is not broken without it — `activityInputOf` falls back to an indexer lookup by lockup script when it is absent. The row-disappearing problem is `viewOf`, not the grouping.)
- it selects markets via `selectMarkets`, not `lnSendRendezvous`. On a live money path a different provider pick is a regression whether or not it is a better one.

So the `lightning` rail wraps the calls that are live today — `requestLnSend` → `sendOffChain` → `trackLnSend`, in that order — and the `asset` rail wraps `sendAssets`. A `PaymentRequest` carries sats only, so the asset list rides the rail's deps.

If/when the SDK rail grows a funding txid and this wallet's market selection, swapping it in is a `use()` call.

## What is preserved, and how it is held

- **Which solver answers.** The rail calls the same `lnSendRendezvous` with the same per-network emulator pin, including the rule that a card disagreeing with the pin is skipped.
- **Both refusal messages.** `options()` reports absence without a cause, so `lnSendRefusal` tells "No Lightning solver available" from "Amount outside solver bounds (min-max sats)" on the form's error path. Discovery is cached, so the second lookup is free.
- **Negotiation errors.** `quote()` is called unguarded on the Lightning path — an `InvoiceRejected` ("invoice has expired", "invoice is not for regtest") or an `AddressMismatch` reaches the user verbatim rather than collapsing into "no route". The on-chain path's skip-to-the-next-rail loop is correct there because it has a fallback rail; Lightning has none.
- **Record order and contents.** Funded first, recorded second, with the funding txid — the opposite of the on-chain leg, and the reason is unchanged: a `trackLnSend` rejection is reported, not raised, because funding IS acceptance.
- **The expiry gate.** Moved into the rail's `send()`, same message, still refusing before anything is funded.
- **Failure behaviour at `send()`.** arkana asked on #944 whether `payOnchain` should fall through to the next rail when `send()` throws. The question does not arise on either new path: Lightning and assets each have exactly one rail, so there is nothing to fall through to, and `payLightning` / `payAssets` let the rejection reach `handleError` — which is what the code they replace did. Specifically, `sendOffChain` throwing after a broadcast leaves a funded, unrecorded covenant; that hazard is unchanged, because the record was written after a successful send before this PR too.

## What changed on purpose

- The negotiation stays **on the form** (the fee has to be on screen before the user signs), but now goes through `options()` + `quote()`. `SendInfo.pendingLnSend` carries the `RouteQuote` instead of an `LnSendRequest`, and the sign screen calls its `send()`.
- `quoteIsForThisInvoice` is the Lightning analogue of #944's wrong-address guard: a quote negotiated for another invoice is refused at the sign screen, not just cleared when the form's invoice changes.
- `createSendRouter` registers a rail only when the deps it needs are present. That is what keeps the Lightning path from deriving an L1 payout pubkey it will never use — a service-worker round trip and a new failure mode on a path that had neither.

## Not in scope

- **The plain ark sats send** (`sendOffChain` to an ark address) is still direct. The SDK's `arkRail` would cover it, but it and the new `asset` rail both match an ark address, so registering both needs a ranking decision — and this PR was asked for Lightning and assets.
- **`smartSetError` in `Form.tsx` takes `string` but is used as a promise `.catch` handler** (`getReceivingAddresses(...).catch(smartSetError)`), so a rejection there puts an `Error` object into React state and `ErrorMessage` renders it as a child — the send form white-screens. Pre-existing, found while building the test harness (which is why the form test supplies a wallet whose addresses resolve). Not touched here.

## Test plan

Baseline re-recorded at `f33d0554` (this PR's base, after its two new commits): **93 files, 802 passed, 1 skipped, 0 failed**.
After: **94 files, 836 passed, 1 skipped, 0 failed** — +1 file, +34 tests, nothing lost.

(The earlier figures in this PR's history were against base `529c0e18`: 93/801 → 94/835. The base has since advanced; both baselines were measured by checking the base out and running the suite, not inferred.)

One pre-existing flake seen twice on full runs and never twice in the same place — `useBounceMorph`'s `controls.start() should only be called after a component has mounted`, and a 5s timeout in `swap.test.tsx`. Both pass in isolation and on a re-run; neither is in a file this PR touches.

`pnpm lint`, `pnpm format:check`, `pnpm build` and `npx tsc --noEmit` all match baseline (tsc has one pre-existing error in `src/test/lib/lnSendRecords.test.ts`).

Every rail-selection decision was mutation-tested — the mutation applied, the suite run, the failing test and its message recorded, the mutation reverted. 15 mutations, 15 caught:

| mutation | caught by |
| --- | --- |
| ln `available`: drop the bounds check | drops itself for a size the one solver will not take |
| ln `available`: never drop the rail | no card / wrong size / discovery throws |
| ln `match`: claim every target | takes an invoice and leaves the other targets alone |
| ln `send`: record before funding | records the swap only once the covenant is funded |
| ln `send`: record without the funding txid | funds the lockup and records the swap WITH its funding txid |
| ln `send`: no expiry gate | refuses to fund an expired quote, and funds nothing |
| ln `send`: a refused record fails the send | does not fail a funded send because the store refused the record |
| `quoteIsForThisInvoice`: always true | the wrong-invoice guard + never funds a route negotiated for a DIFFERENT invoice |
| `lnSendRefusal`: branches swapped | both refusal tests + both form screen tests |
| asset `available`: send with nothing to send | drops itself when there is nothing to send |
| asset `match`: claim every target | takes an ark address and nothing else |
| Details: carry the quote amount, not its total | carries the quote's total, not the amount typed |
| Details: skip the wrong-invoice guard | never funds a route negotiated for a DIFFERENT invoice |
| Details: asset send routed to a held address | routes to the ark address the screen is showing |
| Form: quote discarded instead of carried | carries the route the Lightning rail quoted to the sign screen |
| guard: drop the defined check | refuses when the screen carries no invoice at all |
| never register the solver on-chain rail | ranks the solver ahead of the collaborative exit |
| register the exit rail unconditionally | takes an invoice and leaves the other targets alone |
| Form: ask the registry a second time on the refusal path | discovers the cards once… / still names the refusal when the registry is unreachable |
| Form: rail fetches its own cards instead of the snapshot | hands the rail the cards it already fetched |

### Not covered by CI — and the gap is wider than one file

`src/test/e2e/lnsend.test.ts` is the only end-to-end proof that a Lightning send actually pays an invoice, and it **has never run in CI at all**. `.github/workflows/playwright.yml` enumerates e2e files by name with no glob, and the lists have drifted from the directory in both directions:

- on disk but in **no** job: `lnsend.test.ts`, `solvers.test.ts`, `swaps.test.ts`
- named in the workflow but matching **nothing**: `restore.test.ts`, `swap.test.ts` (singular)

Verified with `npx playwright test --list`: `swap.test.ts` resolves to **0 tests in 0 files** — the args are regexes, and `swap.test.ts` does not match `swaps.test.ts` (there are two characters, `s.`, where the pattern allows one). `swaps.test.ts` resolves to 4 tests, none of which run today. And a non-matching argument alongside a matching one is dropped silently with exit 0 — which is why the jobs stay green and the drift is invisible. This is not a problem this PR introduces, and I am deliberately **not** editing the workflow here — someone else is already fixing it, and two edits to the same file would collide.

For this PR specifically: `lnsend.test.ts` also needs a live `lightning-swap-service` and a generated `.regtest-lightning.card.json`, so wiring it up alone would not make it run. It needs a human with the regtest stack. A green CI here does not cover the corridor this PR touches.


## Follow-up commit

`962fb6ce` fixes something the first commit introduced, found by asking whether `sendInfo.invoice` can differ from what the rail routed to. It can: `decodeBip21` assigns `result.invoice` from the `lightning=` param on nothing more than a lowercase `ln` prefix, so `lightning:lnbc…` reaches flow state unstripped, while the rail's `meta.invoice` is `invoiceTarget(raw)` — stripped. The guard would then refuse a legitimate send.

Before routing that input just failed early (`decodeInvoice` rejects the prefix). Through the rail the negotiation would now succeed and only the sign screen would refuse — a burned quote and an invoice handed to a solver for a payment that cannot then be made. Both sides now normalise through `invoiceTarget`, and an absent target is refused rather than matching a quote with no `meta`.


## Base PR status

#944 currently sits at `CHANGES_REQUESTED` from `arkana-ai-bot`. That blocks this one regardless of its own state — nothing here should merge before #944 is resolved and merged.


## Related issue

#949 — the funded-but-unrecorded window on the send path. Pre-existing, unchanged by this PR (`master` already funds at `Details.tsx:161` and records at `:169`), filed separately so a fix does not ride on a refactoring. Raised by `arkana-ai-bot` in its review here.


## Review round 2 — arkana `CHANGES_REQUESTED` addressed (`211cdef0`)

**Fixed — `lnSendRefusal` could surface a registry error instead of the refusal.** Correct finding. `negotiate()` discovered twice: once through `router.options()` → `available()`, then again to build the message. On a cold cache with an unreachable registry the *second* call throws and `handleError` shows the registry's error where the whole point of that branch is to be informative.

Fixed by discovering **once** and handing the snapshot to the router through its existing `discover` seam. That also restores exactly what `master` did before routing — a single lookup — so a throwing registry surfaces the same error it always did, and no behaviour changes for the case that works.

**Also fixed by the same change — `rendezvousFor` called twice / TOCTOU.** Both calls now read the same in-memory snapshot, so the window where a market disappears between `available()` and `quote()` is closed rather than merely noted. Two new tests pin it: one asserts a single discovery and that the message is built from that list; one asserts the rail is handed the snapshot and asking for it costs no round trip. Both were mutation-checked — restoring either half of the old behaviour fails them.

**Documented, not changed — the asset rail emits only `settled`.** Agreed it is not a regression and worth naming so a future rail author does not read the lightning rail's `sent` as required. One line added at the emit: no counterparty has to act, so the txid *is* settlement and a `sent` would name nothing.

**Pre-existing items** (`smartSetError`, #949, the e2e drift) are unchanged and already documented above; none are touched here.

Gate on `7ef95e3b`: **94 files, 836 passed, 1 skipped, 0 failed**; lint, format, build clean; CI and all four E2E jobs green (dispatched by hand, as before).


## Rebased onto `f33d0554`

The base picked up `5103bb45` and `f33d0554` while this was in review, so this branch was rebased and force-pushed (`211cdef0` → `7ef95e3b`). No conflicts: the base's `Details.tsx` change is inside `payOnchain`, which this PR does not touch — its edits are in `payLightning`, `payAssets` and the `handleContinue` branches.

Worth noting that `f33d0554` cites #949 when explaining why `payOnchain` does not fall through on a `send()` rejection. That is the same reasoning this PR gives for not catching `send()` on the Lightning and asset paths, so the two are now consistent and both grounded in the same issue.

Gate re-run after the rebase against a freshly measured base: **93/802 → 94/836**; lint, format, build clean; CI and all four E2E jobs green on `7ef95e3b`.
