### PR TITLE
fix(send,swap): explain a partial asset spend that cannot fund its change carrier

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -121,6 +121,9 @@ function AssetIcon({ asset }: { asset: AssetOption | null }) {
   )
 }
 
+const PARTIAL_SEND_ERROR =
+  "You don't have enough bitcoin to do a partial send. Please send all or acquire some bitcoin."
+
 export default function SendForm() {
   const { aspInfo } = useContext(AspContext)
   const { config, effectiveTheme, useFiat } = useContext(ConfigContext)
@@ -572,6 +575,11 @@ export default function SendForm() {
     if (isAssetSend && activeAsset) {
       const assetAmount = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
       setLabel(assetAmount > activeAsset.balance ? 'Insufficient asset balance' : 'Continue')
+      // a partial asset send leaves asset change, and that change needs a second
+      // dust carrier; without one the SDK fails with a bare "Insufficient funds"
+      const lacksChangeCarrier =
+        assetAmount > BigInt(0) && assetAmount < activeAsset.balance && availableBalance < 2 * DUST_AMOUNT
+      setError((prev) => (lacksChangeCarrier ? PARTIAL_SEND_ERROR : prev === PARTIAL_SEND_ERROR ? '' : prev))
       return
     }
     const satoshis = sendInfo.satoshis ?? 0
@@ -590,7 +598,7 @@ export default function SendForm() {
                   ? 'Amount below min limit'
                   : 'Continue',
     )
-  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.account, liquidBalance, activeAsset])
+  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.account, liquidBalance, activeAsset, availableBalance])
 
   // manage server unreachable error
   useEffect(() => {

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -575,11 +575,6 @@ export default function SendForm() {
     if (isAssetSend && activeAsset) {
       const assetAmount = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
       setLabel(assetAmount > activeAsset.balance ? 'Insufficient asset balance' : 'Continue')
-      // a partial asset send leaves asset change, and that change needs a second
-      // dust carrier; without one the SDK fails with a bare "Insufficient funds"
-      const lacksChangeCarrier =
-        assetAmount > BigInt(0) && assetAmount < activeAsset.balance && availableBalance < 2 * DUST_AMOUNT
-      setError((prev) => (lacksChangeCarrier ? PARTIAL_SEND_ERROR : prev === PARTIAL_SEND_ERROR ? '' : prev))
       return
     }
     const satoshis = sendInfo.satoshis ?? 0
@@ -598,7 +593,7 @@ export default function SendForm() {
                   ? 'Amount below min limit'
                   : 'Continue',
     )
-  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.account, liquidBalance, activeAsset, availableBalance])
+  }, [sendInfo.satoshis, sendInfo.assets, sendInfo.account, liquidBalance, activeAsset])
 
   // manage server unreachable error
   useEffect(() => {
@@ -872,10 +867,20 @@ export default function SendForm() {
 
   const assetAmt = sendInfo.account?.amount ?? sendInfo.assets?.[0]?.amount ?? BigInt(0)
 
+  // a partial asset send leaves asset change, and that change needs a second
+  // dust carrier; without one the SDK fails with a bare "Insufficient funds".
+  // Derived, not stored: the server-status effect owns `error` and would
+  // clear this on recovery.
+  const carrierError =
+    activeAsset && assetAmt > BigInt(0) && assetAmt < activeAsset.balance && availableBalance < 2 * DUST_AMOUNT
+      ? PARTIAL_SEND_ERROR
+      : ''
+
   const buttonDisabled = isAssetSend
     ? !(arkAddress && assetAmt > 0) ||
       (activeAsset ? assetAmt > activeAsset.balance : true) ||
       Boolean(recipientError) ||
+      Boolean(carrierError) ||
       aspInfo.unreachable ||
       Boolean(error) ||
       processing
@@ -982,7 +987,7 @@ export default function SendForm() {
         <Content>
           <Padded>
             <FlexCol gap='1.25rem' className='send-form-stack'>
-              <ErrorMessage error={Boolean(error)} text={error} />
+              <ErrorMessage error={Boolean(error || carrierError)} text={error || carrierError} />
               <InputAddress
                 error={recipientError}
                 focus={focus === 'recipient'}

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -231,10 +231,18 @@ export default function WalletSwap() {
   const currentPlan = status === 'success' && planMatchesAssetAmount ? plan : null
   const quoteStale = Boolean(toAsset && Number(assetAmount) > 0 && !currentPlan)
   const planError = currentPlan ? validatePlan(currentPlan, assetBalanceAtomic(fromAsset), aspInfo.dust) : undefined
-  const exceedsBalance = unitsToCents(assetAmount, fromAsset.decimals) > assetBalanceAtomic(fromAsset)
+  const amountAtomic = unitsToCents(assetAmount, fromAsset.decimals)
+  const exceedsBalance = amountAtomic > assetBalanceAtomic(fromAsset)
+  // a partial asset deposit leaves asset change, and that change needs a second
+  // dust carrier; without one the SDK fails with a bare "Insufficient funds"
+  const lacksChangeCarrier =
+    fromAsset.assetId !== BTC_ASSET_ID &&
+    amountAtomic < assetBalanceAtomic(fromAsset) &&
+    availableBalance < 2 * Number(aspInfo.dust)
   const validationMessage = swapValidationMessage({
     amount,
     exceedsBalance,
+    lacksChangeCarrier,
     fromAsset,
     pairAvailable: toAsset ? Boolean(pair?.market) : undefined,
     plan: currentPlan,
@@ -283,7 +291,7 @@ export default function WalletSwap() {
   const balanceValidation = isBalanceLimitValidation(validationMessage) ? validationMessage : ''
 
   const quoteLoading = status === 'loading' || (quoteStale && hasPositiveAmount)
-  const canContinue = Boolean(toAsset && currentPlan && !planError)
+  const canContinue = Boolean(toAsset && currentPlan && !planError && !validationMessage)
 
   const stageTransition = prefersReduced ? { duration: 0 } : { duration: 0.28, ease: EASE_IN_OUT_QUINT_TUPLE }
 
@@ -1408,6 +1416,7 @@ function amountForQuote(amount: string, fromAsset: SwapAsset): string {
 function swapValidationMessage({
   amount,
   exceedsBalance,
+  lacksChangeCarrier,
   fromAsset,
   pairAvailable,
   plan,
@@ -1417,6 +1426,7 @@ function swapValidationMessage({
 }: {
   amount: string
   exceedsBalance: boolean
+  lacksChangeCarrier: boolean
   fromAsset: SwapAsset
   pairAvailable: boolean | undefined
   plan: OfferPlan | null
@@ -1426,6 +1436,9 @@ function swapValidationMessage({
 }): string {
   if (!Number(amount)) return ''
   if (exceedsBalance) return 'Insufficient balance'
+  if (lacksChangeCarrier) {
+    return "You don't have enough bitcoin to do a partial swap. Please swap all or acquire some bitcoin."
+  }
   if (pairAvailable === undefined) return ''
   if (!pairAvailable || solvable === false) return 'Swap unavailable for this pair'
   if (status === 'error') return 'Quote unavailable'

--- a/src/test/screens/wallet/send.test.tsx
+++ b/src/test/screens/wallet/send.test.tsx
@@ -360,4 +360,36 @@ describe('Send screen', () => {
       ),
     )
   })
+
+  it('stops a partial asset send that cannot fund its change carrier', async () => {
+    const account = {
+      assetId: 'usdt',
+      ticker: 'USD' as const,
+      balance: BigInt(10_000),
+      decimals: 2,
+      amount: BigInt(8_000),
+      source: { assetId: 'usdt', balance: BigInt(1_000_000), decimals: 4 },
+    }
+
+    renderSendForm({
+      flowContext: {
+        ...mockFlowContextValue,
+        sendInfo: { ...emptySendInfo, account, assets: [{ assetId: 'usdt', amount: BigInt(800_000) }] },
+      },
+      walletContext: {
+        ...mockWalletContextValue,
+        // one dust carrier: the sats the asset itself rides on
+        availableBalance: 330,
+        svcWallet: {
+          ...mockSvcWallet,
+          getAddress: () => 'tark1mockoffchain',
+          getBoardingAddress: () => Promise.resolve('bcrt1mockboarding'),
+          getBalance: () => Promise.resolve({ available: 330 }),
+        } as any,
+      },
+    })
+
+    expect(await screen.findByTestId('error-message')).toHaveTextContent(/partial send/)
+    expect(screen.getByText('Continue').closest('button')).toBeDisabled()
+  })
 })

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -382,6 +382,39 @@ describe('Wallet swap flow', () => {
     expect(screen.getByRole('button', { name: '0.00100000 BTC' })).toBeInTheDocument()
   })
 
+  it('stops a partial asset swap that cannot fund its change carrier', async () => {
+    renderSwap({
+      config: { currency: Currencies.BRL, unit: Unit.SATS },
+      flow: { swapFromAssetId: DEPIX_ID, setSwapFromAssetId: vi.fn() },
+      // one dust carrier: the sats the DEPIX itself rides on
+      wallet: { availableBalance: 333, assetBalances: [{ assetId: DEPIX_ID, amount: BigInt(200_000_000_000) }] },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Bitcoin/i }))
+    for (const key of ['1', '0', '0', '0']) await userEvent.click(screen.getByRole('button', { name: key }))
+
+    await waitFor(() => expect(screen.getByText(/partial swap/)).toBeInTheDocument())
+    expect(screen.getByText(/partial swap/).closest('[data-sonner-toast]')).not.toBeNull()
+    expect(primaryAmount().className).toContain('swap-amount-display--invalid')
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+  })
+
+  it('allows a partial asset swap once a second dust carrier is available', async () => {
+    renderSwap({
+      config: { currency: Currencies.BRL, unit: Unit.SATS },
+      flow: { swapFromAssetId: DEPIX_ID, setSwapFromAssetId: vi.fn() },
+      wallet: { availableBalance: 666, assetBalances: [{ assetId: DEPIX_ID, amount: BigInt(200_000_000_000) }] },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Bitcoin/i }))
+    for (const key of ['1', '0', '0', '0']) await userEvent.click(screen.getByRole('button', { name: key }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled(), { timeout: 3_000 })
+    expect(screen.queryByText(/partial swap/)).not.toBeInTheDocument()
+  })
+
   it('submits the live PR 784 offer plan and a historical display snapshot', async () => {
     renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() } })
 


### PR DESCRIPTION
## Problem

A first-time DePix user holds one VTXO: the DEPIX riding on its 330 sat carrier, nothing else. Swapping or sending part of that balance leaves asset change, and the change output needs a second carrier. Coin selection has nothing left to pull in, so the SDK throws a bare `Insufficient funds` after the user has already pressed Confirm. Swap-all works, since no change output is needed.

## Change

Validate it inline, before anything reaches the SDK. When the asset amount is partial and the available sats are below two dust carriers:

- **Swap** shows "You don't have enough bitcoin to do a partial swap. Please swap all or acquire some bitcoin." through the existing validation path (Sonner toast, invalid amount state) and keeps Continue disabled.
- **Send** shows the same message with "send" as the form error, which already disables Continue.

Swap all, or hold at least one extra carrier of BTC, and the message clears.

Swap reads the threshold from `aspInfo.dust`, which that file already passes to `validatePlan`. Send reads the local `DUST_AMOUNT` it already uses for the balance reserve. Each file stays consistent with itself.

## Tests

- swap: blocked at one carrier (333 sats), allowed at two (666 sats)
- send: blocked at one carrier for a partial account send

`pnpm vitest run` on both screen files (54 passed), `tsc --noEmit`, `pnpm lint` and prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Scach6mrJUJea2qRDHXyhP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Scach6mrJUJea2qRDHXyhP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked partial asset sends and swaps when insufficient Bitcoin is available to support the required change carrier.
  * Added clear guidance to send or swap the full asset balance, or acquire more Bitcoin.
  * Disabled Continue until the validation issue is resolved.

* **Tests**
  * Added coverage for blocked partial sends and swaps, including successful continuation when sufficient Bitcoin is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->