### PR TITLE
fix: pin LF in the repository so format:check means something on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,13 @@
+# LF in the repository, whatever the checkout does.
+#
+# Without this, a Windows clone with `core.autocrlf=true` gets CRLF on disk;
+# `.prettierrc` sets no `endOfLine`, so Prettier applies its `lf` default and
+# flags the line endings of every file it looks at — 493 of them, none about
+# formatting. The pre-commit hook runs `format:check`, so that blocks every
+# commit, and the usual escape is `--no-verify`, which skips the whole hook.
+#
+# `text=auto` leaves git to detect text from binary, so images and archives are
+# untouched. The rule below is more specific and still wins, so the entrypoint
+# keeps LF whatever `text=auto` decides about it.
+* text=auto eol=lf
 docker-entrypoint.sh text eol=lf


### PR DESCRIPTION
`pnpm format:check` reports **493 files** on a Windows checkout and none of it is about formatting. Git writes CRLF when `core.autocrlf=true`, `.prettierrc` sets no `endOfLine`, so Prettier applies its `lf` default and flags the line endings of everything it looks at.

That would be an annoyance on its own. What makes it worse here is that **the pre-commit hook runs `format:check`**, so it blocks every commit from a Windows machine — and the natural escape is `--no-verify`, which skips the entire hook rather than just the formatting.

## The fix

```
* text=auto eol=lf
docker-entrypoint.sh text eol=lf
```

`text=auto` leaves git to detect text from binary, so images and archives are untouched. The existing entrypoint rule is more specific and still wins.

Deliberately **not** `endOfLine` in `.prettierrc`: that would silence the check for whoever set it while CI kept enforcing LF for everyone else.

## The churn is zero, measured rather than assumed

```
$ git add --renormalize .
$ git diff --cached --stat
 .gitattributes | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```

Nothing else moved. The stored blobs were already LF — CI runs on Linux and has been enforcing it all along. No commit rewrites content; the only thing that changes is what future checkouts write to disk.

## Verified

On a Windows checkout, after refreshing the working tree under the new attributes:

```
$ pnpm format:check
Checking formatting...
All matched files use Prettier code style!      exit 0
```

Same command that reported 493 files.

The same pin was merged in `arkade-os/intent-solver` (#52) for the same reason, with the same zero-churn result.
