### PR TITLE
fix(history): show an offer commitment Arkade's history nets to zero

### DIFF
--- a/src/lib/activityHistory.ts
+++ b/src/lib/activityHistory.ts
@@ -199,6 +199,24 @@ const ungroupedLnSendTx = (send: LnSendView, metadata: Record<string, Transactio
   )
 
 /**
+ * One row for an offer whose funding tx Arkade's history does not report.
+ *
+ * Same shape of problem as `ungroupedLnSendTx`, same answer: `createOffer`
+ * registers the covenant as a contract of this wallet, so the deposit reads as
+ * change and `buildTransactionHistory` drops the tx on its `txAmount !== 0`
+ * guard. A resting offer may never be spent, so nothing would ever appear.
+ * Keyed as the resolver would key it, so the real row replaces this one.
+ */
+const ungroupedOfferTx = (
+  swap: WalletAssetSwap,
+  { network, assetDisplay }: Pick<ActivityHistoryOptions, 'network' | 'assetDisplay'>,
+): Tx => ({
+  ...buildAssetSwapActivityTx(swap, [], { network, assetDisplay }),
+  amount: swap.fromAsset === 'btc' ? Number(swap.fromAmount) : 0,
+  historyKey: `swap:${swap.id}`,
+})
+
+/**
  * One row for a unilateral exit, which Arkade's history does not report.
  *
  * The sent side of `buildTransactionHistory` is gated on `isSpent`, and the SDK
@@ -290,6 +308,11 @@ export const activitiesToTxs = (activities: Activity[], options: ActivityHistory
   const grouped = new Set(activities.flatMap((activity) => rfqIdOf(activity) ?? []))
   for (const send of lnSends) {
     if (!grouped.has(send.rfqId)) rows.push(ungroupedLnSendTx(send, metadata))
+  }
+  // The offers history cannot see either — see `ungroupedOfferTx`.
+  const groupedSwaps = new Set(activities.flatMap((activity) => swapIdOf(activity) ?? []))
+  for (const swap of swaps) {
+    if (!groupedSwaps.has(swap.id)) rows.push(ungroupedOfferTx(swap, { network, assetDisplay }))
   }
   // Exits last, for the same reason: history reports none of them either.
   for (const exit of exits) rows.push(exitTx(exit))

--- a/src/test/lib/offerFunding.test.tsx
+++ b/src/test/lib/offerFunding.test.tsx
@@ -1,0 +1,153 @@
+import { renderHook } from '@testing-library/react'
+import { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+import { gatedContracts, type Contract } from '@arkade-os/sdk'
+import { activitiesToTxs } from '../../lib/activityHistory'
+import { ASSET_SWAP_ACTIVITY_KIND } from '../../lib/activity/assetSwapResolver'
+import { usePortfolioFiat } from '../../hooks/usePortfolioFiat'
+import { AspContext } from '../../providers/asp'
+import { FiatContext } from '../../providers/fiat'
+import { WalletContext } from '../../providers/wallet'
+import { mockAspContextValue, mockFiatContextValue, mockWalletContextValue } from '../screens/mocks'
+import type { WalletAssetSwap } from '../../lib/swapRepository'
+
+// The operator's mutinynet report: 110_000 sats held, 50_000 committed to a
+// btc-to-asset offer wanting 206 units. Balance never moved and no row appeared.
+const HELD = 110_000
+const COMMITTED = 50_000
+const FUNDING_TXID = 'dab4578b615fc6a9e3070e7041b2a6314d6515c21f6ac1d72fe8830cba2cfe8f'
+const COVENANT_SCRIPT = '51207b310c1298990c4b1dd2fba639039e75dc421e37b503428c069ae5797bad1db6'
+const WANT_ASSET = 'f1'.repeat(34)
+
+const contract = (over: Partial<Contract>): Contract => ({
+  type: 'default',
+  script: '5120' + 'bb'.repeat(32),
+  address: 'tark1own',
+  params: {},
+  state: 'active' as Contract['state'],
+  createdAt: 4_000,
+  ...over,
+})
+
+// as `registerOfferContract` writes it in @arkade-os/swap
+const offerContract = contract({
+  type: 'arkade',
+  script: COVENANT_SCRIPT,
+  address:
+    'tark1qqcpq7yq3e8hhsx6ml3fud93m7827qggaurtzu3zwsr4a0qs0gf857e3psff3xgvfvwa97ax8ypeuawugg0r0dgrg2xqdxh909a668dkrqlehc',
+  label: 'Arkade swap offer',
+  metadata: { genericallySpendable: false, kind: 'asset-swap-offer' },
+})
+
+const ownContract = contract({})
+
+const offerSwap = (over: Partial<WalletAssetSwap> = {}): WalletAssetSwap =>
+  ({
+    id: FUNDING_TXID,
+    fromAsset: 'btc',
+    toAsset: WANT_ASSET,
+    fromAmount: String(COMMITTED),
+    toAmount: '206',
+    swapAddress: 'tark1qqcpq7yq...',
+    swapPkScript: COVENANT_SCRIPT,
+    offerHex: '0100',
+    fundingTxid: FUNDING_TXID,
+    status: 'pending',
+    createdAt: 4_000,
+    ...over,
+  }) as WalletAssetSwap
+
+const empty = { swaps: [], metadata: {} }
+
+function portfolioWrapper({ children }: { children: ReactNode }) {
+  return (
+    <AspContext.Provider value={mockAspContextValue as never}>
+      <FiatContext.Provider value={{ ...mockFiatContextValue, toFiat: (sats?: number) => sats ?? 0 } as never}>
+        <WalletContext.Provider
+          value={
+            {
+              ...mockWalletContextValue,
+              balance: HELD,
+              availableBalance: HELD - COMMITTED,
+              assetBalances: [],
+              availableAssetBalances: [],
+            } as never
+          }
+        >
+          {children}
+        </WalletContext.Provider>
+      </FiatContext.Provider>
+    </AspContext.Provider>
+  )
+}
+
+describe('funding an Arkade swap offer', () => {
+  it('gates the covenant, so the spendable balance cannot select it', () => {
+    const gated = gatedContracts([offerContract, ownContract])
+
+    expect(gated.has(COVENANT_SCRIPT)).toBe(true)
+    expect(gated.has(ownContract.script)).toBe(false)
+    // fail-closed, so the funds stay gated even if the marker is ever dropped
+    expect(gatedContracts([{ ...offerContract, metadata: {} }]).has(COVENANT_SCRIPT)).toBe(true)
+  })
+
+  it('offers only what is left to spend, while still reporting the coins as owned', () => {
+    const { result } = renderHook(() => usePortfolioFiat(), { wrapper: portfolioWrapper })
+    const btc = result.current.rows.find((row) => row.assetId === 'btc')
+
+    expect(btc?.spendableBalance).toBe(HELD - COMMITTED)
+    expect(btc?.balance).toBe(HELD)
+  })
+
+  it('shows the commitment from its record, before any tx of it reaches history', () => {
+    // The covenant is a contract this wallet registered, so Arkade counts the
+    // 50_000 as change: the funding tx nets to zero and history reports nothing.
+    const [row, ...rest] = activitiesToTxs([], { ...empty, swaps: [offerSwap()] })
+
+    expect(rest).toEqual([])
+    expect(row).toMatchObject({
+      type: 'swap',
+      amount: COMMITTED,
+      createdAt: 4,
+      redeemTxid: FUNDING_TXID,
+      historyKey: `swap:${FUNDING_TXID}`,
+      assetSwap: { fromAssetId: 'btc', fromAmount: BigInt(COMMITTED), fundingTxid: FUNDING_TXID },
+    })
+  })
+
+  it('reads as pending and recoverable, never as money burned', () => {
+    const [row] = activitiesToTxs([], { ...empty, swaps: [offerSwap()] })
+
+    expect(row.assetSwap?.status).toBe('pending')
+    expect(row.settled).toBe(false)
+  })
+
+  it('names a cancelled offer cancelled rather than dropping it from history', () => {
+    const [row] = activitiesToTxs([], { ...empty, swaps: [offerSwap({ status: 'cancelled' })] })
+
+    expect(row.assetSwap?.status).toBe('cancelled')
+  })
+
+  it('yields to the group once one exists, under the same key', () => {
+    const funding = {
+      amount: COMMITTED,
+      createdAt: 4_000,
+      settled: true,
+      type: 'SENT',
+      key: { arkTxid: FUNDING_TXID, boardingTxid: '', commitmentTxid: '' },
+    }
+    const group = {
+      id: `swap:${FUNDING_TXID}`,
+      intent: { kind: ASSET_SWAP_ACTIVITY_KIND, label: 'Swap', metadata: { swapId: FUNDING_TXID } },
+      txs: [funding],
+      amount: -COMMITTED,
+      createdAt: 4_000,
+      settled: true,
+    }
+
+    const rows = activitiesToTxs([group as never], { ...empty, swaps: [offerSwap()] })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].historyKey).toBe(`swap:${FUNDING_TXID}`)
+  })
+})


### PR DESCRIPTION
## The report

An operator funded an Arkade swap offer covenant with 50,000 sats on mutinynet and the wallet showed nothing: no deduction, no activity row. *"Looks like fund disappeared… doesn't even show as a deduction of balance happened, just poof."*

The money is safe. `GET /v1/indexer/vtxos?scripts=51207b310c…` returns the 50,000 unspent at `dab4578b…:0`, and the contract is listed as `Arkade swap offer` / active. The defect is entirely one of visibility.

## Cause

`createOffer` registers the covenant as a contract of this wallet — it has to, since cancelling and unilaterally exiting the offer are ours to do. That makes the covenant output look like our own change.

`buildTransactionHistory` sums **every** tracked output of the funding tx as change:

```js
const changes = fromOldestVtxo.filter((_) => _.txid === vtxo.arkTxId)
txAmount = spentAmount - changeAmount        // 110_000 − (50_000 + 60_000) = 0
if (txAmount !== 0 || assets) { sent.push(...) }   // never fires
```

So the funding tx nets to zero and the row is dropped. The covenant is spent only when the offer is filled or cancelled, so for a resting offer nothing ever appears.

Driving the SDK's own `buildTransactionHistory` over this scenario:

```
funding an offer covenant (a registered wallet contract):  0 rows
the identical send to an address the wallet does not track: SENT 50000
```

### The balance is not double-counted

The natural suspicion is that `getBalance()` counts the covenant back in as spendable. It does not. The contract registers with `metadata: { genericallySpendable: false }`, `ArkadeContractHandler.isGenericallySpendable` requires an explicit `true`, and `gatedContracts` therefore gates the script — verified against the operator's real pkScript:

```
offer generically spendable : false
gated map : [['51207b310c…1db6', 'arkade']]
```

`computeOffchainBalance` puts those sats in `gated`, so `available` — the number Send and Swap cap at — was already correct at 60,000.

What the operator saw as "no deduction" is `setBalance(total - unrolled)` in `providers/wallet.tsx`: `total` is the SDK's reporting figure and includes `gated`, so the headline legitimately stayed at 110,000. The 50,000 moved from spendable to committed, and nothing said so.

## The fix

The same defect `ungroupedLnSendTx` already fixes for the RFQ lockup — which registers with the same `genericallySpendable: false` marker and nets to zero the same way — and the same answer: build the row from the record the wallet already keeps.

`buildAssetSwapActivityTx` needs the member txs only for the fill, so an offer still waiting on one loses nothing by having none. Keyed as the resolver would key it (`swap:<id>`), so the real row replaces this one once a fill or cancel forms the group rather than doubling it.

## Where the funds now appear

Deliberately as a **distinct, recoverable commitment**, not a subtraction. An offer is cancellable (`user` + `server`) and exitable (`user` alone after the CSV), so the sats are committed, not gone — and the row carries the offer's own `pending`/`cancelled` status to say so, while the owned total keeps reporting them.

This is exactly how the wallet already treats a Lightning send in flight: the headline includes the locked lockup and the synthesized row explains it. Offers were the one corridor that never got the same treatment.

Not changed: `available` already excluded the covenant, and the Contracts screen already showed it active.

## Gate

CI runs on this base (`ci.yml`/`playwright.yml` are gated on `branches: [master, next]`, and this PR targets `master`).

| | baseline | after |
|---|---|---|
| `npx tsc --noEmit` | 1 error (`lnSendRecords.test.ts:33`, pre-existing) | 1 error, same one |
| `pnpm test:unit` | 88 files, 758 passed, 1 skipped, 0 failing | 89 files, 764 passed, 1 skipped, 0 failing |

`+1` file and `+6` tests are exactly the additions here. `format:check`, `lint` and `csp:check` all pass; the pre-commit hook ran normally.

`src/test/lib/offerFunding.test.tsx` reproduces the report at the operator's own numbers — 110,000 held, 50,000 committed — and fails 3/6 before the change.

### Mutations

| mutation | result |
|---|---|
| report the owned total as spendable (`spendableBalance: balance`) | killed — `expected 110000 to be 60000` |
| make the SDK treat the covenant as spendable (`isGenericallySpendable → true`) | killed — `expected false to be true` |
| suppress the synthesized row | killed (3) — `expected undefined to match object { type: 'swap', amount: 50000, …(4) }` |
| drop the owned total to the spendable one, so it reads as burned | killed — `expected 60000 to be 110000` |
| strip the recoverable framing (plain settled `sent` row, no `assetSwap`) | killed (3) — `expected undefined to be 'pending'` |
| emit the row even when a group exists | killed — `expected [ … ] to have a length of 1 but got 2` |

## Branch

`master`, not `ts-sdk-0.5` (#936) or `feat/payment-router-send` (#944). The balance and history path is byte-identical on all three — `setBalance(total - unrolled)` at `master:542` / `0.5:539` / `944:539`, `usePortfolioFiat.ts` identical by checksum — and both SDK versions ship the same `computeOffchainBalance` and `gated` bucket. The bug is at the root of the stack, so fixing it here reaches both PRs on their next rebase and does not leave `master` to be fixed separately later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where funding activity for Arkade swap offers could be missing from transaction history.
  - Swap offer funding now appears correctly even when the underlying transaction is not initially reported in history.
  - Prevented duplicate entries by replacing standalone funding activity with the corresponding swap activity when it becomes available.

- **Tests**
  - Added coverage for swap funding activity, including pending, cancelled, balance, and transaction-history scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->