### PR TITLE
Show asset swaps whose funding tx nets to zero in history

### DIFF
--- a/src/lib/activityHistory.ts
+++ b/src/lib/activityHistory.ts
@@ -291,6 +291,23 @@ export const activitiesToTxs = (activities: Activity[], options: ActivityHistory
   for (const send of lnSends) {
     if (!grouped.has(send.rfqId)) rows.push(ungroupedLnSendTx(send, metadata))
   }
+  // The asset swaps history cannot see, for the same reason as the Lightning
+  // sends: `createOffer` registers the offer covenant as a contract of this
+  // wallet, so `buildTransactionHistory` counts the funding output as change
+  // and the funding tx nets to zero — no row. A cancel returns the same sats
+  // to the same wallet and nets to zero too. Only a fill produces a row, keyed
+  // on the fill txid, which the resolver groups by `spentTxid`. So a pending,
+  // cancelled or recoverable swap has no group at all, and the record is the
+  // only thing that can put it on screen — same key the group would carry, so
+  // the row is replaced rather than doubled once a fill arrives.
+  const groupedSwaps = new Set(activities.flatMap((activity) => swapIdOf(activity) ?? []))
+  for (const swap of swaps) {
+    if (groupedSwaps.has(swap.id)) continue
+    rows.push({
+      ...graftMetadata(buildAssetSwapActivityTx(swap, [], { network, assetDisplay }), metadata[swap.fundingTxid]),
+      historyKey: `swap:${swap.id}`,
+    })
+  }
   // Exits last, for the same reason: history reports none of them either.
   for (const exit of exits) rows.push(exitTx(exit))
   return sortLocalTxs(rows)

--- a/src/test/lib/activityHistory.test.ts
+++ b/src/test/lib/activityHistory.test.ts
@@ -132,6 +132,57 @@ describe('activitiesToTxs', () => {
 
     expect(activitiesToTxs([older, newer], empty).map((tx) => tx.redeemTxid)).toEqual(['new', 'old'])
   })
+
+  // The offer covenant is a contract of this wallet, so history nets the
+  // funding tx (and a cancel) to zero and emits no row for it: the record is
+  // the only source of the row until a fill shows up.
+  it('builds a swap row from the record alone when history has no group for it', () => {
+    const [tx] = activitiesToTxs([], { ...empty, swaps: [swap()] })
+
+    expect(tx).toMatchObject({
+      type: 'swap',
+      historyKey: 'swap:swap-1',
+      redeemTxid: 'funding-txid',
+      createdAt: 2,
+      settled: false,
+      assetSwap: { status: 'pending', fundingTxid: 'funding-txid', fromAmount: BigInt(10_000), toAmount: BigInt(992) },
+    })
+  })
+
+  it('keeps a cancelled swap on screen although its cancel tx nets to nothing in history', () => {
+    const cancelled = swap({ status: 'cancelled', spentTxid: 'cancel-txid' })
+
+    const [tx] = activitiesToTxs([], { ...empty, swaps: [cancelled] })
+
+    expect(tx).toMatchObject({
+      redeemTxid: 'cancel-txid',
+      settled: true,
+      assetSwap: { status: 'cancelled', fillTxid: 'cancel-txid' },
+    })
+  })
+
+  it('does not double a swap whose group is in history', () => {
+    const fulfilled = swap({ status: 'fulfilled', spentTxid: 'fill-txid' })
+    const group = activity(
+      'swap:swap-1',
+      [arkTx('fill-txid', { type: 'SENT' as ArkTransaction['type'] })],
+      swapIntent('swap-1'),
+    )
+
+    const txs = activitiesToTxs([group], { ...empty, swaps: [fulfilled] })
+
+    expect(txs).toHaveLength(1)
+    expect(txs[0]).toMatchObject({ historyKey: 'swap:swap-1', assetSwap: { status: 'completed' } })
+  })
+
+  it('grafts the funding tx metadata onto a record-only swap row', () => {
+    const [tx] = activitiesToTxs([], {
+      swaps: [swap()],
+      metadata: { 'funding-txid': { networkFee: 12, savedAt: 0 } },
+    })
+
+    expect(tx).toMatchObject({ networkFee: 12 })
+  })
 })
 
 describe('getActivities', () => {


### PR DESCRIPTION
## Problem

Asset swaps do not show up in the activity list, on every browser.

`createOffer` registers the offer covenant as a contract of this wallet, and the SDK's `getTransactionHistory` folds every contract's vtxos into the wallet's set. `buildTransactionHistory` then counts the covenant output as change, so the funding tx nets to zero and emits no row. A cancel returns the same sats to the same wallet and nets to zero too. Only a fill produces a row, keyed on the fill txid.

Run against the SDK's own `buildTransactionHistory` with synthetic vtxos:

| Scenario | Rows for the swap |
|---|---|
| BTC to asset, pending | none |
| BTC to asset, cancelled | none |
| BTC to asset, fulfilled | one `SENT` keyed on the fill txid |

So a pending, cancelled or recoverable swap has no activity group at all. The list never shows it, and nothing can be cancelled from the UI. Same mechanism the wallet already documents for the Lightning lockup contract (`ungroupedLnSendTx`).

## Fix

`activitiesToTxs` builds the row from the swap record when no group carries its id, under the key the group would carry so a fill replaces it rather than doubling it. Four new cases in `activityHistory.test.ts`.

## Relationship to the SDK

This is a wallet-side compensation. The root cause is in the SDK and is addressed in [arkade-os/ts-sdk#853](https://github.com/arkade-os/ts-sdk/pull/853). Once that ships and the wallet bumps, the funding tx comes back as a `SENT` row and this record-only path stops firing for open offers. It stays useful for the window between a record write and the next history refresh, the same way `ungroupedLnSendTx` does.

Split out of #954, which now carries only the Safari IndexedDB fix.

## Not fixed here

- The restore scan (`restoreAssetSwaps`) needs the funding tx as a `sent` row to find the offer packet, so a restored wallet still cannot rebuild swap records until the SDK fix lands.
- The swap e2e tests have been `test.skip` since #908; they would have caught this.

## Validation

Unit suite green: 89 files, 773 tests. Lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EugrC3vqmX7aGYEGpyYr6i

---
_Generated by [Claude Code](https://claude.ai/code/session_01EugrC3vqmX7aGYEGpyYr6i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset swaps now appear in activity history even when they are missing from the underlying history feed.
  * Pending, cancelled, and recoverable swaps are represented consistently until a completed swap activity becomes available.
  * Swap records are deduplicated when matching history entries arrive, preventing duplicate entries.
  * Available transaction metadata, such as network and asset display details, is retained for record-only swap entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->