### PR TITLE
TEMPORARY: verification probe for #966 - do not review, closing immediately

### DIFF
--- a/.ci966-trigger-probe
+++ b/.ci966-trigger-probe
@@ -1,0 +1,1 @@
+temporary probe for issue 966 verification; branch is deleted immediately after


### PR DESCRIPTION
Throwaway probe for #971 / #966. Base is `tmp/ci966-verify-base`, not `master`, and that base carries the trigger fix. Purpose is only to observe whether `test` and the four `E2E` checks are created on a non-master base. Closed and both branches deleted as soon as the check list appears.