### PR TITLE
fix(swaps): resolve swaps stuck pending, shown as two rows

### DIFF
--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -84,6 +84,27 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
     return next
   }
 
+  /**
+   * One notice per swap outcome.
+   *
+   * Four paths write the same terminal status — the watcher event, the
+   * unseen-spend pass, the restore scan and `cancelSwap` — and any two can
+   * resolve the same spend at once. The record write is idempotent through
+   * `spendUpdate`; a toast is not, so the outcome is what gets deduplicated
+   * rather than the write.
+   *
+   * Keyed by outcome, not by swap, so a record that legitimately moves twice
+   * (`cancelling` reverted, then cancelled for real) is still announced.
+   */
+  const announced = useRef(new Set<string>())
+  const announceOutcome = (swap: Pick<AssetSwap, 'id' | 'status' | 'toAsset'>) => {
+    const key = `${swap.id}:${swap.status}`
+    if (announced.current.has(key)) return
+    announced.current.add(key)
+    if (swap.status === 'fulfilled') toast.success(`Swap completed, ${tickerFor(swap.toAsset)} received`)
+    else if (swap.status === 'cancelled') toast.success('Swap cancelled, funds returned')
+  }
+
   /** A swap the chain has not reported an outcome for. `pending` is the absence
    * of an answer and `cancelling` is a cancel whose spend has not landed; every
    * other status is one. Both reconciliation passes below ask this, so they
@@ -94,6 +115,9 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   // than with it. Re-read on every dataReady transition: a wallet reset clears
   // the repository, and the emptied list has to reach the UI.
   useEffect(() => {
+    // a reset empties the store and a restore rebuilds the same ids, so what
+    // has been announced cannot outlive the records it was announced for
+    announced.current.clear()
     readSwaps()
       .then(applySwaps)
       .catch((err) => consoleError(err, 'failed to read asset swaps'))
@@ -250,10 +274,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
       }
       if (!next || stale()) return
       const list = applySwaps(next)
-      for (const swap of resolved) {
-        if (swap.status === 'fulfilled') toast.success(`Swap completed, ${tickerFor(swap.toAsset)} received`)
-        else if (swap.status === 'cancelled') toast.success('Swap cancelled, funds returned')
-      }
+      for (const swap of resolved) announceOutcome(swap)
       // a covenant this run settled is still in the watched set. Liveness is a
       // property of every record at a script, so the list goes whole.
       if (resolved.length > 0 && svcWallet) {
@@ -365,7 +386,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
         applySwaps(after)
       }
       if (stored?.status !== 'fulfilled') {
-        toast.success('Swap cancelled, funds returned')
+        announceOutcome({ ...swap, status: 'cancelled' })
         reloadWallet().catch(consoleError)
       }
     } catch (err) {
@@ -409,8 +430,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
         ...(cancelled ? {} : { completedAt: Date.now() }),
       }),
     )
-    if (cancelled) toast.success('Swap cancelled, funds returned')
-    else toast.success(`Swap completed, ${tickerFor(swap.toAsset)} received`)
+    announceOutcome({ ...swap, status: cancelled ? 'cancelled' : 'fulfilled' })
     reloadWallet().catch(consoleError)
     return true
   }
@@ -435,10 +455,9 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
    * surface in history as a *sent* row — which it does not while the covenant
    * is registered and the deposit still counts as the wallet's own.
    *
-   * Known limitation: a spend another path resolves while this one is between
-   * its re-read and its write is announced twice, since both toast. The write
-   * is idempotent through `spendUpdate`, so the cost is a duplicate toast, not
-   * a duplicate record.
+   * A spend another path resolves while this one is between its re-read and its
+   * write costs a redundant write, not a redundant notice: `spendUpdate` makes
+   * the write idempotent and `announceOutcome` deduplicates the toast.
    */
   const reconcileUnseenSpends = async (stale: () => boolean) => {
     if (!svcWallet) return
@@ -492,9 +511,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
       if (stale()) return
       applySwaps(updated)
       settled.add(swap.swapPkScript)
-      toast.success(
-        cancelled ? 'Swap cancelled, funds returned' : `Swap completed, ${tickerFor(swap.toAsset)} received`,
-      )
+      announceOutcome({ ...swap, status: cancelled ? 'cancelled' : 'fulfilled' })
     }
     if (settled.size === 0 || stale()) return
     // only the scripts this run resolved: liveness is a property of all records
@@ -543,13 +560,9 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
         : [updated, ...swapsRef.current],
     )
     if (before?.status === updated.status) return
-    if (updated.status === 'fulfilled') {
-      toast.success(`Swap completed, ${tickerFor(updated.toAsset)} received`)
-      reloadWallet().catch(consoleError)
-    } else if (updated.status === 'cancelled') {
-      toast.success('Swap cancelled, funds returned')
-      reloadWallet().catch(consoleError)
-    }
+    if (updated.status !== 'fulfilled' && updated.status !== 'cancelled') return
+    announceOutcome(updated)
+    reloadWallet().catch(consoleError)
   }
 
   // The watcher rides the wallet's contract events — registration in

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -63,7 +63,7 @@ export const AssetSwapsContext = createContext<AssetSwapsContextProps>({
 
 export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   const { aspInfo } = useContext(AspContext)
-  const { dataReady, svcWallet, reloadWallet, setAssetSwaps, txs } = useContext(WalletContext)
+  const { dataReady, svcWallet, reloadWallet, setAssetSwaps, txs, ungroupedTxs } = useContext(WalletContext)
 
   const [markets, setMarkets] = useState<DiscoveredMarket[]>([])
   const [swaps, setSwaps] = useState<WalletAssetSwap[]>([])
@@ -157,12 +157,17 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   // Bumped to re-enter the effect when a queued rescan has to start, since no
   // dependency of its own has changed by then.
   const [scanTick, setScanTick] = useState(0)
+  // Ungrouped rows, not `txs`: the scan takes candidates from `sent` rows, and
+  // `txs` turns a swap's funding row into a grouped `swap` one as soon as its
+  // record exists. Feeding it `txs` would hide the tx the record was built
+  // from, so a record could be created and then never re-answered.
+  //
   // Read inside the scan so a re-run sees the history that arrived mid-flight.
   // Committed values only, or a discarded render marks txids that never landed.
-  const txsRef = useRef(txs)
+  const txsRef = useRef(ungroupedTxs)
   useLayoutEffect(() => {
-    txsRef.current = txs
-  }, [txs])
+    txsRef.current = ungroupedTxs
+  }, [ungroupedTxs])
 
   // A token rather than a cancellation flag: this cleanup fires only when the
   // wallet changed or the provider went away, and `txs`, which must not abandon
@@ -177,7 +182,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   }, [aspInfo.url, aspInfo.signerPubkey, dataReady])
 
   useEffect(() => {
-    if (!aspInfo.url || !aspInfo.signerPubkey || !dataReady || txs.length === 0) return
+    if (!aspInfo.url || !aspInfo.signerPubkey || !dataReady || ungroupedTxs.length === 0) return
     // A run is already in flight and cannot see this newer history: ask it to go
     // round again instead of dropping the change. Returning without this is what
     // made a skipped run a lost one.
@@ -272,7 +277,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
         setScanTick((tick) => tick + 1)
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [aspInfo.url, aspInfo.signerPubkey, dataReady, txs, scanTick])
+  }, [aspInfo.url, aspInfo.signerPubkey, dataReady, ungroupedTxs, scanTick])
 
   // read through a ref so the watcher (which deliberately does not rebind on
   // market refreshes) always names assets from the current list

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -20,6 +20,8 @@ import {
   findMarket,
   getAssetSwaps,
   restoreAssetSwaps,
+  retireSettledOfferContracts,
+  spendUpdate,
   updateAssetSwap,
   watchOfferSwaps,
   type AssetSwap,
@@ -358,6 +360,122 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
     return true
   }
 
+  /**
+   * Spends the watcher never received.
+   *
+   * `watchOfferSwaps` learns a spend only from a live subscription event, and
+   * the SDK's other two discovery paths reach it with nothing usable: the boot
+   * sync runs before any subscriber exists (`ContractManager.initialize` awaits
+   * `reconcileWatched()` before `startWatching()`), and the failsafe poll emits
+   * the stale cached rows it diffed against, which carry no spend txid. Either
+   * way the record keeps `pending`, and `assetSwapResolver` indexes only
+   * `fundingTxid` and `spentTxid`, so the fill tx cannot bind to the swap and
+   * one swap renders as two rows: the funding row `ungroupedOfferTx`
+   * synthesizes, plus the fill as a bare received one.
+   *
+   * Nothing else resolves it. The restore scan skips any txid already stored as
+   * a record id, and would not see this one anyway: it takes candidates from
+   * *sent* rows, and an offer's funding tx nets to zero against its own
+   * covenant output.
+   *
+   * Known limitation: a spend the watcher receives while this pass is between
+   * its re-read and its write is announced twice, since both paths toast. The
+   * write is idempotent through `spendUpdate`, so the cost is a duplicate
+   * toast, not a duplicate record.
+   */
+  const reconcileUnseenSpends = async (stale: () => boolean) => {
+    if (!svcWallet) return
+    // `cancelling` too: a restart mid-cancel strands that status the same way
+    const open = (await readSwaps()).filter((swap) => swap.status === 'pending' || swap.status === 'cancelling')
+    if (open.length === 0) return
+
+    const manager = await svcWallet.getContractManager()
+    const contracts = await manager.getContractsWithVtxos({
+      script: [...new Set(open.map((swap) => swap.swapPkScript))],
+    })
+    const spent = contracts.flatMap(({ vtxos }) => vtxos).filter((vtxo) => vtxo.isSpent)
+    // the steady state, and worth a check to skip the history read below
+    if (spent.length === 0) return
+
+    const history = await getTxHistory(svcWallet)
+    const settled = new Set<string>()
+    for (const swap of open) {
+      const deposit = spent.find((v) => v.contractScript === swap.swapPkScript && v.txid === swap.fundingTxid)
+      // the ark txid, which is what the resolver matches a fill on
+      const spentTxid = deposit?.arkTxId || deposit?.spentBy
+      if (!spentTxid) continue
+
+      // `isCancelSpend` answers only when the offer wants an asset, which
+      // arrives on a fill and never on a cancel. Where the want side is BTC a
+      // cancel returns the offered asset and nets to zero, reading exactly like
+      // a fill: that needs the package's leaf classifier, so leave those alone.
+      const offer = decodeOffer(hex.decode(swap.offerHex))
+      if (!offer.wantAsset) continue
+
+      // no row yet means nothing to classify from, and a stored status is
+      // skipped by every later scan, so a guess here would be permanent
+      const spend = history.find((tx) => [tx.boardingTxid, tx.redeemTxid, tx.roundTxid].includes(spentTxid))
+      if (!spend) continue
+
+      // the watcher or a cancel in flight is the authority if it got here first
+      const current = (await readSwaps()).find((candidate) => candidate.id === swap.id)
+      if (!current || (current.status !== 'pending' && current.status !== 'cancelling')) continue
+
+      const cancelled = isCancelSpend(offer, spend)
+      const changes = spendUpdate(current, {
+        txid: spentTxid,
+        kind: cancelled ? 'cancelled' : 'fulfilled',
+        at: spend.createdAt * 1000, // history in seconds, records in milliseconds
+      })
+      if (!changes) continue
+      // every await above outlives a wallet switch, so re-ask on the near side
+      // of each side effect: writing past one would move a record into the
+      // wallet the user just left, or repaint it into the one they arrived at
+      if (stale()) return
+      const updated = await updateAssetSwap(assetSwapRepository, swap.id, changes)
+      if (stale()) return
+      applySwaps(updated)
+      settled.add(swap.swapPkScript)
+      toast.success(
+        cancelled ? 'Swap cancelled, funds returned' : `Swap completed, ${tickerFor(swap.toAsset)} received`,
+      )
+    }
+    if (settled.size === 0 || stale()) return
+    // only the scripts this run resolved: liveness is a property of all records
+    // at a script, so the filter keeps the check sound
+    await retireSettledOfferContracts(
+      manager,
+      swapsRef.current.filter((swap) => settled.has(swap.swapPkScript)),
+    )
+    if (stale()) return
+    reloadWallet().catch(consoleError)
+  }
+
+  /**
+   * Re-run on every history change, not once at start.
+   *
+   * The pass can only classify a spend once the transaction that made it has
+   * reached history, and with the app left open that arrives long after the
+   * watcher started — the fill itself is what puts it there. Running once at
+   * start covers only a spend that predates the session.
+   *
+   * Chained rather than gated by a flag, so a change landing mid-run is
+   * answered instead of dropped, and each queued run carries its own liveness
+   * so a wallet switch abandons it.
+   */
+  const reconcileQueue = useRef<Promise<void>>(Promise.resolve())
+  useEffect(() => {
+    if (!svcWallet || txs.length === 0) return
+    let stopped = false
+    reconcileQueue.current = reconcileQueue.current
+      .then(() => (stopped ? undefined : reconcileUnseenSpends(() => stopped)))
+      .catch((err) => consoleError(err, 'unseen spend reconciliation failed'))
+    return () => {
+      stopped = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [svcWallet, txs])
+
   /** A status the watcher persisted. It writes before it notifies, so the
    * record is durable by the time this runs — all that is left is telling the
    * user and refreshing balances. */
@@ -382,9 +500,10 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   // createOffer is what makes an offer visible to it — and persists each
   // classified spend itself.
   //
-  // Known gap: it subscribes to spends only, so a swept deposit is no longer
-  // noticed live. That status now waits for the next restore scan, which still
-  // produces it. Latency, not loss.
+  // Known gap: it subscribes to spends only, so a swept deposit is not noticed
+  // live, and the restore scan does not resolve it later — that scan skips any
+  // txid already stored as a record id. `reconcileUnseenSpends` covers the
+  // spends it can classify; a sweep is not one of them.
   useEffect(() => {
     if (!svcWallet || !aspInfo.url) return
     let watcher: OfferSwapWatcher | undefined

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -84,6 +84,12 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
     return next
   }
 
+  /** A swap the chain has not reported an outcome for. `pending` is the absence
+   * of an answer and `cancelling` is a cancel whose spend has not landed; every
+   * other status is one. Both reconciliation passes below ask this, so they
+   * cannot disagree about which records are still theirs to resolve. */
+  const isOpen = (swap: AssetSwap) => swap.status === 'pending' || swap.status === 'cancelling'
+
   // The store is async now, so the list arrives after the first render rather
   // than with it. Re-read on every dataReady transition: a wallet reset clears
   // the repository, and the emptied list has to reach the UI.
@@ -136,9 +142,16 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   // After a restore the swap store is empty while the funding/fill txs are
   // back in history, so swaps would show as bare sent/received rows. Scan the
   // sent virtual txs for offer packets and rebuild the lost records by
-  // binding each funding vtxo to the tx that spent it (fill or cancel). The
-  // scan is incremental — answered txids persist, so late-synced history is
-  // picked up by later runs and nothing is fetched twice.
+  // binding each funding vtxo to the tx that spent it (fill or cancel).
+  //
+  // The scan is incremental but not one-shot: answered txids persist, so
+  // late-synced history is picked up by later runs and nothing is fetched
+  // twice, while a record still open is re-asked until the chain answers it.
+  // That second part is what a rebuilt record needs. `createOffer` registers
+  // the covenant and the watcher rides those contract events; a record the
+  // scan rebuilt has no contract behind it, so no watcher event and no
+  // `reconcileUnseenSpends` pass can ever reach it. Its only route to an
+  // outcome is another scan.
   const scanningRef = useRef(false)
   const rescanRef = useRef(false)
   // Bumped to re-enter the effect when a queued rescan has to start, since no
@@ -178,33 +191,70 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
     const stale = () => !token.live
     const scan = async () => {
       const [existing, scanned] = await Promise.all([readSwaps(), assetSwapRepository.getScannedTxids()])
+      // Both skip lists exempt open records, and they have to agree: an id in
+      // `existingIds` or a txid in `scanned` is dropped before the scan reads
+      // it. The cost of exempting them is one psbt and one vtxo lookup per open
+      // swap per history change, and it stops the moment the swap settles.
+      const open = new Map(existing.filter(isOpen).map((swap) => [swap.id, swap]))
       const { restored, scannedTxids } = await restoreAssetSwaps(
         new RestIndexerProvider(aspInfo.url),
         txsRef.current,
-        new Set(existing.map((s) => s.id)),
-        // x-only, matching the key the covenants were funded against
-        { serverPubkey: hex.decode(aspInfo.signerPubkey).slice(1), scanned },
+        new Set(existing.filter((swap) => !isOpen(swap)).map((swap) => swap.id)),
+        {
+          // x-only, matching the key the covenants were funded against
+          serverPubkey: hex.decode(aspInfo.signerPubkey).slice(1),
+          scanned: new Set([...scanned].filter((txid) => !open.has(txid))),
+        },
       )
       if (stale()) return
       // a run with nothing new to answer for opens no transaction at all
       if (scannedTxids.length > 0) await assetSwapRepository.markTxidsScanned(scannedTxids)
       if (restored.length === 0) return
-      let next: WalletAssetSwap[] = []
+      let next: WalletAssetSwap[] | undefined
+      const resolved: AssetSwap[] = []
       for (const swap of restored) {
         if (stale()) return
-        // quote-time facts are not on chain; the fee rate is the one fact a
-        // restore can backfill, from the pair's current market card — an
-        // approximation if the solver changed its fee since the swap.
-        // TODO: delete this backfill once fee bps rides in a packet inside
-        // the funding tx — restoreAssetSwaps will then decode the actual
-        // historic rate from chain, like it already does the offer.
-        const feeBps = findMarket(marketsRef.current, swap.fromAsset, swap.toAsset)?.market?.fee_bps
-        next = (await addAssetSwap(
-          assetSwapRepository,
-          feeBps === undefined ? swap : ({ ...swap, quote: { feeBps } } as AssetSwap),
-        )) as WalletAssetSwap[]
+        const stored = open.get(swap.id)
+        if (!stored) {
+          // quote-time facts are not on chain; the fee rate is the one fact a
+          // restore can backfill, from the pair's current market card — an
+          // approximation if the solver changed its fee since the swap.
+          // TODO: delete this backfill once fee bps rides in a packet inside
+          // the funding tx — restoreAssetSwaps will then decode the actual
+          // historic rate from chain, like it already does the offer.
+          const feeBps = findMarket(marketsRef.current, swap.fromAsset, swap.toAsset)?.market?.fee_bps
+          next = (await addAssetSwap(
+            assetSwapRepository,
+            feeBps === undefined ? swap : ({ ...swap, quote: { feeBps } } as AssetSwap),
+          )) as WalletAssetSwap[]
+          continue
+        }
+        // `pending` is the absence of an answer, not one: writing it back would
+        // say nothing, and over a cancel in flight it would lose that status.
+        if (swap.status === 'pending' || swap.status === stored.status) continue
+        // Only the outcome. The scan rebuilds every field from chain, so
+        // writing the record whole would drop what only this wallet holds: the
+        // quote snapshot, and the funded address a cancel needs, which a
+        // restored record carries as an empty string.
+        next = (await updateAssetSwap(assetSwapRepository, swap.id, {
+          status: swap.status,
+          ...(swap.spentTxid ? { spentTxid: swap.spentTxid } : {}),
+          ...(swap.completedAt ? { completedAt: swap.completedAt } : {}),
+        })) as WalletAssetSwap[]
+        resolved.push(swap)
       }
-      applySwaps(next)
+      if (!next || stale()) return
+      const list = applySwaps(next)
+      for (const swap of resolved) {
+        if (swap.status === 'fulfilled') toast.success(`Swap completed, ${tickerFor(swap.toAsset)} received`)
+        else if (swap.status === 'cancelled') toast.success('Swap cancelled, funds returned')
+      }
+      // a covenant this run settled is still in the watched set. Liveness is a
+      // property of every record at a script, so the list goes whole.
+      if (resolved.length > 0 && svcWallet) {
+        await retireSettledOfferContracts(await svcWallet.getContractManager(), list)
+        if (stale()) return
+      }
       // re-merge the activity list so the tx couple collapses into Swap rows
       reloadWallet().catch(consoleError)
     }
@@ -373,20 +423,21 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
    * one swap renders as two rows: the funding row `ungroupedOfferTx`
    * synthesizes, plus the fill as a bare received one.
    *
-   * Nothing else resolves it. The restore scan skips any txid already stored as
-   * a record id, and would not see this one anyway: it takes candidates from
-   * *sent* rows, and an offer's funding tx nets to zero against its own
-   * covenant output.
+   * This pass and the restore scan cover each other's blind spot, because they
+   * read different sources. This one reads the wallet's contract rows, so it
+   * needs the covenant registered — which `createOffer` does, and a rebuilt
+   * record never had. The scan reads chain, so it needs the funding tx to
+   * surface in history as a *sent* row — which it does not while the covenant
+   * is registered and the deposit still counts as the wallet's own.
    *
-   * Known limitation: a spend the watcher receives while this pass is between
-   * its re-read and its write is announced twice, since both paths toast. The
-   * write is idempotent through `spendUpdate`, so the cost is a duplicate
-   * toast, not a duplicate record.
+   * Known limitation: a spend another path resolves while this one is between
+   * its re-read and its write is announced twice, since both toast. The write
+   * is idempotent through `spendUpdate`, so the cost is a duplicate toast, not
+   * a duplicate record.
    */
   const reconcileUnseenSpends = async (stale: () => boolean) => {
     if (!svcWallet) return
-    // `cancelling` too: a restart mid-cancel strands that status the same way
-    const open = (await readSwaps()).filter((swap) => swap.status === 'pending' || swap.status === 'cancelling')
+    const open = (await readSwaps()).filter(isOpen)
     if (open.length === 0) return
 
     const manager = await svcWallet.getContractManager()
@@ -419,7 +470,7 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
 
       // the watcher or a cancel in flight is the authority if it got here first
       const current = (await readSwaps()).find((candidate) => candidate.id === swap.id)
-      if (!current || (current.status !== 'pending' && current.status !== 'cancelling')) continue
+      if (!current || !isOpen(current)) continue
 
       const cancelled = isCancelSpend(offer, spend)
       const changes = spendUpdate(current, {
@@ -500,10 +551,9 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   // createOffer is what makes an offer visible to it — and persists each
   // classified spend itself.
   //
-  // Known gap: it subscribes to spends only, so a swept deposit is not noticed
-  // live, and the restore scan does not resolve it later — that scan skips any
-  // txid already stored as a record id. `reconcileUnseenSpends` covers the
-  // spends it can classify; a sweep is not one of them.
+  // It subscribes to spends only, so a swept deposit is not noticed live;
+  // the restore scan re-asks an open record until the chain answers, and a
+  // swept one comes back `recoverable`.
   useEffect(() => {
     if (!svcWallet || !aspInfo.url) return
     let watcher: OfferSwapWatcher | undefined

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -43,6 +43,7 @@ import { assetNameChanged } from '../lib/assets'
 import { consoleError } from '../lib/logs'
 import { Tx, Vtxo, Wallet } from '../lib/types'
 import { activitiesToTxs, getActivities } from '../lib/activityHistory'
+import { arkTransactionToTx } from '../lib/transactionHistory'
 import { Indexer } from '../lib/indexer'
 import { lnSendViews, swapActivityInputs, type LnSendView } from '../lib/lnSendRecords'
 import { assetSwapResolver } from '../lib/activity/assetSwapResolver'
@@ -113,6 +114,12 @@ interface WalletContextProps {
   svcWallet: ServiceWorkerWallet | undefined
   vtxoManager: IVtxoManager | undefined
   txs: Tx[]
+  /** History rows before grouping, and deliberately not derived from
+   * `assetSwaps`. The restore scan takes its candidates from `sent` rows, and
+   * `txs` replaces a swap's funding row with the grouped one the moment its
+   * record exists — so feeding it `txs` hides the very tx the record was built
+   * from, and no later scan can re-answer that record. */
+  ungroupedTxs: Tx[]
   /** Set by the asset-swaps provider, which owns the records. This provider
    * merges them into `txs`; the dependency runs one way, so they travel up
    * rather than being read back down. */
@@ -165,6 +172,7 @@ export const WalletContext = createContext<WalletContextProps>({
   dismissLoadError: () => {},
   authState: 'unknown',
   txs: [],
+  ungroupedTxs: [],
   setAssetSwaps: () => {},
   vtxos: { spendable: [], spent: [] },
   devAutoInitFailed: false,
@@ -231,6 +239,11 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [history, assetSwaps, aspInfo.network, assetDisplayVersion],
+  )
+
+  const ungroupedTxs = useMemo(
+    () => history.activities.flatMap((activity) => activity.txs).map((tx) => arkTransactionToTx(tx)),
+    [history],
   )
 
   const verifiedAssetsFetched = useRef(false)
@@ -1034,6 +1047,7 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
         lockWallet,
         restartWallet,
         txs,
+        ungroupedTxs,
         setAssetSwaps,
         balance,
         availableBalance,

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -307,11 +307,19 @@ describe('AssetSwapsProvider restore scan', () => {
     return <span data-testid='restored'>{swaps.map((s) => s.id).join(',') || 'none'}</span>
   }
 
-  const tree = (txs: (typeof mockTxInfo)[], signerPubkey: string = SIGNER_PUBKEY) =>
+  const tree = (txs: (typeof mockTxInfo)[], signerPubkey: string = SIGNER_PUBKEY, svcWallet?: unknown) =>
     providerTree(
-      { asp: { network: '', url: 'https://ark.test', signerPubkey }, wallet: { dataReady: true, txs } },
+      { asp: { network: '', url: 'https://ark.test', signerPubkey }, wallet: { dataReady: true, txs, svcWallet } },
       <ScanHarness />,
     )
+
+  /** A wallet whose contract manager answers both reconciliation paths: nothing
+   * spent for `reconcileUnseenSpends`, and a retire the scan can be seen to make. */
+  const scanWallet = () => {
+    const setContractWatchState = vi.fn().mockResolvedValue(undefined)
+    const manager = { setContractWatchState, getContractsWithVtxos: vi.fn().mockResolvedValue([]) }
+    return { setContractWatchState, svcWallet: { identity: {}, getContractManager: async () => manager } }
+  }
 
   /** Renders with the first `restoreAssetSwaps` held open, so a rerender lands
    * while a scan is provably in flight. Returns the release for that run. */
@@ -389,6 +397,75 @@ describe('AssetSwapsProvider restore scan', () => {
     await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(2))
     // and it sees the newer history, not the list its effect closed over
     expect(restoreAssetSwaps.mock.calls[1][1]).toHaveLength(2)
+  })
+
+  it('re-asks about a record still open and writes the outcome the chain reports', async () => {
+    // The bug this closes: a record whose covenant was never registered — every
+    // record a restore rebuilt — has no contract row, so no watcher event and
+    // no `reconcileUnseenSpends` pass can reach it. Left in `existingIds` it was
+    // skipped by every later scan too, so `pending` was permanent and the swap
+    // rendered as a Swap-pending row plus a bare received one, forever.
+    const stored: WalletAssetSwap = { ...pendingSwap, quote: { feeBps: 30 } }
+    await addAssetSwap(repository, stored)
+    await repository.markTxidsScanned([stored.id])
+    restoreAssetSwaps.mockResolvedValue({
+      restored: [
+        // as the scan builds it: every field from chain, and no funded address
+        { ...pendingSwap, swapAddress: '', status: 'fulfilled', spentTxid: 'fill-txid', completedAt: 99 },
+      ],
+      scannedTxids: [stored.id],
+    })
+    const seams = scanWallet()
+
+    render(tree([sentTx(stored.id)], SIGNER_PUBKEY, seams.svcWallet))
+
+    await waitFor(async () =>
+      expect((await getAssetSwaps(repository))[0]).toMatchObject({
+        status: 'fulfilled',
+        spentTxid: 'fill-txid',
+        completedAt: 99,
+        // the two the scan cannot know and must not overwrite
+        swapAddress: pendingSwap.swapAddress,
+        quote: { feeBps: 30 },
+      }),
+    )
+    // neither skip list may hold it back, or the scan never sees the candidate
+    expect(restoreAssetSwaps.mock.calls[0][2].has(stored.id)).toBe(false)
+    expect(restoreAssetSwaps.mock.calls[0][3].scanned.has(stored.id)).toBe(false)
+    // and the covenant it settled leaves the watched set
+    await waitFor(() => expect(seams.setContractWatchState).toHaveBeenCalledWith(stored.swapPkScript, 'retained'))
+  })
+
+  it('stops asking about a record the chain has answered', async () => {
+    const stored: WalletAssetSwap = { ...pendingSwap, status: 'cancelled', spentTxid: 'cancel-txid' }
+    await addAssetSwap(repository, stored)
+    await repository.markTxidsScanned([stored.id])
+    restoreAssetSwaps.mockResolvedValue({ restored: [], scannedTxids: [] })
+
+    render(tree([sentTx(stored.id)]))
+
+    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(1))
+    expect(restoreAssetSwaps.mock.calls[0][2].has(stored.id)).toBe(true)
+    expect(restoreAssetSwaps.mock.calls[0][3].scanned.has(stored.id)).toBe(true)
+  })
+
+  it('leaves a cancel in flight alone when the scan has no answer for it yet', async () => {
+    // `pending` off the scan means the deposit is still unspent, which is not an
+    // outcome. Writing it back would drop the cancel `cancelOffer` is running.
+    await addAssetSwap(repository, { ...pendingSwap, status: 'cancelling' })
+    restoreAssetSwaps.mockResolvedValue({
+      restored: [{ ...pendingSwap, swapAddress: '', status: 'pending' }],
+      scannedTxids: [],
+    })
+
+    render(tree([sentTx(pendingSwap.id)]))
+
+    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.getByTestId('restored')).toHaveTextContent(pendingSwap.id))
+    expect((await getAssetSwaps(repository))[0]).toMatchObject({
+      status: 'cancelling',
+      swapAddress: pendingSwap.swapAddress,
+    })
   })
 })
 

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -11,6 +11,7 @@ import { WalletContext } from '../../providers/wallet'
 import { assetSwapRepository as repository, type WalletAssetSwap } from '../../lib/swapRepository'
 import { btcUsdt, maratNapo, MARAT_ID, NAPO_ID, USDT_ID } from '../lib/swapFixtures'
 import { saveSolverCards } from '../../lib/solverCards'
+import { toast } from '../../components/Toast'
 import { mockAspContextValue, mockTxInfo, mockWalletContextValue } from '../screens/mocks'
 
 const cancelOffer = vi.hoisted(() => vi.fn())
@@ -46,6 +47,13 @@ vi.mock('../../lib/swapRepository', async () => {
 })
 
 // keep the discovery effect off the network; these tests hand plans in directly
+// only `toast.success` is spied; the provider component and everything else in
+// the module stay real, since the tree renders them
+vi.mock('../../components/Toast', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../components/Toast')>()
+  return { ...actual, toast: { ...actual.toast, success: vi.fn() } }
+})
+
 vi.mock('../../lib/swapMarkets', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../lib/swapMarkets')>()),
   discoverMarkets,
@@ -591,6 +599,7 @@ describe('AssetSwapsProvider spends the watcher never saw', () => {
   beforeEach(async () => {
     await repository.clear()
     restoreAssetSwaps.mockReset().mockResolvedValue({ restored: [], scannedTxids: [] })
+    vi.mocked(toast.success).mockClear()
     await addAssetSwap(repository, pendingSwap)
   })
 
@@ -647,6 +656,30 @@ describe('AssetSwapsProvider spends the watcher never saw', () => {
         spentTxid: FILL_TXID,
       }),
     )
+  })
+
+  it('announces a resolved swap once when the watcher and this pass both land on it', async () => {
+    // `watch.ts` notifies through `updateAssetSwapBestEffort`, so it can
+    // announce an outcome it failed to persist. This pass then re-reads
+    // `pending` from the store, resolves it for real, and with a toast per
+    // writer the user is told twice about one swap.
+    const seams = walletWith({ vtxos: [spentDeposit], history: [] })
+    const tree = (txs: unknown[]) =>
+      providerTree(
+        { asp: { network: '', url: 'https://ark.test' }, wallet: { svcWallet: seams.svcWallet, txs } },
+        <CancelHarness />,
+      )
+    const { rerender } = render(tree([]))
+    await waitFor(() => expect(watchOfferSwaps).toHaveBeenCalled())
+
+    act(() => watchOfferSwaps.mock.calls[0][0].onUpdate({ ...pendingSwap, status: 'fulfilled', spentTxid: FILL_TXID }))
+    expect(toast.success).toHaveBeenCalledTimes(1)
+
+    seams.getTransactionHistory.mockResolvedValue([spendRow(filled)])
+    rerender(tree([{ redeemTxid: FILL_TXID }]))
+
+    await waitFor(async () => expect((await getAssetSwaps(repository))[0].status).toBe('fulfilled'))
+    expect(toast.success).toHaveBeenCalledTimes(1)
   })
 
   it('leaves the record pending while no history row can classify the spend', async () => {

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -309,7 +309,11 @@ describe('AssetSwapsProvider restore scan', () => {
 
   const tree = (txs: (typeof mockTxInfo)[], signerPubkey: string = SIGNER_PUBKEY, svcWallet?: unknown) =>
     providerTree(
-      { asp: { network: '', url: 'https://ark.test', signerPubkey }, wallet: { dataReady: true, txs, svcWallet } },
+      {
+        asp: { network: '', url: 'https://ark.test', signerPubkey },
+        // the scan reads the ungrouped rows; `txs` is the grouped display list
+        wallet: { dataReady: true, txs, ungroupedTxs: txs, svcWallet },
+      },
       <ScanHarness />,
     )
 
@@ -397,6 +401,31 @@ describe('AssetSwapsProvider restore scan', () => {
     await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(2))
     // and it sees the newer history, not the list its effect closed over
     expect(restoreAssetSwaps.mock.calls[1][1]).toHaveLength(2)
+  })
+
+  it('feeds the scan the ungrouped rows, not the grouped ones its own records produced', async () => {
+    // The second lock on the same door: `txs` replaces a swap's funding row
+    // with a grouped `swap` row the moment its record exists, and the scan
+    // takes candidates from `sent` rows only. A scan reading `txs` therefore
+    // loses the very tx it rebuilt the record from, so exempting the record
+    // from both skip lists buys nothing — there is no candidate left to ask
+    // about. It could create a record and never re-answer it.
+    restoreAssetSwaps.mockResolvedValue({ restored: [], scannedTxids: [] })
+    const funding = sentTx('funding-txid')
+    const grouped = { ...mockTxInfo, type: 'swap', redeemTxid: 'funding-txid', createdAt: 1 }
+
+    render(
+      providerTree(
+        {
+          asp: { network: '', url: 'https://ark.test', signerPubkey: SIGNER_PUBKEY },
+          wallet: { dataReady: true, txs: [grouped], ungroupedTxs: [funding] },
+        },
+        <ScanHarness />,
+      ),
+    )
+
+    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(1))
+    expect(restoreAssetSwaps.mock.calls[0][1]).toEqual([funding])
   })
 
   it('re-asks about a record still open and writes the outcome the chain reports', async () => {

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -20,6 +20,7 @@ const getVtxos = vi.hoisted(() => vi.fn())
 const discoverMarkets = vi.hoisted(() => vi.fn(async (_network: string, _useCache?: boolean) => []))
 const restoreAssetSwaps = vi.hoisted(() => vi.fn())
 const watchOfferSwaps = vi.hoisted(() => vi.fn())
+const decodeOffer = vi.hoisted(() => vi.fn())
 
 vi.mock('@arkade-os/sdk', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@arkade-os/sdk')>()),
@@ -32,6 +33,7 @@ vi.mock('@arkade-os/swap', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@arkade-os/swap')>()),
   cancelOffer,
   createOffer,
+  decodeOffer,
   restoreAssetSwaps,
   watchOfferSwaps,
 }))
@@ -118,6 +120,8 @@ function renderCreateProvider(plan: OfferPlan) {
 beforeEach(() => {
   discoverMarkets.mockClear()
   watchOfferSwaps.mockReset().mockResolvedValue({ stop: () => {}, idle: async () => {} })
+  // only the two reconciliation paths decode, and both want the offer's want-asset
+  decodeOffer.mockReset().mockReturnValue({ wantAsset: { toString: () => pendingSwap.toAsset } })
 })
 
 describe('AssetSwapsProvider createSwap offer encoding', () => {
@@ -427,5 +431,180 @@ describe('AssetSwapsProvider solver cards', () => {
     // cache bypassed: the TTL cache holds the registry's answer, which is
     // exactly what a newly stored card changes
     expect(discoverMarkets.mock.calls[1][1]).toBe(false)
+  })
+})
+
+describe('AssetSwapsProvider spends the watcher never saw', () => {
+  const FILL_TXID = 'fill-txid'
+  const SPENT_AT = 1_700_000_000_000
+
+  /** The manager answers for the deposit's fate, history for what spent it. */
+  const walletWith = ({ vtxos, history }: { vtxos: unknown[]; history: unknown[] }) => {
+    const setContractWatchState = vi.fn().mockResolvedValue(undefined)
+    const getContractsWithVtxos = vi.fn().mockResolvedValue([{ vtxos }])
+    const getTransactionHistory = vi.fn().mockResolvedValue(history)
+    return {
+      setContractWatchState,
+      getContractsWithVtxos,
+      getTransactionHistory,
+      svcWallet: {
+        identity: {},
+        getContractManager: async () => ({ getContractsWithVtxos, setContractWatchState }),
+        getTransactionHistory,
+      },
+    }
+  }
+
+  const spentDeposit = {
+    contractScript: pendingSwap.swapPkScript,
+    txid: pendingSwap.fundingTxid,
+    isSpent: true,
+    arkTxId: FILL_TXID,
+  }
+
+  /** As the SDK reports it, before `arkTransactionToTx` normalizes it. */
+  const spendRow = (assets: { assetId: string; amount: bigint }[] = []) => ({
+    key: { arkTxid: FILL_TXID, commitmentTxid: '', boardingTxid: '' },
+    type: 'SENT',
+    amount: 9670,
+    settled: true,
+    createdAt: SPENT_AT,
+    assets,
+  })
+
+  const filled = [{ assetId: pendingSwap.toAsset, amount: BigInt(500) }]
+
+  const renderWith = (svcWallet: unknown, reloadWallet = vi.fn().mockResolvedValue(undefined)) =>
+    render(
+      providerTree(
+        { asp: { network: '', url: 'https://ark.test' }, wallet: { reloadWallet, svcWallet } },
+        <CancelHarness />,
+      ),
+    )
+
+  beforeEach(async () => {
+    await repository.clear()
+    restoreAssetSwaps.mockReset().mockResolvedValue({ restored: [], scannedTxids: [] })
+    await addAssetSwap(repository, pendingSwap)
+  })
+
+  afterEach(async () => await repository.clear())
+
+  it('resolves a fill that arrived while nothing was listening', async () => {
+    const seams = walletWith({ vtxos: [spentDeposit], history: [spendRow(filled)] })
+    const reloadWallet = vi.fn().mockResolvedValue(undefined)
+    renderWith(seams.svcWallet, reloadWallet)
+
+    await waitFor(async () =>
+      expect((await getAssetSwaps(repository))[0]).toMatchObject({
+        status: 'fulfilled',
+        spentTxid: FILL_TXID,
+        completedAt: SPENT_AT,
+      }),
+    )
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('fulfilled'))
+    // scoped to the covenants in question, and the settled one leaves the watched set
+    expect(seams.getContractsWithVtxos).toHaveBeenCalledWith({ script: [pendingSwap.swapPkScript] })
+    await waitFor(() => expect(seams.setContractWatchState).toHaveBeenCalledWith(pendingSwap.swapPkScript, 'retained'))
+    expect(reloadWallet).toHaveBeenCalled()
+  })
+
+  it('reads a spend that returned the deposit as a cancel', async () => {
+    // no want-asset in the spend: the deposit came back rather than being filled
+    renderWith(walletWith({ vtxos: [spentDeposit], history: [spendRow()] }).svcWallet)
+
+    await waitFor(async () =>
+      expect((await getAssetSwaps(repository))[0]).toMatchObject({ status: 'cancelled', spentTxid: FILL_TXID }),
+    )
+    expect((await getAssetSwaps(repository))[0].completedAt).toBeUndefined()
+  })
+
+  it('resolves a spend that lands while the app is left open', async () => {
+    // the case a run-once-at-start pass cannot reach: the deposit is spent
+    // twenty minutes into the session, and the fill's own history row is what
+    // makes it classifiable
+    const seams = walletWith({ vtxos: [spentDeposit], history: [] })
+    const tree = (txs: unknown[]) =>
+      providerTree(
+        { asp: { network: '', url: 'https://ark.test' }, wallet: { svcWallet: seams.svcWallet, txs } },
+        <CancelHarness />,
+      )
+    const { rerender } = render(tree([]))
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('pending'))
+    seams.getTransactionHistory.mockResolvedValue([spendRow(filled)])
+    rerender(tree([{ redeemTxid: FILL_TXID }]))
+
+    await waitFor(async () =>
+      expect((await getAssetSwaps(repository))[0]).toMatchObject({
+        status: 'fulfilled',
+        spentTxid: FILL_TXID,
+      }),
+    )
+  })
+
+  it('leaves the record pending while no history row can classify the spend', async () => {
+    // a stored status is skipped by every later scan, so a guess here is permanent
+    const seams = walletWith({ vtxos: [spentDeposit], history: [] })
+    renderWith(seams.svcWallet)
+
+    await waitFor(() => expect(seams.getTransactionHistory).toHaveBeenCalled())
+    expect((await getAssetSwaps(repository))[0].status).toBe('pending')
+  })
+
+  it('leaves a BTC-want offer alone, where the moved-value test cannot answer', async () => {
+    // its cancel nets to zero against the deposit and so reads exactly like a fill
+    decodeOffer.mockReturnValue({ offerAsset: { toString: () => 'asset-alpha' } })
+    const seams = walletWith({ vtxos: [spentDeposit], history: [spendRow()] })
+    renderWith(seams.svcWallet)
+
+    await waitFor(() => expect(seams.getTransactionHistory).toHaveBeenCalled())
+    expect((await getAssetSwaps(repository))[0].status).toBe('pending')
+    expect(seams.setContractWatchState).not.toHaveBeenCalled()
+  })
+
+  it('resolves a swap left cancelling by a restart mid-cancel', async () => {
+    await updateAssetSwap(repository, pendingSwap.id, { status: 'cancelling' })
+    renderWith(walletWith({ vtxos: [spentDeposit], history: [spendRow()] }).svcWallet)
+
+    await waitFor(async () =>
+      expect((await getAssetSwaps(repository))[0]).toMatchObject({ status: 'cancelled', spentTxid: FILL_TXID }),
+    )
+  })
+
+  it('writes nothing once the wallet has been switched out from under it', async () => {
+    // the reads are slow enough to outlive a switch, and a write past one would
+    // land a record in the wallet the user just left
+    const seams = walletWith({ vtxos: [spentDeposit], history: [] })
+    let deliver!: (history: unknown[]) => void
+    seams.getTransactionHistory.mockReturnValue(new Promise((resolve) => (deliver = resolve)))
+    const reloadWallet = vi.fn().mockResolvedValue(undefined)
+    const { unmount } = renderWith(seams.svcWallet, reloadWallet)
+
+    await waitFor(() => expect(seams.getTransactionHistory).toHaveBeenCalled())
+    unmount()
+    // deliver, then drain: the continuation has several awaits of its own, and
+    // asserting before they run would pass whether or not it stopped. The count
+    // is deliberately far above the awaits actually on that path, so adding one
+    // cannot quietly turn this into a test that passes on a regressed guard.
+    await act(async () => deliver([spendRow(filled)]))
+    for (let i = 0; i < 25; i++) await act(async () => {})
+
+    expect((await getAssetSwaps(repository))[0].status).toBe('pending')
+    expect(reloadWallet).not.toHaveBeenCalled()
+    expect(seams.setContractWatchState).not.toHaveBeenCalled()
+  })
+
+  it('does not read history at all when the deposit is still unspent', async () => {
+    const seams = walletWith({
+      vtxos: [{ ...spentDeposit, isSpent: false, arkTxId: undefined }],
+      history: [spendRow(filled)],
+    })
+    renderWith(seams.svcWallet)
+
+    await waitFor(() => expect(seams.getContractsWithVtxos).toHaveBeenCalled())
+    expect(seams.getTransactionHistory).not.toHaveBeenCalled()
+    expect((await getAssetSwaps(repository))[0].status).toBe('pending')
+    expect(seams.setContractWatchState).not.toHaveBeenCalled()
   })
 })

--- a/src/test/screens/mocks.ts
+++ b/src/test/screens/mocks.ts
@@ -137,6 +137,7 @@ export const mockWalletContextValue = {
   assetMetadataCache: new Map(),
   setCacheEntry: () => ({ cachedAt: 0 }) as any,
   txs: [mockTxInfo],
+  ungroupedTxs: [mockTxInfo],
   vtxos: { spendable: [], spent: [] },
   iconApprovalManager: new AssetIconApprovalManager(),
   isVerifiedAsset: () => false,


### PR DESCRIPTION
A swap whose deposit was spent stays `pending` forever and renders as two rows: "Swap pending" at the funding, plus the spend as a bare "Received". The reported case was a **cancel**, not a fill — the indexer has the deposit at `5120149f48e0…` spent by `arkTxid 44c02e2f…`, the 5,000-sat return. Either outcome behaves the same: the record never leaves `pending`, so nothing binds the spend to the swap.

Three independent causes, each found only after fixing the one before it. Reporter has confirmed the row now collapses on the branch preview.

**1. The watcher is never told.** `watchOfferSwaps` only learns a spend delivered live. The boot sync runs before any subscriber exists (`ContractManager.initialize` awaits `reconcileWatched()` before `startWatching()`), and the failsafe poll emits the stale cached rows it diffed against, which carry no spend txid, so `watch.ts:158` drops them. `assetSwapResolver` indexes `fundingTxid` and `spentTxid` only, so with neither written the spend cannot group. (arkade-os/ts-sdk#864, #865)

**2. A rebuilt record has no covenant behind it.** `createOffer` registers the covenant as a wallet contract; `restoreAssetSwaps` does not. So a restored record has no contract row, gets no watcher event, and is invisible to the pass in cause 1, which reads contract rows. The restore scan could still answer it from chain, but a stored id went into `existingIds` and its funding txid into the scanned cursor, so no later scan asked again. The reported wallet is exactly this: 35 records, every one with `swapAddress: ""`, zero contract rows. (arkade-os/ts-sdk#877, #878)

**3. The scan's own output removed its input.** `txs` is the display list, `activitiesToTxs(history.activities, { swaps })`, which replaces a swap's funding row with a grouped `type: 'swap'` row the moment its record exists. `unscannedSwapCandidates` takes `sent` rows only. So the scan built a record from a funding row and thereby deleted that row from its own input — born `pending`, never asked about again. Relaxing the skip lists bought nothing because no candidate was left. Wallet-side only, and why the first two commits appeared to do nothing.

## Verified against mainnet

Calling `restoreAssetSwaps` directly against `arkade.computer` with the reported funding txid and the live server key returns `status: "cancelled"`, `spentTxid: 44c02e2f…`. The package was right throughout; only the candidate list reaching it was wrong.

## What changed

`reconcileUnseenSpends` asks the contract manager what became of every open deposit, classifies it against the history row the spend produced, and writes through `spendUpdate`. It runs on every history change, not once at start, because the classifying row arrives long after the watcher starts; runs are chained so a change landing mid-run is answered, and each carries its own liveness so a wallet switch abandons it.

The restore scan exempts open records from both skip lists and reads candidates from a new `ungroupedTxs`, deliberately not derived from `assetSwaps`. It classifies from the covenant leaf the spending psbt names — authoritative, the only answer a rebuilt record can get, and the one that tells a cancel from a fill. On an existing record it writes the outcome only, so the quote snapshot and the funded address a cancel needs survive. `pending` off the scan is never written back, since over a cancel in flight it would lose that status.

The two passes cover each other: one needs the covenant registered, the other needs the funding tx in history as a `sent` row.

Four writers can reach the same terminal status, so the notice is deduplicated by swap id and outcome. `watch.ts` notifies through `updateAssetSwapBestEffort` and can announce an outcome it failed to persist; `spendUpdate` already made that write idempotent, `announceOutcome` now does the same for the toast. Found by CodeRabbit.

Falls out for free: a swept deposit comes back `recoverable` from the same re-ask.

## Tests

Twelve cases in `src/test/providers/assetSwaps.test.tsx`, each mutation-verified against the code it covers. The re-ask test fails on the exact symptom (`status` stays `pending`), the ungrouped-rows test fails if the scan is pointed back at `txs`, the cancel-in-flight test fails without the `pending` guard, and the notice test fails without the dedup ledger. Suite 790 passed; tsc, eslint, prettier and build clean against master's SDK 0.4.71.

## Follow-ups

Cause 1 belongs inside `watchOfferSwaps`, where it would reuse the package's leaf classifier and fix every consumer rather than this app (ts-sdk#864). Cause 2 belongs in the package: the restore scan should restore coverage (#877) and take open records directly instead of making every consumer rediscover the skip-list relaxation this PR hand-rolls (#878). Also filed: #863, #866, #867, #868.

Who issued that cancel is a separate open question. The psbt carries the maker's own signature, so it came from a wallet holding the seed, and nothing in this app cancels without a click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCGopokSkmbcbNZMKnYVEG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved asset-swap restoration so open swaps remain discoverable and settled contracts are finalized correctly.
  - Added reconciliation for missed on-chain activity, including fills, cancellations, returned funds, and recoverable deposits.
  - Improved handling across wallet changes and transaction-history updates.
  - Prevented in-progress cancellations from being overwritten by later reconciliation.
  - Deduplicated swap outcome notifications so each terminal result produces only one success message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->