### PR TITLE
Read swap records in one tick so Safari sees them

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
-    "@arkade-os/solver-discovery": "0.2.3",
     "@arkade-os/sdk": "0.4.69",
+    "@arkade-os/solver-discovery": "0.2.3",
     "@arkade-os/swap": "0.0.12",
     "@base-ui/react": "^1.4.1",
     "@branta-ops/branta": "3.1.3",
@@ -116,6 +116,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eventsource": "^4.1.0",
+    "fake-indexeddb": "6.2.5",
     "globals": "^16.3.0",
     "husky": "^8.0.3",
     "jsdom": "^26.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       eventsource:
         specifier: ^4.1.0
         version: 4.1.0
+      fake-indexeddb:
+        specifier: 6.2.5
+        version: 6.2.5
       globals:
         specifier: ^16.3.0
         version: 16.5.0
@@ -2388,6 +2391,10 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -6634,6 +6641,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/src/lib/swapRepository.ts
+++ b/src/lib/swapRepository.ts
@@ -16,11 +16,80 @@
  * WHOLE database, asset swaps and markets cache included. Rolling back this
  * release means rolling back the data, not just the bundle.
  */
-import { IndexedDbAssetSwapRepository, type AssetSwap } from '@arkade-os/swap'
+import { promisifyRequest } from '@arkade-os/sdk'
+import {
+  IndexedDbAssetSwapRepository,
+  type AssetSwap,
+  type MarketsCacheEntry,
+  type RfqSwapRecord,
+} from '@arkade-os/swap'
+
+// The package's store names and markets-cache key, restated because it does not
+// export them. `swapRepository.test.ts` round-trips the package's own writes
+// through the reads below, so a rename upstream fails there rather than in
+// Safari.
+const STORE_SWAPS = 'swaps'
+const STORE_RFQ_SWAPS = 'rfqSwaps'
+const STORE_SCANNED = 'scannedTxids'
+const STORE_MARKETS = 'markets'
+const marketsCacheKey = (network: string, registry: string) => `arkade-intents-markets-${network}-${registry}`
+
+/**
+ * `IndexedDbAssetSwapRepository` with reads that work in Safari.
+ *
+ * WebKit deactivates an IndexedDB transaction the moment the script that
+ * created it returns — BEFORE the microtask queue drains. Chrome and Firefox
+ * keep it active to the end of the microtask checkpoint, which is what the spec
+ * asks for. The package reads through an async `readStore()` and issues the
+ * request only after `await`ing it, so in Safari every read throws
+ * `TransactionInactiveError`: `getAssetSwaps` swallows that into an empty list,
+ * the activity resolver's `prepare()` fails and swaps render as bare sent and
+ * received rows, and `addAssetSwap` (read, then write) rejects AFTER the
+ * funding tx was sent. `RfqSwapManager.saveRecord` reads first too, so
+ * Lightning sends lose their records the same way. Writes are unaffected —
+ * `write()` issues its requests synchronously.
+ *
+ * Each read here creates the transaction and issues its request in one tick.
+ * Drop this subclass once the package does the same.
+ */
+export class SafariSafeAssetSwapRepository extends IndexedDbAssetSwapRepository {
+  private async readInOneTick<T>(store: string, request: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+    // `ensureDb` is the package's private connection getter: the only way to
+    // the IDBDatabase without opening a second connection to the same stores.
+    const ensureDb: unknown = this['ensureDb']
+    if (typeof ensureDb !== 'function') throw new Error('IndexedDbAssetSwapRepository.ensureDb is gone')
+    const db = (await ensureDb.call(this)) as IDBDatabase
+    return promisifyRequest(request(db.transaction([store], 'readonly').objectStore(store)))
+  }
+
+  override getAllSwaps(): Promise<AssetSwap[]> {
+    return this.readInOneTick(STORE_SWAPS, (store) => store.getAll() as IDBRequest<AssetSwap[]>)
+  }
+
+  override getRfqSwap(rfqId: string): Promise<RfqSwapRecord | undefined> {
+    return this.readInOneTick(STORE_RFQ_SWAPS, (store) => store.get(rfqId) as IDBRequest<RfqSwapRecord | undefined>)
+  }
+
+  override getAllRfqSwaps(): Promise<RfqSwapRecord[]> {
+    return this.readInOneTick(STORE_RFQ_SWAPS, (store) => store.getAll() as IDBRequest<RfqSwapRecord[]>)
+  }
+
+  override async getScannedTxids(): Promise<Set<string>> {
+    const keys = await this.readInOneTick(STORE_SCANNED, (store) => store.getAllKeys() as IDBRequest<string[]>)
+    return new Set(keys)
+  }
+
+  override getCachedMarkets(network: string, registry: string): Promise<MarketsCacheEntry | undefined> {
+    return this.readInOneTick(
+      STORE_MARKETS,
+      (store) => store.get(marketsCacheKey(network, registry)) as IDBRequest<MarketsCacheEntry | undefined>,
+    )
+  }
+}
 
 /** Shared per tab: the repository opens its database lazily on first use, and
  * a second instance would open a second connection to the same stores. */
-export const assetSwapRepository = new IndexedDbAssetSwapRepository()
+export const assetSwapRepository: IndexedDbAssetSwapRepository = new SafariSafeAssetSwapRepository()
 
 /** Display facts frozen at quote time — only what the activity UI reads.
  * Every field is optional: a restore can only backfill what is recoverable

--- a/src/test/lib/swapRepository.test.ts
+++ b/src/test/lib/swapRepository.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+// node rather than jsdom: the SDK's connection manager resolves the global
+// through `self`, which jsdom defines without an `indexedDB` on it.
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { IndexedDbAssetSwapRepository, type AssetSwap, type RfqSwapRecord } from '@arkade-os/swap'
+import { SafariSafeAssetSwapRepository } from '../../lib/swapRepository'
+
+/**
+ * WebKit's transaction lifetime: a transaction goes inactive the moment the
+ * script that created it yields, BEFORE the microtask queue drains — so a
+ * request issued after any `await`, even of an already-settled promise, throws
+ * `TransactionInactiveError`. Chrome and Firefox deactivate at the end of the
+ * microtask checkpoint instead. fake-indexeddb follows the latter, so the
+ * former is emulated here: every store handed out by a transaction refuses
+ * requests once a microtask has passed since the transaction was created.
+ */
+const REQUESTS = new Set(['add', 'clear', 'count', 'delete', 'get', 'getAll', 'getAllKeys', 'getKey', 'put'])
+const originalTransaction = IDBDatabase.prototype.transaction
+
+const emulateWebKitDeactivation = () => {
+  IDBDatabase.prototype.transaction = function (this: IDBDatabase, ...args: Parameters<IDBDatabase['transaction']>) {
+    const tx = originalTransaction.apply(this, args)
+    let active = true
+    queueMicrotask(() => {
+      active = false
+    })
+    const objectStore = tx.objectStore.bind(tx)
+    tx.objectStore = (name: string) =>
+      new Proxy(objectStore(name), {
+        get(target, prop) {
+          const value = Reflect.get(target, prop, target)
+          if (typeof value !== 'function') return value
+          return (...params: unknown[]) => {
+            if (!active && typeof prop === 'string' && REQUESTS.has(prop)) {
+              throw new DOMException(
+                'Failed to execute request: the transaction is not active.',
+                'TransactionInactiveError',
+              )
+            }
+            return value.apply(target, params)
+          }
+        },
+      })
+    return tx
+  }
+}
+
+const restoreTransaction = () => {
+  IDBDatabase.prototype.transaction = originalTransaction
+}
+
+let dbCounter = 0
+const freshDbName = () => `swap-repository-test-${Date.now()}-${dbCounter++}`
+
+const swap: AssetSwap = {
+  id: 'funding-txid',
+  fromAsset: 'btc',
+  toAsset: 'asset-beta',
+  fromAmount: '10000',
+  toAmount: '500',
+  swapAddress: 'tark1q...',
+  swapPkScript: `5120${'ab'.repeat(32)}`,
+  offerHex: '0100',
+  fundingTxid: 'funding-txid',
+  status: 'pending',
+  createdAt: 1,
+}
+
+const rfqSwap = { rfqId: 'rfq-1', state: 'pending' } as unknown as RfqSwapRecord
+
+describe('SafariSafeAssetSwapRepository', () => {
+  describe.each([
+    ['WebKit transaction lifetime', emulateWebKitDeactivation],
+    ['spec transaction lifetime', () => {}],
+  ])('under the %s', (_label, arrange) => {
+    let repository: SafariSafeAssetSwapRepository
+
+    beforeEach(() => {
+      arrange()
+      repository = new SafariSafeAssetSwapRepository(freshDbName())
+    })
+
+    afterEach(async () => {
+      restoreTransaction()
+      await repository[Symbol.asyncDispose]()
+    })
+
+    it('reads back the swaps the package wrote', async () => {
+      await repository.saveSwap(swap)
+      expect(await repository.getAllSwaps()).toEqual([swap])
+    })
+
+    it('reads back RFQ swap records by id and in bulk', async () => {
+      await repository.saveRfqSwap(rfqSwap)
+      expect(await repository.getRfqSwap('rfq-1')).toEqual(rfqSwap)
+      expect(await repository.getRfqSwap('rfq-2')).toBeUndefined()
+      expect(await repository.getAllRfqSwaps()).toEqual([rfqSwap])
+    })
+
+    it('reads back the scanned txids', async () => {
+      await repository.markTxidsScanned(['a', 'b'])
+      expect(await repository.getScannedTxids()).toEqual(new Set(['a', 'b']))
+    })
+
+    it('reads back the markets cache under the key the package writes', async () => {
+      const entry = { markets: [], fetchedAt: 42 }
+      await repository.saveCachedMarkets('bitcoin', 'https://registry', entry)
+      expect(await repository.getCachedMarkets('bitcoin', 'https://registry')).toEqual(entry)
+      expect(await repository.getCachedMarkets('bitcoin', 'https://other')).toBeUndefined()
+    })
+
+    it('reads an empty store after clear', async () => {
+      await repository.saveSwap(swap)
+      await repository.clear()
+      expect(await repository.getAllSwaps()).toEqual([])
+    })
+  })
+
+  // The reason the subclass exists. When this starts failing the package has
+  // fixed its reads and the subclass can go.
+  it("documents that the package's own reads break under the WebKit lifetime", async () => {
+    emulateWebKitDeactivation()
+    const repository = new IndexedDbAssetSwapRepository(freshDbName())
+    try {
+      await repository.saveSwap(swap)
+      await expect(repository.getAllSwaps()).rejects.toMatchObject({ name: 'TransactionInactiveError' })
+    } finally {
+      restoreTransaction()
+      await repository[Symbol.asyncDispose]()
+    }
+  })
+})


### PR DESCRIPTION
## Problem

In Safari, every IndexedDB read in `@arkade-os/swap` rejects with `TransactionInactiveError`.

WebKit deactivates a transaction when the creating script yields, before microtasks drain. Chrome and Firefox keep it active to the end of the microtask checkpoint. The package's `readStore()` is async and callers `await` it before issuing the request, so every read throws in Safari. Writes are unaffected.

Consequences in Safari: `getAssetSwaps` swallows the error into an empty list, `addAssetSwap` (read, then write) rejects after the funding tx has already been sent, and `RfqSwapManager.saveRecord` loses Lightning records the same way.

## Fix

`SafariSafeAssetSwapRepository` subclasses the package repository and overrides the five reads to create the transaction and issue the request in one tick. `swapRepository.test.ts` emulates the WebKit lifetime on `fake-indexeddb`, round-trips the package's own writes through the wallet's reads, and pins the package bug so the subclass can be deleted once upstream reads the same way.

## Relationship to the SDK

Upstream fix: [arkade-os/ts-sdk#852](https://github.com/arkade-os/ts-sdk/pull/852). Once the wallet bumps to a swap package carrying it, the pinning test here starts failing and the subclass goes.

The browser-independent bug that hid swaps on Chrome too is split out into its own PR from branch `claude/swap-rows-from-records`.

## Validation

Unit suite green. Lint and prettier clean. Verified under an emulated WebKit lifetime; not run in a real Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EugrC3vqmX7aGYEGpyYr6i