### PR TITLE
test(send): e2e for the on-chain send's unhappy paths

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,7 @@ jobs:
             test_files: >-
               src/test/e2e/asset.test.ts
               src/test/e2e/send.test.ts
+              src/test/e2e/send-onchain-fallback.test.ts
           - group: core
             test_files: >-
               src/test/e2e/backup.test.ts

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,14 +29,15 @@ jobs:
               src/test/e2e/form.test.ts
               src/test/e2e/init.test.ts
               src/test/e2e/keyboard.test.ts
+              src/test/e2e/lnsend.test.ts
               src/test/e2e/lnurl.test.ts
               src/test/e2e/lock.test.ts
               src/test/e2e/nostr.test.ts
               src/test/e2e/pwa.test.ts
               src/test/e2e/receive.test.ts
-              src/test/e2e/restore.test.ts
               src/test/e2e/serverdown.test.ts
-              src/test/e2e/swap.test.ts
+              src/test/e2e/solvers.test.ts
+              src/test/e2e/swaps.test.ts
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,8 +53,11 @@ jobs:
       run: pnpm exec playwright install chrome chromium --with-deps
     - name: Start regtest environment
       run: node regtest/regtest.mjs start --env .env.regtest
+    # The cert is what makes wss://localhost:10548 exist, and a solver card's
+    # relays must be wss:// — `regtest:start` generates it, these open-coded
+    # steps did not, so relay-tls has been serving nothing.
     - name: Start nostr relay
-      run: docker compose -f docker-compose.nak.yml up -d --build
+      run: node scripts/gen-relay-tls-cert.mjs && docker compose -f docker-compose.nak.yml up -d --build
     - name: Verify environment
       run: pnpm regtest:setup
     - name: Run Playwright tests

--- a/src/test/e2e/send-onchain-fallback.test.ts
+++ b/src/test/e2e/send-onchain-fallback.test.ts
@@ -3,12 +3,10 @@ import { SimplePool } from 'nostr-tools'
 import { prettyNumber } from '../../lib/format'
 import { test, expect, createWallet, fundWallet, prePay } from './utils'
 
-/**
- * The regtest solver serves asset markets only, so a send there never reaches
- * the solver rail — "falls back to the exit" would pass with the rail deleted.
- * Every test pins a card that really advertises `arkade:BTC -> onchain:BTC` and
- * asserts the refusal it provoked: two failing alike would be one test twice.
- */
+/** The regtest solver serves asset markets only, so a send there never reaches the
+ *  solver rail — "falls back to the exit" would pass with the rail deleted. Every
+ *  test pins a card that really advertises `arkade:BTC -> onchain:BTC` and asserts
+ *  the refusal it provoked: two failing alike would be one test twice. */
 const RFQ_KIND = 24859
 const RELAY = 'ws://localhost:10547'
 /** On-curve and nobody's: an off-curve key fails at decompression, before any relay is dialled. */
@@ -29,6 +27,8 @@ const cardWithRelays = (relays: string[]) => ({
       quote_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
       quote_corridor: 'onchain',
       fee_bps: 10,
+      // Base side off, as beta-solver.card.json has it: `rendezvousOf` bounds
+      // against the QUOTE side, so a "0" here is disabled, not broken.
       min_base_amount: '0',
       max_base_amount: '0',
       min_quote_amount: '500',

--- a/src/test/e2e/send-onchain-fallback.test.ts
+++ b/src/test/e2e/send-onchain-fallback.test.ts
@@ -1,0 +1,159 @@
+import { execSync } from 'child_process'
+import { SimplePool } from 'nostr-tools'
+import { prettyNumber } from '../../lib/format'
+import { test, expect, createWallet, fundWallet, prePay } from './utils'
+
+/**
+ * The regtest solver serves asset markets only, so a send there never reaches
+ * the solver rail — "falls back to the exit" would pass with the rail deleted.
+ * Every test pins a card that really advertises `arkade:BTC -> onchain:BTC` and
+ * asserts the refusal it provoked: two failing alike would be one test twice.
+ */
+const RFQ_KIND = 24859
+const RELAY = 'ws://localhost:10547'
+/** On-curve and nobody's: an off-curve key fails at decompression, before any relay is dialled. */
+const SOLVER = '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+const RECIPIENT = 'bcrt1qv9zftxjdep9x3sq85aguvd3d4n7dj4ytnf4ez7'
+const FUNDED = 5000
+const SENT = 2000
+
+const cardWithRelays = (relays: string[]) => ({
+  version: 0,
+  name: 'e2e-onchain-solver',
+  discovery_pubkey: SOLVER,
+  transports: { nostr: { relays } },
+  markets: [
+    {
+      pair: 'BTC/onchain:BTC',
+      base_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+      quote_asset: { id: 'btc', name: 'Bitcoin', ticker: 'BTC', decimals: 8 },
+      quote_corridor: 'onchain',
+      fee_bps: 10,
+      min_base_amount: '0',
+      max_base_amount: '0',
+      min_quote_amount: '500',
+      max_quote_amount: '1000000',
+    },
+  ],
+})
+
+type Page = Parameters<typeof createWallet>[0]
+
+const pinSolver = (page: Page, relays: string[]) =>
+  page.addInitScript((card) => {
+    localStorage.setItem('solverCards', JSON.stringify([{ network: 'regtest', label: 'e2e-onchain', card }]))
+  }, cardWithRelays(relays))
+
+const routeLog = (page: Page): Promise<string[]> =>
+  page.evaluate(() =>
+    (JSON.parse(localStorage.getItem('logs') ?? '[]') as { msg: string }[])
+      .map((l) => l.msg)
+      .filter((m) => m.startsWith('onchain send:')),
+  )
+
+const expectRoute = async (page: Page, refusal: RegExp) => {
+  const log = await routeLog(page)
+  expect(log.find((m) => m.includes('solver-onchain could not quote'))).toMatch(refusal)
+  expect(log.some((m) => m.includes('paying via onchain'))).toBe(true)
+}
+
+const fundedWalletOnDetails = async (page: Page, isMobile: boolean) => {
+  await createWallet(page)
+  await fundWallet(page, FUNDED)
+  await prePay(page, RECIPIENT, isMobile, SENT)
+  await expect(page.getByTestId('Total')).toContainText(`${prettyNumber(SENT)} sats`)
+}
+
+/** Subscribe as the solver would, answer nothing. Without a listener `nak serve`
+ *  refuses the ephemeral RFQ ("mute: no one was listening for this"), turning
+ *  the timeout case back into the socket one; the count proves delivery. */
+const silentSolver = async (run: (delivered: () => number) => Promise<void>) => {
+  const pool = new SimplePool()
+  let seen = 0
+  const sub = pool.subscribe(
+    [RELAY],
+    { kinds: [RFQ_KIND], '#p': [SOLVER] },
+    {
+      onevent: () => {
+        seen++
+      },
+    },
+  )
+  try {
+    await run(() => seen)
+  } finally {
+    sub.close()
+    pool.close([RELAY])
+  }
+}
+
+test.describe('on-chain send when the solver rail fails', () => {
+  // An unset intent fee parses as NaN, which makes Tap to Sign a silent no-op.
+  test.beforeAll(() => execSync('docker exec -t arkd arkd fees intent --onchain-output "200.0"'))
+  test.afterAll(() => execSync('docker exec -t arkd arkd fees clear'))
+
+  test('pays through the collaborative exit when the solver cannot be reached', async ({ page, isMobile }) => {
+    await pinSolver(page, ['wss://localhost:9'])
+    await fundedWalletOnDetails(page, isMobile)
+
+    await page.getByText('Tap to Sign').click()
+    await page.getByTestId('loading-logo').waitFor({ timeout: 10_000 })
+    await page.waitForSelector('text=Payment sent', { timeout: 60_000 })
+
+    await expectRoute(page, /no relay accepted/)
+    await page.getByRole('button', { name: /Sounds good|Tap to go home/ }).click()
+    await page.waitForSelector(`text=- ${prettyNumber(SENT)} sats`, { timeout: 15_000 })
+  })
+
+  test('pays through the collaborative exit when the solver never answers', async ({ page, isMobile }) => {
+    test.setTimeout(180_000)
+    await silentSolver(async (delivered) => {
+      await pinSolver(page, ['wss://localhost:10548'])
+      await fundedWalletOnDetails(page, isMobile)
+
+      await page.getByText('Tap to Sign').click()
+      await page.getByTestId('loading-logo').waitFor({ timeout: 10_000 })
+      // Bounded, not indefinite: the RFQ gives up on its own and the exit pays.
+      await page.waitForSelector('text=Payment sent', { timeout: 120_000 })
+
+      expect(delivered()).toBeGreaterThan(0)
+      await expectRoute(page, /not responding/)
+      await page.getByRole('button', { name: /Sounds good|Tap to go home/ }).click()
+      await page.waitForSelector(`text=- ${prettyNumber(SENT)} sats`, { timeout: 15_000 })
+    })
+  })
+
+  test('names the failure and offers the retry when the exit fails too', async ({ page, isMobile }) => {
+    test.setTimeout(180_000)
+    await pinSolver(page, ['wss://localhost:9'])
+    await fundedWalletOnDetails(page, isMobile)
+
+    // Offline fails both rails; the spinner must not be where the user is left.
+    await page.context().setOffline(true)
+    await page.getByText('Tap to Sign').click()
+
+    await expect(page.getByText(/Settlement failed/)).toBeVisible({ timeout: 120_000 })
+    await expect(page.getByText('Tap to Sign')).toBeVisible()
+    await expect(page.getByTestId('loading-logo')).toHaveCount(0)
+    await page.context().setOffline(false)
+  })
+
+  test('completes the send the user walked away from, without hijacking the screen', async ({ page, isMobile }) => {
+    test.setTimeout(180_000)
+    await silentSolver(async () => {
+      await pinSolver(page, ['wss://localhost:10548'])
+      await fundedWalletOnDetails(page, isMobile)
+
+      await page.getByText('Tap to Sign').click()
+      await page.getByTestId('loading-logo').waitFor({ timeout: 10_000 })
+      // #946's window, held open by the RFQ timeout. Funding is committed either
+      // way, so the balance must land; a success screen pushed over whatever the
+      // user opened next would be a hijack.
+      await page.goBack()
+      await expect(page.getByTestId('input-amount-max')).toBeVisible({ timeout: 10_000 })
+
+      await expect(page.getByText(`${prettyNumber(FUNDED - SENT)} sats available`)).toBeVisible({ timeout: 120_000 })
+      await expect(page.getByTestId('input-amount-max')).toBeVisible()
+    })
+  })
+})


### PR DESCRIPTION
Stacked on #944 — base is `feat/payment-router-send`. Merge #944 first and this retargets to `master`.

#944 routes on-chain sends through the `PaymentRouter` with the solver rail first and the collaborative exit behind it, and adds no e2e at all: every test it ships is unit or component. The fallback is the whole point of the design and nothing exercised it in a browser.

Four commits, each revertible on its own.

## 1. `src/test/e2e/send-onchain-fallback.test.ts`

| path | what breaks | what the user gets |
| --- | --- | --- |
| solver unreachable | relay socket refused | exit pays; `no relay accepted the RFQ message` |
| solver silent | request delivered, never answered | exit pays after the 30s RFQ timeout |
| both rails fail | offline | a named error and the retry button, not a spinner |
| user leaves mid-quote (#946) | `goBack()` during the quote | the send completes, the screen is not hijacked |

Each asserts the *specific* refusal it provoked, not merely that one happened.

### Three things that made this harder than it looks

**The regtest solver has no on-chain corridor.** `frenchman` serves `BTC/RGT` asset markets only; `solverRendezvous` wants `base_asset.id == quote_asset.id == "btc"` with `quote_corridor: onchain`, so nothing matches and the rail's `available()` is false on the stock stack. *A "falls back to the exit" assertion there passes with the rail deleted.* Every test pins its own card advertising `arkade:BTC -> onchain:BTC`.

**An off-curve pubkey is not a solver failure.** An earlier draft used `'bb'.repeat(32)` as `discovery_pubkey`. Both the "unreachable" and "timeout" tests passed, and both were failing at `Cannot find square root` — secp256k1 decompression, before any relay was dialled. Two tests, one path, two misleading names. The key is now the generator's x-coordinate: on-curve, and nobody's.

**`nak serve` refuses an ephemeral event nobody is listening for.** `["OK", …, false, "mute: no one was listening for this"]`, which collapses the timeout case back into the socket case. The timeout test subscribes as the solver would, answers nothing, and asserts the request was delivered before the wallet gave up.

### Mutation results

| mutation | killed |
| --- | --- |
| `continue` → `throw err` on a rail that cannot quote (no fallback) | all four |
| rail priority reversed, exit first | unreachable, silent — the silent one on `delivered() == 0` |
| `payOnchain(…).catch(handleError)` → unguarded | both-rails-fail (spinner never resolves) |
| `navigate(Pages.SendSuccess)` added to `handleSent` | walked-away (success screen over the Send form) |
| `reloadWallet()` removed from `handleSent` | **nothing** — the balance also lands via the worker's own refresh, so that assertion pins "the payment completed", not "this screen refreshed" |

## 2. `ci(e2e)`: generate the relay TLS cert before starting the proxy

`relay-tls` bind-mounts `./.relay-tls` and the workflow never created it, so `wss://localhost:10548` has never worked in CI. `regtest:start` runs `gen-relay-tls-cert.mjs`; the workflow open-codes the same steps and dropped it.

Caught by the timeout test, which needs a real relay. Before the fix it failed on `delivered() == 0` in **6.8s** on all six attempts in both projects; after it, it passes in **36.6s** — the actual 30s RFQ timeout. A card's relays must be `wss://` (`RELAY = /^wss:\/\/[^\s]+$/` in solver-discovery's validator), so there is no plaintext way round it. `lnsend.test.ts` depends on the same proxy and was in no CI group, which is presumably why nobody hit this.

## 3. `ci(e2e)`: reconcile the enumerated list with the files on disk

The matrix enumerates files rather than globbing, and had drifted both ways:

- `restore.test.ts` — listed, deleted in #908 with the Boltz removal
- `swap.test.ts` — listed, renamed to `swaps.test.ts` in #784; #815 wrote the pre-rename name when it split the suite into groups
- `swaps.test.ts`, `solvers.test.ts`, `lnsend.test.ts` — on disk, in no group

Nothing complained because Playwright treats the arguments as regexes and only errors when the **total** is zero. `playwright test src/test/e2e/restore.test.ts` alone exits 1 with `No tests found`; beside twelve filters that do match, it is ignored and the job stays green. Verified with `--list` on both shapes.

What it buys, measured rather than assumed:

- **`solvers.test.ts`** — 2 tests, both pass. Real coverage, and the repo's only solver e2e, which matters while #944 adds a solver rail.
- **`swaps.test.ts`** — 2 tests, both `test.skip` since `73e4084e`. The typo fix is safe and buys nothing: the suite is dead at the source too.
- **`lnsend.test.ts`** — skips itself without `.regtest-lightning.card.json`, which CI does not produce, so it will report as skipped. Listed anyway: a named skip is visible, an unlisted file is not.

## Verification

CI does not trigger on this base (`pull_request: branches: [master, next]`), so both workflows were dispatched manually against the branch.

- Unit CI: green.
- Playwright: all four jobs green, and **all four new test names appear in the run log** as `✓` in both projects — job-passed is not evidence, test-ran is.

## One pre-existing bug, found but not fixed

An unset arkd intent fee makes Tap to Sign a silent no-op. `calcOnchainOutputFee()` is `parseInt(aspInfo.fees?.intentFee?.onchainOutput ?? '0', 10)`, and `??` does not catch the empty string arkd returns when no fee is configured, so `parseInt('')` is `NaN`. `details.satoshis` becomes `NaN`, `handleContinue`'s `!details.satoshis` guard returns, and nothing happens — no spinner, no error, no log. Pre-existing and outside this PR; it is why `send.test.ts` sets a fee first, and why these tests do too.

## 4. `test(send)`: say why the card's base side is zeroed

Comment only, from arkana's review. `max_base_amount: '0'` reads as a mistake; `sideLimits(market, side)` reads only the queried side and `rendezvousOf` queries the **quote** side, so the base side is disabled rather than broken � the same shape as `beta-solver.card.json`. Verified against solver-discovery 0.2.3 `pricing.js:172` rather than taken on trust.

---

*CodeRabbit has not reviewed this PR: auto-review is disabled for non-default base branches, and an explicit `@coderabbitai review` came back `Review rate limited`. Its check reports SUCCESS regardless � that green is not a review.*
