### PR TITLE
TEMPORARY probe C - do not review, closing shortly

### DIFF
--- a/.ci966-probeC
+++ b/.ci966-probeC
@@ -1,0 +1,1 @@
+probe C: head has the fix, base does not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches: [ master, next ]
+  # No branches filter. pull_request.branches matches the BASE, so any list here
+  # silently runs zero tests on every PR stacked onto an integration branch.
   pull_request:
-    branches: [ master, next ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,8 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches: [master, next]
+  # No branches filter — it matches the BASE, so it skips every stacked PR.
   pull_request:
-    branches: [master, next]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   test:
     name: E2E (${{ matrix.group }} / ${{ matrix.project }})


### PR DESCRIPTION
Throwaway. Base is a copy of `ts-sdk-0.5` WITHOUT the #971 fix; the HEAD has `origin/master` merged in so it DOES carry the fix. Isolating whether the base branch or the merge commit decides. Deleted shortly.