### PR TITLE
fix(receipt): stop a corridor send billing the solver spread twice

### DIFF
--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -216,11 +216,10 @@ export default function Details({ details, variant }: { details?: DetailsProps; 
     ...amountRows,
     ['Price rate', priceRate, <ArrowUpDownIcon key='price-rate-icon' />],
     ['Network fees', fees === undefined ? undefined : formatAmount(fees), <FeesIcon key='fees-icon' />],
-    ['Swap fees', formatSensitiveDetail(swapFees), <FeesIcon key='swap-fees-icon' />],
     [
       'Swap fees',
-      swapFeeSats === undefined ? undefined : formatAmount(swapFeeSats),
-      <FeesIcon key='swap-fee-sats-icon' />,
+      formatSensitiveDetail(swapFees) ?? (swapFeeSats === undefined ? undefined : formatAmount(swapFeeSats)),
+      <FeesIcon key='swap-fees-icon' />,
     ],
     [
       'Recipient gets',

--- a/src/hooks/useCorridorSendReceipt.ts
+++ b/src/hooks/useCorridorSendReceipt.ts
@@ -11,6 +11,8 @@ export interface CorridorSendReceipt {
   claimTxid?: string
   corridor?: string
   recipientGets?: number
+  /** Always 0, always spread: `networkFee` holds the corridor quote's fee, so `Details`' own value bills it twice. */
+  fees: number
   /** The solver's spread, sats — not the network fee. */
   swapFeeSats?: number
   solver?: string
@@ -48,6 +50,7 @@ export function useCorridorSendReceipt(tx: Tx | undefined): CorridorSendReceipt 
     spendLabel: refunded ? 'Refunded' : onchain ? 'Lockup spent' : 'Completed',
     claimTxid: swap?.claimTxid,
     corridor: swap?.corridor ? (CORRIDOR_LABEL[swap.corridor] ?? swap.corridor) : undefined,
+    fees: 0,
     recipientGets: swap?.takeAmount,
     swapFeeSats: swap?.feeAmount,
     solver: swap?.solver,

--- a/src/test/screens/wallet/transaction-ln-send.test.tsx
+++ b/src/test/screens/wallet/transaction-ln-send.test.tsx
@@ -83,6 +83,17 @@ describe('Lightning send receipt', () => {
     expect(screen.getByTestId('Completed')).toHaveTextContent('claim-txid')
   })
 
+  it('bills the solver spread once — it is the swap fee, and not also a network fee', async () => {
+    renderReceipt({
+      ...lnSwapTx({ outcome: 'settled', spendTxid: 'claim-txid', feeAmount: 60, takeAmount: 4940 }),
+      networkFee: 60,
+    })
+
+    expect(await screen.findByTestId('Swap fees')).toHaveTextContent(/^0\.00000060 BTC$/)
+    expect(screen.getByTestId('Recipient gets')).toHaveTextContent(/^0\.00004940 BTC$/)
+    expect(screen.getByTestId('Network fees')).toHaveTextContent(/^0 BTC$/)
+  })
+
   it('calls the second leg a refund, not a cancellation, when the funds came back', async () => {
     // Nobody cancelled anything: the solver could not pay the invoice and the
     // covenant returned the money.


### PR DESCRIPTION
## The bug

A corridor send's receipt showed the solver's fee twice, under two labels, and the totals proved only one fee had been charged:

```
Value            $5.11
Network fees     $0.06
Swap fees        $0.06
Recipient gets   $5.06
Total            $5.11
```

`$5.11 − $5.06 = $0.05`. One fee. Two rows at `$0.06` would leave the recipient `$4.99`.

Both rows read one number by two routes:

- **Swap fees** ← `swapFeeSats`, spread in from `useCorridorSendReceipt` (`swapFeeSats: swap?.feeAmount`), which is `feeAmount: Number(record.fee.amount)` — the solver's quoted spread.
- **Network fees** ← `Details`' `fees`, which on this path is `Transaction`'s own `tx.networkFee ?? (tx.type === 'sent' ? defaultFee : 0)`. `tx.networkFee` is saved by the send screen from the **same corridor quote** (`handleSent(result?.txid, quote.total, quote.fee)` on both swap rails, and `networkFee: details?.fees` from `cost.fee` on the exit path).

**The mechanism is a gap in a spread.** `Transaction` builds the details object with its own `fees`, then spreads `...corridorReceipt` over it. `CorridorSendReceipt` set every `Details` field it owns *except* `fees`, so the value underneath leaked through. The asset-swap branch of the same ternary already passes `fees: 0`; the corridor branch did not.

The code already knew the two were distinct — `swapFeeSats` is documented *"The solver's spread, sats — not the network fee."*

## Why here and not at the source

The alternative is to stop `Send/Details.tsx` writing the quote's spread into `networkFee`. Both fix **new** sends, but only suppressing the row also corrects **receipts already stored** — otherwise every past corridor send keeps rendering a phantom network fee forever, because `networkFee` is persisted per-txid metadata that nothing rewrites.

## Is a real network fee being hidden?

No. The lockup is funded offchain, so there is no miner fee for the sender to pay, and on `arkade -> onchain` the rail prices its L1 claim out of the recipient's payout (`claimFeeRateSatVb`: *"it comes out of the recipient's payout"*), not as a second charge to the sender. The collaborative-exit rail *does* charge a genuine network fee — but it creates no swap record, so `useCorridorSendReceipt` returns `undefined` for it and the spread never happens. Exit sends are untouched.

## One thing to decide

`fees: 0` **shows a zero row**, it does not remove the row. `Table` drops a row only when its value is `''`, `undefined` or `null`, and `formatAmount(0)` returns `'0 BTC'` / `'0 sats'` — which is why the e2e suite asserts `Network fees` `toContainText('0 sats')` on ordinary sends.

So the receipt now reads `Network fees 0 BTC` rather than omitting the line. That is deliberate: it matches the asset-swap branch, matches every other send receipt in the wallet, and states affirmatively that no network fee was taken rather than staying silent about it. **If you would rather the row disappear entirely on corridor receipts, the change is one word — `fees: 0` → `fees: undefined`** — and the test's last assertion becomes `expect(screen.queryByTestId('Network fees')).not.toBeInTheDocument()`.

## Second commit, droppable

`5e3dffb2` collapses two rows that were **both labelled "Swap fees"** — one for `swapFees` (asset-denominated `SwapDisplayAmount`), one for `swapFeeSats` (a number). `Table` keys rows by title and renders it as the DOM `id` and the `data-testid`, so a receipt setting both would render the label twice and leave `Swap fees` ambiguous to `getElementById` and `getByTestId`. Latent today — an asset swap sets the first, a corridor send the second, and no transaction is both — so behaviour is unchanged: the absent row already rendered `null`, and the survivor keeps its position, label and icon. `git revert 5e3dffb2` drops it without touching the fix.

## Base, and #936

**#944 is merged**, so its branch is not a live target — this is based on `ts-sdk-0.5`, where the code actually lives (`master` has none of it). Because #936 *is* `ts-sdk-0.5 → master`, merging this carries the fix into #936 automatically; no separate port is needed. Nothing on `ts-sdk-0.5` itself was pushed.

## Test plan — the manual gate is the only gate

**No tests run on this PR.** `ci.yml` and `playwright.yml` both trigger on `pull_request: branches: [master, next]`, and `branches` matches the **base** — so a PR into `ts-sdk-0.5` runs neither the unit suite nor E2E. Any green check below is a Cloudflare Pages build, not verification. Filed as #966.

Run locally, on Windows, in a clean worktree off `45fbb908`:

| gate | baseline (before) | after |
| --- | --- | --- |
| `pnpm test:unit` | 97 files, 857 passed / 1 skipped (858), exit 0 | 97 files, **858** passed / 1 skipped (859), exit 0 |
| `pnpm lint` | exit 0 | exit 0 |
| `tsc --noEmit` | exit 0 | exit 0 |
| `pnpm format:check` | exit 0 | exit 0 |

Delta is `+1` test and nothing else — the new case, `Lightning send receipt > bills the solver spread once`.

Written failing first. Against the unfixed hook it reports:

```
expect(element).toHaveTextContent()
Expected element to have text content: /^0 BTC$/
Received: 0.00000060 BTC
```

— the Network fees row restating the solver's 60-sat spread. Reverting `useCorridorSendReceipt` alone and re-running turns it red again with the same message, so the test is bound to the fix and not to its neighbours.

**Why the assertion is an anchored regex and not `toContain('0 BTC')`.** The buggy value, `'0.00000060 BTC'`, *ends in* `"0 BTC"` — so the obvious substring assertion would have passed against the exact defect it was written to catch. That is a vacuous-test shape worth naming, because it is not the usual one: not a missing assertion and not a wrong matcher, but a **correct matcher whose looseness the defect happens to satisfy.** `/^0 BTC$/` is deliberate — please keep it anchored.
