### PR TITLE
fix(swap): keep one dust carrier back when depositing BTC next to assets

### DIFF
--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,4 +1,5 @@
 import Decimal from 'decimal.js'
+import { ASSET_CARRIER_SATS } from '@arkade-os/sdk'
 
 export const MAX_DECIMALS = 8 // Arbitrary value to allow at least 1 sat/asset
 
@@ -127,14 +128,9 @@ export const assetNameChanged = (
   next: { ticker?: string; decimals?: number } | undefined,
 ): boolean => previous?.ticker !== next?.ticker || previous?.decimals !== next?.decimals
 
-/** Sats a BTC spend keeps back while the wallet holds assets. Every asset
- * output rides on a dust carrier and asset change needs one of its own, so
- * spending the last carrier fails inside coin selection with a bare
- * "Insufficient funds". */
-export const DUST_AMOUNT = 330
-
-/** The BTC a spend may take: the available balance less the reserve above
- * when `holdsAssets`. Clamped at zero, since a balance below the reserve is
- * "nothing sendable" rather than a negative amount. */
+/** The BTC a spend may take. While the wallet holds assets one carrier stays
+ * back: every asset output rides on `ASSET_CARRIER_SATS`, asset change needs
+ * one of its own, and spending the last one fails inside coin selection with
+ * a bare "Insufficient funds". Never negative. */
 export const liquidBtcBalance = (availableBalance: number, holdsAssets: boolean): number =>
-  Math.max(0, availableBalance - (holdsAssets ? DUST_AMOUNT : 0))
+  Math.max(0, availableBalance - (holdsAssets ? ASSET_CARRIER_SATS : 0))

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,5 +1,4 @@
 import Decimal from 'decimal.js'
-import { ASSET_CARRIER_SATS } from '@arkade-os/sdk'
 
 export const MAX_DECIMALS = 8 // Arbitrary value to allow at least 1 sat/asset
 
@@ -129,8 +128,8 @@ export const assetNameChanged = (
 ): boolean => previous?.ticker !== next?.ticker || previous?.decimals !== next?.decimals
 
 /** The BTC a spend may take. While the wallet holds assets one carrier stays
- * back: every asset output rides on `ASSET_CARRIER_SATS`, asset change needs
- * one of its own, and spending the last one fails inside coin selection with
- * a bare "Insufficient funds". Never negative. */
-export const liquidBtcBalance = (availableBalance: number, holdsAssets: boolean): number =>
-  Math.max(0, availableBalance - (holdsAssets ? ASSET_CARRIER_SATS : 0))
+ * back: every asset output rides on `dust` sats (the server's threshold),
+ * asset change needs one of its own, and spending the last one fails inside
+ * coin selection with a bare "Insufficient funds". Never negative. */
+export const liquidBtcBalance = (availableBalance: number, holdsAssets: boolean, dust: bigint): number =>
+  Math.max(0, availableBalance - (holdsAssets ? Number(dust) : 0))

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -126,3 +126,15 @@ export const assetNameChanged = (
   previous: { ticker?: string; decimals?: number } | undefined,
   next: { ticker?: string; decimals?: number } | undefined,
 ): boolean => previous?.ticker !== next?.ticker || previous?.decimals !== next?.decimals
+
+/** Sats a BTC spend keeps back while the wallet holds assets. Every asset
+ * output rides on a dust carrier and asset change needs one of its own, so
+ * spending the last carrier fails inside coin selection with a bare
+ * "Insufficient funds". */
+export const DUST_AMOUNT = 330
+
+/** The BTC a spend may take: the available balance less the reserve above
+ * when `holdsAssets`. Clamped at zero, since a balance below the reserve is
+ * "nothing sendable" rather than a negative amount. */
+export const liquidBtcBalance = (availableBalance: number, holdsAssets: boolean): number =>
+  Math.max(0, availableBalance - (holdsAssets ? DUST_AMOUNT : 0))

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -28,7 +28,7 @@ import { aspErrorText, getReceivingAddresses } from '../../../lib/asp'
 import { isMobileBrowser } from '../../../lib/browser'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
-import { ArkNote, ASSET_CARRIER_SATS, AssetDetails, isValidArkAddress, type NetworkName } from '@arkade-os/sdk'
+import { ArkNote, AssetDetails, isValidArkAddress, type NetworkName } from '@arkade-os/sdk'
 import { LimitsContext } from '../../../providers/limits'
 import { checkLnUrlConditions, fetchInvoice, fetchArkAddress, isValidLnUrl, LnUrlResponse } from '../../../lib/lnurl'
 import { extractError } from '../../../lib/error'
@@ -193,7 +193,7 @@ export default function SendForm() {
   const RECIPIENT_DEBOUNCE_MS = 800
   const hasAssets = assetBalances.length > 0
   const reserveApplied = !isAssetSend && hasAssets
-  const liquidBalance = liquidBtcBalance(availableBalance, reserveApplied)
+  const liquidBalance = liquidBtcBalance(availableBalance, reserveApplied, aspInfo.dust)
 
   const smartSetError = (str: string) => {
     setError(str === '' ? (aspInfo.unreachable ? aspErrorText(aspInfo, 'Arkade server unreachable') : '') : str)
@@ -869,7 +869,7 @@ export default function SendForm() {
   // Derived, not stored: the server-status effect owns `error` and would
   // clear this on recovery.
   const carrierError =
-    activeAsset && assetAmt > BigInt(0) && assetAmt < activeAsset.balance && availableBalance < 2 * ASSET_CARRIER_SATS
+    activeAsset && assetAmt > BigInt(0) && assetAmt < activeAsset.balance && availableBalance < 2 * Number(aspInfo.dust)
       ? PARTIAL_SEND_ERROR
       : ''
 
@@ -1154,7 +1154,7 @@ export default function SendForm() {
         <FlexCol gap='1rem'>
           <Text bold>Balance reserve</Text>
           <Text color='neutral-500' small wrap>
-            {`${ASSET_CARRIER_SATS} sats are kept in reserve to protect your assets. Your max sendable amount is ${prettyNumber(liquidBalance)} sats.`}
+            {`${aspInfo.dust} sats are kept in reserve to protect your assets. Your max sendable amount is ${prettyNumber(liquidBalance)} sats.`}
           </Text>
           <FlexCol gap='0.5rem'>
             <Button onClick={confirmSendAll} label='Send max' />

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -38,7 +38,7 @@ import { withRfqTransport } from '../../../lib/nostrRfq'
 import { discoverMarkets } from '../../../lib/swapMarkets'
 import { decodeBip21, isBip21 } from '../../../lib/bip21'
 import { InfoLine } from '../../../components/Info'
-import { centsToUnits, prettyAssetAmount, unitsToCents } from '../../../lib/assets'
+import { centsToUnits, DUST_AMOUNT, liquidBtcBalance, prettyAssetAmount, unitsToCents } from '../../../lib/assets'
 import { FeesContext } from '../../../providers/fees'
 import SheetModal from '../../../components/SheetModal'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -190,13 +190,10 @@ export default function SendForm() {
   const activeAsset = accountAsset ?? selectedAsset
   const isAssetSend = activeAsset !== null
 
-  const DUST_AMOUNT = 330
   const RECIPIENT_DEBOUNCE_MS = 800
   const hasAssets = assetBalances.length > 0
   const reserveApplied = !isAssetSend && hasAssets
-  // clamp: a balance below the reserve is "nothing sendable", not a negative
-  // amount (and the provider's availableBalance never flashes 0 on mount)
-  const liquidBalance = Math.max(0, availableBalance - (reserveApplied ? DUST_AMOUNT : 0))
+  const liquidBalance = liquidBtcBalance(availableBalance, reserveApplied)
 
   const smartSetError = (str: string) => {
     setError(str === '' ? (aspInfo.unreachable ? aspErrorText(aspInfo, 'Arkade server unreachable') : '') : str)

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -28,7 +28,7 @@ import { aspErrorText, getReceivingAddresses } from '../../../lib/asp'
 import { isMobileBrowser } from '../../../lib/browser'
 import { ConfigContext } from '../../../providers/config'
 import { FiatContext } from '../../../providers/fiat'
-import { ArkNote, AssetDetails, isValidArkAddress, type NetworkName } from '@arkade-os/sdk'
+import { ArkNote, ASSET_CARRIER_SATS, AssetDetails, isValidArkAddress, type NetworkName } from '@arkade-os/sdk'
 import { LimitsContext } from '../../../providers/limits'
 import { checkLnUrlConditions, fetchInvoice, fetchArkAddress, isValidLnUrl, LnUrlResponse } from '../../../lib/lnurl'
 import { extractError } from '../../../lib/error'
@@ -38,7 +38,7 @@ import { withRfqTransport } from '../../../lib/nostrRfq'
 import { discoverMarkets } from '../../../lib/swapMarkets'
 import { decodeBip21, isBip21 } from '../../../lib/bip21'
 import { InfoLine } from '../../../components/Info'
-import { centsToUnits, DUST_AMOUNT, liquidBtcBalance, prettyAssetAmount, unitsToCents } from '../../../lib/assets'
+import { centsToUnits, liquidBtcBalance, prettyAssetAmount, unitsToCents } from '../../../lib/assets'
 import { FeesContext } from '../../../providers/fees'
 import SheetModal from '../../../components/SheetModal'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -869,7 +869,7 @@ export default function SendForm() {
   // Derived, not stored: the server-status effect owns `error` and would
   // clear this on recovery.
   const carrierError =
-    activeAsset && assetAmt > BigInt(0) && assetAmt < activeAsset.balance && availableBalance < 2 * DUST_AMOUNT
+    activeAsset && assetAmt > BigInt(0) && assetAmt < activeAsset.balance && availableBalance < 2 * ASSET_CARRIER_SATS
       ? PARTIAL_SEND_ERROR
       : ''
 
@@ -1154,7 +1154,7 @@ export default function SendForm() {
         <FlexCol gap='1rem'>
           <Text bold>Balance reserve</Text>
           <Text color='neutral-500' small wrap>
-            {`${DUST_AMOUNT} sats are kept in reserve to protect your assets. Your max sendable amount is ${prettyNumber(liquidBalance)} sats.`}
+            {`${ASSET_CARRIER_SATS} sats are kept in reserve to protect your assets. Your max sendable amount is ${prettyNumber(liquidBalance)} sats.`}
           </Text>
           <FlexCol gap='0.5rem'>
             <Button onClick={confirmSendAll} label='Send max' />

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -17,7 +17,7 @@ import ChevronDownIcon from '../../../icons/ChevronDown'
 import InfoIcon from '../../../icons/Info'
 import SwapIcon from '../../../icons/Swap'
 import { EASE_IN_OUT_QUINT_TUPLE, EASE_OUT_QUINT_TUPLE } from '../../../lib/animations'
-import { centsToUnits, unitsToCents } from '../../../lib/assets'
+import { centsToUnits, liquidBtcBalance, unitsToCents } from '../../../lib/assets'
 import { extractError } from '../../../lib/error'
 import { formatFiatAmountParts, normalizeBitcoinUnit, prettyFiatAmount, prettyNumber } from '../../../lib/format'
 import { hapticLight, hapticSubtle, hapticTap } from '../../../lib/haptics'
@@ -122,7 +122,9 @@ export default function WalletSwap() {
           ticker: btcUnit === Unit.BTC ? 'BTC' : btcUnit,
           currency: Currencies.BTC,
           decimals: btcUnit === Unit.BTC ? 8 : 0,
-          balance: BigInt(availableBalance),
+          // the same reserve Send applies: a BTC deposit from a wallet that
+          // holds assets keeps one dust carrier back for the asset change
+          balance: BigInt(liquidBtcBalance(availableBalance, availableAssetBalances.length > 0)),
           fiatText: bitcoinRow?.hasFiatPrice
             ? prettyFiatAmount(bitcoinRow.fiatAmount, config.currency, { bitcoinUnit: config.unit })
             : undefined,

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -17,7 +17,6 @@ import ChevronDownIcon from '../../../icons/ChevronDown'
 import InfoIcon from '../../../icons/Info'
 import SwapIcon from '../../../icons/Swap'
 import { EASE_IN_OUT_QUINT_TUPLE, EASE_OUT_QUINT_TUPLE } from '../../../lib/animations'
-import { ASSET_CARRIER_SATS } from '@arkade-os/sdk'
 import { centsToUnits, liquidBtcBalance, unitsToCents } from '../../../lib/assets'
 import { extractError } from '../../../lib/error'
 import { formatFiatAmountParts, normalizeBitcoinUnit, prettyFiatAmount, prettyNumber } from '../../../lib/format'
@@ -123,7 +122,7 @@ export default function WalletSwap() {
           ticker: btcUnit === Unit.BTC ? 'BTC' : btcUnit,
           currency: Currencies.BTC,
           decimals: btcUnit === Unit.BTC ? 8 : 0,
-          balance: BigInt(liquidBtcBalance(availableBalance, availableAssetBalances.length > 0)),
+          balance: BigInt(liquidBtcBalance(availableBalance, availableAssetBalances.length > 0, aspInfo.dust)),
           fiatText: bitcoinRow?.hasFiatPrice
             ? prettyFiatAmount(bitcoinRow.fiatAmount, config.currency, { bitcoinUnit: config.unit })
             : undefined,
@@ -153,6 +152,7 @@ export default function WalletSwap() {
     })
   }, [
     assetMetadataCache,
+    aspInfo.dust,
     aspInfo.network,
     availableAssetBalances,
     availableBalance,
@@ -239,7 +239,7 @@ export default function WalletSwap() {
   const lacksChangeCarrier =
     fromAsset.assetId !== BTC_ASSET_ID &&
     amountAtomic < assetBalanceAtomic(fromAsset) &&
-    availableBalance < 2 * ASSET_CARRIER_SATS
+    availableBalance < 2 * Number(aspInfo.dust)
   const validationMessage = swapValidationMessage({
     amount,
     exceedsBalance,

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -17,6 +17,7 @@ import ChevronDownIcon from '../../../icons/ChevronDown'
 import InfoIcon from '../../../icons/Info'
 import SwapIcon from '../../../icons/Swap'
 import { EASE_IN_OUT_QUINT_TUPLE, EASE_OUT_QUINT_TUPLE } from '../../../lib/animations'
+import { ASSET_CARRIER_SATS } from '@arkade-os/sdk'
 import { centsToUnits, liquidBtcBalance, unitsToCents } from '../../../lib/assets'
 import { extractError } from '../../../lib/error'
 import { formatFiatAmountParts, normalizeBitcoinUnit, prettyFiatAmount, prettyNumber } from '../../../lib/format'
@@ -122,8 +123,6 @@ export default function WalletSwap() {
           ticker: btcUnit === Unit.BTC ? 'BTC' : btcUnit,
           currency: Currencies.BTC,
           decimals: btcUnit === Unit.BTC ? 8 : 0,
-          // the same reserve Send applies: a BTC deposit from a wallet that
-          // holds assets keeps one dust carrier back for the asset change
           balance: BigInt(liquidBtcBalance(availableBalance, availableAssetBalances.length > 0)),
           fiatText: bitcoinRow?.hasFiatPrice
             ? prettyFiatAmount(bitcoinRow.fiatAmount, config.currency, { bitcoinUnit: config.unit })
@@ -240,7 +239,7 @@ export default function WalletSwap() {
   const lacksChangeCarrier =
     fromAsset.assetId !== BTC_ASSET_ID &&
     amountAtomic < assetBalanceAtomic(fromAsset) &&
-    availableBalance < 2 * Number(aspInfo.dust)
+    availableBalance < 2 * ASSET_CARRIER_SATS
   const validationMessage = swapValidationMessage({
     amount,
     exceedsBalance,

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -395,12 +395,10 @@ describe('Wallet swap flow', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
     fireEvent.click(screen.getByRole('button', { name: /Bitcoin/i }))
-    for (const key of ['1', '0', '0', '0']) await userEvent.click(screen.getByRole('button', { name: key }))
+    // one key and one lookup: the toast lives 2s, and a slow runner spends
+    // that typing more digits or querying twice
+    await userEvent.click(screen.getByRole('button', { name: '1' }))
 
-    // the toast lands after four keypad round-trips; the same allowance the
-    // Sonner test above gives it, since a busy runner has missed the default
-    // one lookup: Sonner auto-dismisses after 4s, and a slow runner can cross
-    // that between two separate queries
     const notice = await screen.findByText(/partial swap/, {}, { timeout: 3_000 })
     expect(notice.closest('[data-sonner-toast]')).not.toBeNull()
     expect(primaryAmount().className).toContain('swap-amount-display--invalid')

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -352,7 +352,7 @@ describe('Wallet swap flow', () => {
   })
 
   it('replaces the available balance with a max action for insufficient balance', async () => {
-    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() } })
+    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() }, wallet: { assetBalances: [] } })
 
     for (const key of ['9', '9', '9']) {
       await userEvent.click(screen.getByRole('button', { name: key }))
@@ -371,7 +371,7 @@ describe('Wallet swap flow', () => {
 
   it('keeps non-limit validation errors in Sonner', async () => {
     fetchMocker.mockRejectOnce(new Error('feed unavailable'))
-    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() } })
+    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() }, wallet: { assetBalances: [] } })
 
     fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
     fireEvent.click(screen.getByRole('button', { name: /USD/i }))
@@ -652,15 +652,16 @@ describe('Wallet swap flow', () => {
     expect(await screen.findByRole('button', { name: /NAPO/i })).toBeInTheDocument()
   })
 
-  it('funds the whole balance when the balance under the from-asset is tapped', async () => {
+  it('funds the balance less one dust carrier when the wallet also holds assets', async () => {
     renderSwap({ config: { unit: Unit.SATS }, flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() } })
 
     fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
     fireEvent.click(screen.getByRole('button', { name: /USD/i }))
 
-    // the wallet holds 100,000 sats (loaded async) — tapping the balance enters all of it
-    await userEvent.click(await screen.findByRole('button', { name: '100,000 sats' }))
-    expect(primaryAmount()).toHaveTextContent('100000 sats')
+    // the wallet holds 100,000 sats (loaded async) next to USDT and DEPIX, so
+    // tapping the balance keeps the 330 sat carrier their change will need
+    await userEvent.click(await screen.findByRole('button', { name: '99,670 sats' }))
+    expect(primaryAmount()).toHaveTextContent('99670 sats')
 
     const continueButton = screen.getByRole('button', { name: 'Continue' })
     await waitFor(() => expect(continueButton).toBeEnabled(), { timeout: 3_000 })
@@ -668,7 +669,7 @@ describe('Wallet swap flow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Confirm swap' }))
 
     await waitFor(() => expect(createSwap).toHaveBeenCalledOnce())
-    expect(createSwap.mock.calls[0][0].deposit.atomic).toBe(BigInt(100_000))
+    expect(createSwap.mock.calls[0][0].deposit.atomic).toBe(BigInt(99_670))
   })
 
   it('offers only the spendable part of an asset held partly in swap escrow', async () => {
@@ -712,7 +713,7 @@ describe('Wallet swap flow', () => {
     renderSwap({
       config: { currency: Currencies.USD, unit: Unit.SATS },
       flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() },
-      wallet: { availableBalance: 1_093_180 },
+      wallet: { availableBalance: 1_093_180, assetBalances: [] },
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
@@ -779,7 +780,11 @@ describe('Wallet swap flow', () => {
   })
 
   it('quotes a sane amount when typing a fiat amount with the display unit set to sats', async () => {
-    renderSwap({ config: { unit: Unit.SATS }, flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() } })
+    renderSwap({
+      config: { unit: Unit.SATS },
+      flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() },
+      wallet: { assetBalances: [] },
+    })
 
     fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
     fireEvent.click(screen.getByRole('button', { name: /USD/i }))
@@ -864,6 +869,7 @@ describe('Wallet swap flow', () => {
     renderSwap({
       config: { unit: Unit.BTC },
       flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() },
+      wallet: { assetBalances: [] },
     })
 
     // the mocked wallet balance (100,000 sats) is shown in whole-BTC terms, at

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -399,8 +399,10 @@ describe('Wallet swap flow', () => {
 
     // the toast lands after four keypad round-trips; the same allowance the
     // Sonner test above gives it, since a busy runner has missed the default
-    await waitFor(() => expect(screen.getByText(/partial swap/)).toBeInTheDocument(), { timeout: 3_000 })
-    expect(screen.getByText(/partial swap/).closest('[data-sonner-toast]')).not.toBeNull()
+    // one lookup: Sonner auto-dismisses after 4s, and a slow runner can cross
+    // that between two separate queries
+    const notice = await screen.findByText(/partial swap/, {}, { timeout: 3_000 })
+    expect(notice.closest('[data-sonner-toast]')).not.toBeNull()
     expect(primaryAmount().className).toContain('swap-amount-display--invalid')
     expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
   })

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -662,9 +662,9 @@ describe('Wallet swap flow', () => {
     fireEvent.click(screen.getByRole('button', { name: /USD/i }))
 
     // the wallet holds 100,000 sats (loaded async) next to USDT and DEPIX, so
-    // tapping the balance keeps the 330 sat carrier their change will need
-    await userEvent.click(await screen.findByRole('button', { name: '99,670 sats' }))
-    expect(primaryAmount()).toHaveTextContent('99670 sats')
+    // tapping the balance keeps the dust carrier their change will need (333 in the mock)
+    await userEvent.click(await screen.findByRole('button', { name: '99,667 sats' }))
+    expect(primaryAmount()).toHaveTextContent('99667 sats')
 
     const continueButton = screen.getByRole('button', { name: 'Continue' })
     await waitFor(() => expect(continueButton).toBeEnabled(), { timeout: 3_000 })
@@ -672,7 +672,7 @@ describe('Wallet swap flow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Confirm swap' }))
 
     await waitFor(() => expect(createSwap).toHaveBeenCalledOnce())
-    expect(createSwap.mock.calls[0][0].deposit.atomic).toBe(BigInt(99_670))
+    expect(createSwap.mock.calls[0][0].deposit.atomic).toBe(BigInt(99_667))
   })
 
   it('offers only the spendable part of an asset held partly in swap escrow', async () => {

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -137,6 +137,9 @@ function renderSwap({
   return { ...view, goBack, navigate }
 }
 
+// the reserve off: the BTC balance is spendable whole only while no asset is held
+const NO_ASSETS = { assetBalances: [] }
+
 const primaryAmount = () => screen.getByRole('button', { name: /^Swap amount,/ })
 const secondaryAmount = () => screen.getByRole('button', { name: /^Show .+ first/ })
 
@@ -352,7 +355,7 @@ describe('Wallet swap flow', () => {
   })
 
   it('replaces the available balance with a max action for insufficient balance', async () => {
-    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() }, wallet: { assetBalances: [] } })
+    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() }, wallet: NO_ASSETS })
 
     for (const key of ['9', '9', '9']) {
       await userEvent.click(screen.getByRole('button', { name: key }))
@@ -371,7 +374,7 @@ describe('Wallet swap flow', () => {
 
   it('keeps non-limit validation errors in Sonner', async () => {
     fetchMocker.mockRejectOnce(new Error('feed unavailable'))
-    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() }, wallet: { assetBalances: [] } })
+    renderSwap({ flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() }, wallet: NO_ASSETS })
 
     fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
     fireEvent.click(screen.getByRole('button', { name: /USD/i }))
@@ -713,7 +716,7 @@ describe('Wallet swap flow', () => {
     renderSwap({
       config: { currency: Currencies.USD, unit: Unit.SATS },
       flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() },
-      wallet: { availableBalance: 1_093_180, assetBalances: [] },
+      wallet: { ...NO_ASSETS, availableBalance: 1_093_180 },
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
@@ -783,7 +786,7 @@ describe('Wallet swap flow', () => {
     renderSwap({
       config: { unit: Unit.SATS },
       flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() },
-      wallet: { assetBalances: [] },
+      wallet: NO_ASSETS,
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
@@ -869,7 +872,7 @@ describe('Wallet swap flow', () => {
     renderSwap({
       config: { unit: Unit.BTC },
       flow: { swapFromAssetId: 'btc', setSwapFromAssetId: vi.fn() },
-      wallet: { assetBalances: [] },
+      wallet: NO_ASSETS,
     })
 
     // the mocked wallet balance (100,000 sats) is shown in whole-BTC terms, at


### PR DESCRIPTION
## Problem

The other half of #968. Swap-all from BTC into DEPIX fails with `Send failed: Error: Insufficient funds` when the wallet also holds assets. The composer's BTC balance is `availableBalance`, which counts the dust carrier under every asset VTXO. Max spends those carriers, coin selection ends up with asset change and no sats left to carry it, and the SDK throws after Confirm.

## Change

Send already keeps one carrier back for a BTC send whenever the wallet holds assets. This lifts that guard into `lib/assets` as `liquidBtcBalance(availableBalance, holdsAssets, dust)` and applies it to the composer's BTC balance. Max, the balance shown under the asset, and the insufficient-balance check all read that one field, so the composer change is one line.

The reserve, both partial-spend guards, and Send's reserve modal now read the operator's `aspInfo.dust` instead of a hardcoded 330. That is the same value the SDK fills into every asset carrier it builds (`wallet.send` defaults a missing recipient amount to `info.dust`), so the reserve matches what coin selection will actually need. It is 0 until the operator answers, which is fine: neither Send nor Swap can proceed without the operator anyway.

One carrier is enough however many asset VTXOs are held: all asset change merges into a single change output.

## Tests

- swap: tapping the balance on a wallet holding USDT and DEPIX funds the balance less one carrier (99,667 of 100,000 sats with the mocked dust of 333) and submits that as the deposit
- five existing swap tests that assert the full 100,000 sats now render a wallet with no assets via a shared `NO_ASSETS` fixture, which is what their numbers were assuming
- the #968 carrier toast test asserts after one keystroke in a single lookup, since the toast lives 2s and a slow runner crossed that window

`pnpm test:unit` (797 passed), `tsc --noEmit`, eslint and prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Scach6mrJUJea2qRDHXyhP