### PR TITLE
ci: run the test gate on every PR, not only PRs into master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches: [ master, next ]
+  # No branches filter. pull_request.branches matches the BASE, so any list here
+  # silently runs zero tests on every PR stacked onto an integration branch.
   pull_request:
-    branches: [ master, next ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,8 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches: [master, next]
+  # No branches filter — it matches the BASE, so it skips every stacked PR.
   pull_request:
-    branches: [master, next]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   test:
     name: E2E (${{ matrix.group }} / ${{ matrix.project }})


### PR DESCRIPTION
Fixes #966.

## The defect

Both test workflows carried the same trigger:

```yaml
pull_request:
  branches: [ master, next ]
```

`pull_request.branches` matches the **base**. A PR into anything else therefore runs neither `ci.yml` (format, lint, unit suite, build) nor `playwright.yml` (E2E). Such a PR gets the two Cloudflare Pages builds and nothing more — and those say the site *compiled*, not that it works. From the check list a reader cannot tell it apart from a fully tested PR.

Live cases in this repo, read from the API rather than assumed:

| PR | base | complete check list | outcome |
| --- | --- | --- | --- |
| #944 — reworks the send path | `ts-sdk-0.5` | 2× Cloudflare Pages | merged, zero tests |
| #970 — user-visible fee-display bug | `ts-sdk-0.5` | 2× Cloudflare Pages | merged today 08:35, zero tests |
| #659 — open since 2026-06-10 | `wt-wallet-redesign-followups-20260520` | one CodeRabbit entry, no conclusion | three months, no test check at all |

The list has also already drifted from reality: `git ls-remote --heads origin next` returns nothing. Of the two branches it names, one does not exist.

## The change

Drop `branches:` from `pull_request:` in both files. Every PR now runs the gate regardless of base.

Enumerating instead (`[ master, next, ts-sdk-0.5 ]`) was rejected deliberately. It needs an edit each time an integration branch appears, and when someone forgets, the failure is silent — a PR that runs nothing and looks green. That silent skip *is* the defect, so a fix that reintroduces it isn't one. Each `on:` block carries a one-line note, because a bare `pull_request:` otherwise reads like an oversight to the next person who edits it.

## `push:` — checked, and deliberately left filtered

`push: branches: [ master, next ]` stays as it was. A merge into `ts-sdk-0.5` still runs nothing directly, which is a real if narrower gap. Three reasons not to close it by dropping the filter:

- **The PR run already covers the merged tree.** `actions/checkout` on a `pull_request` event checks out the merge ref, not the head. Confirmed from this PR's own CI log ([34330672657](https://github.com/arkade-os/wallet/actions/runs/34330672657)): `HEAD is now at b4ab6e7 Merge f4dfc5bb into b96ff0c6` — this branch merged into `master`. So the post-merge state is what the PR run exercised, and a `push` run adds signal only when the base moved after the last PR run.
- **Cost.** This repo has **212 remote branches**. An unfiltered `push` fires CI plus four Playwright legs on every push to every one of them.
- **Duplication.** Every push to a PR branch would run twice — once as `push` on `refs/heads/<branch>`, once as `pull_request` on `refs/pull/N/merge`. Those are different concurrency groups, so neither cancels the other.

`workflow_dispatch` stays on both for the manual case. If maintainers want post-merge signal on the integration branch specifically, adding `ts-sdk-0.5` to the **push** list is a reasonable separate change — that's a short list of *trunks*, not a list of *bases*, so it doesn't carry the silent-skip failure mode.

## Concurrency — added, and why the cost doesn't run away

Neither workflow had a `concurrency` group. That already wastes runner time on `master` PRs: `claude/depix-dust-carrier-onramp-482txm` produced four Playwright runs between 06:12 and 06:33 today, all four running to completion, four legs each — 16 jobs where 4 would have done. Turning the gate on for every PR multiplies that.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`github.workflow` is the workflow name, so CI and Playwright land in separate groups and don't cancel each other. `cancel-in-progress` is scoped to `pull_request` on purpose: superseding an outdated PR run is free, but cancelling a `push` run on `master` would leave a trunk commit unverified.

This is the separable half of the PR. Deleting the two `concurrency:` blocks reverts it and leaves the trigger fix intact.

`permissions:` deliberately **not** added: `GET /repos/arkade-os/wallet/actions/permissions/workflow` returns `{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`, so a `contents: read` block would be a no-op here. Neither workflow references `secrets.` or `GITHUB_TOKEN`, and both are `pull_request`, not `pull_request_target`, so fork PRs already got a read-only token and no secrets.

## Playwright needed no more than the trigger change

So both workflows are in scope rather than `ci.yml` alone. It already runs on every `master`-based PR and nothing in it is branch-specific: it installs its own browsers (`playwright install chrome chromium --with-deps`), boots its own regtest stack and nostr relay in-job, and reads no secret. Its one submodule, `ArkLabsHQ/arkade-regtest`, is public (`"visibility": "public"`), so `submodules: recursive` works for fork PRs too.

## What newly goes red: `ts-sdk-0.5` E2E is broken, and this change propagates that

Read this part before merging.

**Unit gate — clean.** Run locally against the branch, not inferred. At `45fbb908`: `pnpm lint` 0, `pnpm format:check` 0, `npx tsc --noEmit` 0, `pnpm test:unit` **97 files / 857 passed / 1 skipped, exit 0**. At `ef1050f0` (current head, after #970 merged): `pnpm test:unit` **97 files / 858 passed / 1 skipped, exit 0**.

**E2E gate — red, and specific to this branch.** `ts-sdk-0.5`'s Playwright run at `45fbb908` failed both `assets-send` legs while both `core` legs passed:

- `src/test/e2e/send-onchain-fallback.test.ts` — three tests (`solver cannot be reached`, `solver never answers`, `completes the send the user walked away from`)
- `src/test/e2e/send.test.ts:356` — `should send sats (some and max) to onchain address with collaborative exit`

Each exhausted all five retries on `page.waitForSelector('text=Payment sent', { timeout: 60_000 })`, on both browser projects. Not a one-off: 24 failing attempts.

`master`'s own Playwright push run earlier the same day ([34319570821](https://github.com/arkade-os/wallet/actions/runs/34319570821), 06:33) was green on **all four** legs, including `assets-send`, which contains that same `send.test.ts` test. So the collaborative-exit send path works on `master` and does not on `ts-sdk-0.5` — the shape of breakage that accumulates on a branch nothing gates.

**Nothing here is skipped, filtered or relabelled to get green.** Two consequences worth being explicit about:

1. This red is already visible today, on #936 (`ts-sdk-0.5 → master`), which is master-based and therefore gated. This PR does not create it.
2. After this merges, PRs stacked *on* `ts-sdk-0.5` inherit it — they will show a red `assets-send` leg they had nothing to do with. That is the gate working, but it needs fixing on `ts-sdk-0.5` rather than here.

One caveat on the unit suite: #936's CI at `ef1050f0` reported a single failure in `swap.test.tsx > quotes the minimum in the asset being sent (BTC), not the asset being received (USDT)`. It did **not** reproduce — that file passes alone (42/42) and the full suite passes at the same SHA locally. One of my three full-suite runs on `master` also produced a single non-reproducing failure (its name was truncated out of the captured output, so I can't say it was the same test). Reading both as flakes rather than breakage; flagged because turning the gate on everywhere will surface flakes more often.

## Precedent

arkade-os/intent-solver#111 made the same argument for that repo's e2e workflow — dropped a label gate so every PR runs, added `push: branches: [main]`. On its first outing it caught a real red within minutes on a leg no PR-level check could previously see (a stale `covclaimd` pin; two tests burning their full timeout). Same gap, same fix, and the red it found is the argument for the change.

## What this PR proves, and what it does not

**This PR is based on `master`, so it runs the gate either way. A green check here does not demonstrate the fix** — `master` already ran.

What is verified:

- Both files parse. `yaml.safe_load` gives triggers `pull_request, push, workflow_dispatch`; `on.pull_request` → `null` (default types, every base); `on.push` → `{"branches": ["master", "next"]}`; the `concurrency` block present in both with `jobs.test` intact.
- `actionlint` (via `rhysd/actionlint`) reports the **same two pre-existing findings before and after** — the `SC2086` in the `pnpm store path` step and `actions/cache@v3` being old — and nothing new. In particular it does not object to the `cancel-in-progress` expression. Were that expression invalid the workflow would fail to parse, which this PR's own CI run would show.

**The case that actually matters — a PR into a non-`master` base — was demonstrated directly**, since a green check on this PR alone would not have shown it. A workflow trigger is read from the *base* branch, so the probe needed a base carrying the fix:

1. Pushed this branch a second time as `tmp/ci966-verify-base`.
2. Opened #972 (draft) from a one-file throwaway head into that base. Base was neither `master` nor `next`.
3. Its check list came up as `test`, `E2E (assets-send / Mobile Chrome)`, `E2E (assets-send / Google Chrome)`, `E2E (core / Mobile Chrome)`, `E2E (core / Google Chrome)` — runs [34330795127](https://github.com/arkade-os/wallet/actions/runs/34330795127) (CI) and [34330795257](https://github.com/arkade-os/wallet/actions/runs/34330795257) (Playwright), both event `pull_request`. That is the same list a `master`-based PR gets and exactly what #944, #970 and #659 never received.
4. Both runs cancelled once the checks appeared — the point was that they were *created*, and cancelling kept the runner cost to about a minute. PR closed, both `tmp/` branches deleted; `git ls-remote --heads origin "refs/heads/tmp/*"` is now empty.

The remaining unverified step is the ordinary one: this has to be on `master` before PRs into `ts-sdk-0.5` pick it up.

Branch protection context: `GET /repos/arkade-os/wallet/branches/master/protection` is `404 Branch not protected`, so no check in this repo currently blocks a merge. This change adds signal, not a new merge gate.

## Test plan

Workflow-only change — nothing under `src/` is touched, and no test reads `.github/` (grepped `src/test` for `workflows`, `ci.yml`, `playwright.yml`, `.github`: no matches). The suite should be identical, and a non-zero delta would mean something was wrong.

Baseline at `b96ff0c6` → this branch:

| | baseline | after |
| --- | --- | --- |
| `pnpm test:unit` | 90 files / 797 passed / 1 skipped, exit 0 | 90 files / 797 passed / 1 skipped, exit 0 |
| `pnpm lint` | 0 | 0 |
| `pnpm format:check` | 0 | 0 |
| `npx tsc --noEmit` | 0 | 0 |

Delta: zero, as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Continuous integration checks now run for pull requests targeting any branch.
  * Redundant in-progress pull request checks are automatically canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->