### PR TITLE
Adopt CAIP-19 and swap restore via published packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "homepage": ".",
   "dependencies": {
     "@arkade-os/solver-discovery": "0.2.3",
-    "@arkade-os/sdk": "0.4.71",
-    "@arkade-os/swap": "0.0.14",
+    "@arkade-os/sdk": "0.4.72",
+    "@arkade-os/swap": "0.0.15",
     "@base-ui/react": "^1.4.1",
     "@branta-ops/branta": "3.1.3",
     "@fontsource-variable/geist": "^5.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@arkade-os/sdk': 0.4.72
   '@babel/core': '>=7.29.6 <8.0.0'
   js-yaml@<4: '>=3.15.0 <4.0.0'
   js-yaml@>=4: '>=4.2.0 <5.0.0'
@@ -16,14 +17,14 @@ importers:
   .:
     dependencies:
       '@arkade-os/sdk':
-        specifier: 0.4.71
-        version: 0.4.71
+        specifier: 0.4.72
+        version: 0.4.72
       '@arkade-os/solver-discovery':
         specifier: 0.2.3
         version: 0.2.3
       '@arkade-os/swap':
-        specifier: 0.0.14
-        version: 0.0.14(nostr-tools@2.17.2(typescript@5.9.3))
+        specifier: 0.0.15
+        version: 0.0.15(nostr-tools@2.17.2(typescript@5.9.3))
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.26)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -253,8 +254,8 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@arkade-os/sdk@0.4.71':
-    resolution: {integrity: sha512-gLoHL40EPi21+XlZzxMVfLYl4nWNVXqhRIwksV0vzSb8ID+hfYl9PYm5cgazEwxFkP/tm08C2uK72QjSAkG94A==}
+  '@arkade-os/sdk@0.4.72':
+    resolution: {integrity: sha512-u0h+oLu+l9//VBQxroIgHjXTdfQsOZZGfmXKkmZj5SzaozsDH6L2FDUbUtzGlNZF/UBKqcwwBHb4PzsP8unjZQ==}
     engines: {node: '>=22.12.0 <27'}
     peerDependencies:
       '@react-native-async-storage/async-storage': '>=1.0.0'
@@ -278,8 +279,8 @@ packages:
     resolution: {integrity: sha512-i77/BCAmHY4fec41HfYb5osu+QkCEOf2jLha1HX5pkp6bHGrm10WG8eOGREKqPCC4bOI3E8cKwEVGxP0qlNt5g==}
     engines: {node: '>=18'}
 
-  '@arkade-os/swap@0.0.14':
-    resolution: {integrity: sha512-Wn159smG1KrcJk9oCyp4MCLK1cLeiNEGUeYuQNQcKZ8SMxLRW2J3sf34KK4EJVOfuU1nDOgLcb8fsL2A8Wm8vw==}
+  '@arkade-os/swap@0.0.15':
+    resolution: {integrity: sha512-G7XQs9YwtfxVCNMUFj4/JvmymdoEZbr2jcTZExE+ogebbamqRDW8OWyIXOw6s9dp4gjg1JSkuxJf9v1RGgobMA==}
     peerDependencies:
       nostr-tools: ^2.12.0
     peerDependenciesMeta:
@@ -4359,7 +4360,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@arkade-os/sdk@0.4.71':
+  '@arkade-os/sdk@0.4.72':
     dependencies:
       '@bitcoinerlab/descriptors-scure': 3.1.7
       '@marcbachmann/cel-js': 8.0.0
@@ -4380,9 +4381,9 @@ snapshots:
 
   '@arkade-os/solver-discovery@0.2.3': {}
 
-  '@arkade-os/swap@0.0.14(nostr-tools@2.17.2(typescript@5.9.3))':
+  '@arkade-os/swap@0.0.15(nostr-tools@2.17.2(typescript@5.9.3))':
     dependencies:
-      '@arkade-os/sdk': 0.4.71
+      '@arkade-os/sdk': 0.4.72
       '@arkade-os/solver-discovery': 0.2.3
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ onlyBuiltDependencies:
   - '@arkade-os/sdk'
 
 overrides:
+  '@arkade-os/sdk': '0.4.72'
   '@babel/core': '>=7.29.6 <8.0.0'
   js-yaml@<4: '>=3.15.0 <4.0.0'
   js-yaml@>=4: '>=4.2.0 <5.0.0'

--- a/src/lib/activityHistory.ts
+++ b/src/lib/activityHistory.ts
@@ -199,24 +199,6 @@ const ungroupedLnSendTx = (send: LnSendView, metadata: Record<string, Transactio
   )
 
 /**
- * One row for an offer whose funding tx Arkade's history does not report.
- *
- * Same shape of problem as `ungroupedLnSendTx`, same answer: `createOffer`
- * registers the covenant as a contract of this wallet, so the deposit reads as
- * change and `buildTransactionHistory` drops the tx on its `txAmount !== 0`
- * guard. A resting offer may never be spent, so nothing would ever appear.
- * Keyed as the resolver would key it, so the real row replaces this one.
- */
-const ungroupedOfferTx = (
-  swap: WalletAssetSwap,
-  { network, assetDisplay }: Pick<ActivityHistoryOptions, 'network' | 'assetDisplay'>,
-): Tx => ({
-  ...buildAssetSwapActivityTx(swap, [], { network, assetDisplay }),
-  amount: swap.fromAsset === 'btc' ? Number(swap.fromAmount) : 0,
-  historyKey: `swap:${swap.id}`,
-})
-
-/**
  * One row for a unilateral exit, which Arkade's history does not report.
  *
  * The sent side of `buildTransactionHistory` is gated on `isSpent`, and the SDK
@@ -308,11 +290,6 @@ export const activitiesToTxs = (activities: Activity[], options: ActivityHistory
   const grouped = new Set(activities.flatMap((activity) => rfqIdOf(activity) ?? []))
   for (const send of lnSends) {
     if (!grouped.has(send.rfqId)) rows.push(ungroupedLnSendTx(send, metadata))
-  }
-  // The offers history cannot see either — see `ungroupedOfferTx`.
-  const groupedSwaps = new Set(activities.flatMap((activity) => swapIdOf(activity) ?? []))
-  for (const swap of swaps) {
-    if (!groupedSwaps.has(swap.id)) rows.push(ungroupedOfferTx(swap, { network, assetDisplay }))
   }
   // Exits last, for the same reason: history reports none of them either.
   for (const exit of exits) rows.push(exitTx(exit))

--- a/src/lib/importRestore.ts
+++ b/src/lib/importRestore.ts
@@ -1,0 +1,14 @@
+import type { IWallet } from '@arkade-os/sdk'
+import { registerAssetSwapRestore, type RegisterAssetSwapRestoreOptions } from '@arkade-os/swap'
+
+export type RestorableWallet = IWallet & {
+  restore(options?: { gapLimit?: number }): Promise<void>
+}
+
+export const restoreImportedWallet = async (
+  wallet: RestorableWallet,
+  options: RegisterAssetSwapRestoreOptions,
+): Promise<void> => {
+  registerAssetSwapRestore(wallet, options)
+  await wallet.restore()
+}

--- a/src/lib/lnSwap.ts
+++ b/src/lib/lnSwap.ts
@@ -25,7 +25,7 @@
 import { hex } from '@scure/base'
 import { sideLimits, type DiscoveredMarket, type Side } from '@arkade-os/solver-discovery'
 import type { NetworkName, RestIndexerProvider } from '@arkade-os/sdk'
-import { requestLightningSend, type InvoiceFacts, type RfqTransport } from '@arkade-os/swap'
+import { marketCorridor, requestLightningSend, type InvoiceFacts, type RfqTransport } from '@arkade-os/swap'
 import { decodeInvoice, invoiceMatchesNetwork, isInvoiceExpired, type DecodedInvoice } from './bolt11'
 import type { LnSendRecordFacts } from './lnSendRecords'
 
@@ -181,7 +181,8 @@ const lnRendezvous = (
 ): LnSendRendezvous | undefined => {
   const pinned = fallbackEmulatorPubkey ? hex.encode(fallbackEmulatorPubkey) : undefined
   for (const market of markets) {
-    if (market.quote_corridor !== 'lightning') continue
+    if (marketCorridor(market, 'quote') !== 'bolt11') continue
+    if (marketCorridor(market, 'base') !== 'arkade') continue
     const transports = {
       nostr: {
         relays: market.transports?.nostr?.relays ?? [],

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -169,16 +169,26 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
     if (changed) applySwaps(list)
   }
 
+  const discoveryGeneration = useRef(0)
+  const backfillQueue = useRef<Promise<void>>(Promise.resolve())
+
   const runDiscovery = (network: NetworkName, useCache: boolean) => {
+    const generation = ++discoveryGeneration.current
     discoverMarkets(network, useCache)
       // Corridor (RFQ) markets — the bundled Lightning-send card — are not
       // tradeable here: this provider builds offers, and a corridor is
       // negotiated with a solver instead. Keeping them would let one Lightning
       // card turn the whole swap surface on with nothing behind it.
       .then((all) => {
+        if (generation !== discoveryGeneration.current) return
         const available = all.filter((m) => !isRfqMarket(m))
         setMarkets(available)
-        backfillMissingFees(available).catch((err) => consoleError(err, 'failed to backfill asset swap fees'))
+        backfillQueue.current = backfillQueue.current
+          .then(async () => {
+            if (generation !== discoveryGeneration.current) return
+            await backfillMissingFees(available)
+          })
+          .catch((err) => consoleError(err, 'failed to backfill asset swap fees'))
       })
       .catch((err) => consoleError(err, 'solver discovery failed'))
   }

--- a/src/providers/assetSwaps.tsx
+++ b/src/providers/assetSwaps.tsx
@@ -27,7 +27,8 @@ import {
   decodeOffer,
   findMarket,
   getAssetSwaps,
-  restoreAssetSwaps,
+  isRfqMarket,
+  restoreAssetSwapRepository,
   retireSettledOfferContracts,
   spendTxidsOf,
   spendUpdate,
@@ -154,13 +155,31 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
     [aspInfo.network],
   )
 
+  const backfillMissingFees = async (availableMarkets: DiscoveredMarket[]) => {
+    let list = await readSwaps()
+    let changed = false
+    for (const swap of list) {
+      if (swap.quote?.feeBps !== undefined) continue
+      const feeBps = findMarket(availableMarkets, swap.fromAsset, swap.toAsset)?.market?.fee_bps
+      if (feeBps === undefined) continue
+      const changes: Partial<WalletAssetSwap> = { quote: { ...swap.quote, feeBps } }
+      list = (await updateAssetSwap(assetSwapRepository, swap.id, changes)) as WalletAssetSwap[]
+      changed = true
+    }
+    if (changed) applySwaps(list)
+  }
+
   const runDiscovery = (network: NetworkName, useCache: boolean) => {
     discoverMarkets(network, useCache)
       // Corridor (RFQ) markets — the bundled Lightning-send card — are not
       // tradeable here: this provider builds offers, and a corridor is
       // negotiated with a solver instead. Keeping them would let one Lightning
       // card turn the whole swap surface on with nothing behind it.
-      .then((all) => setMarkets(all.filter((m) => !m.quote_corridor)))
+      .then((all) => {
+        const available = all.filter((m) => !isRfqMarket(m))
+        setMarkets(available)
+        backfillMissingFees(available).catch((err) => consoleError(err, 'failed to backfill asset swap fees'))
+      })
       .catch((err) => consoleError(err, 'solver discovery failed'))
   }
 
@@ -189,12 +208,10 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   //
   // The scan is incremental but not one-shot: answered txids persist, so
   // late-synced history is picked up by later runs and nothing is fetched
-  // twice, while a record still open is re-asked until the chain answers it.
-  // That second part is what a rebuilt record needs. `createOffer` registers
-  // the covenant and the watcher rides those contract events; a record the
-  // scan rebuilt has no contract behind it, so no watcher event and no
-  // `reconcileUnseenSpends` pass can ever reach it. Its only route to an
-  // outcome is another scan.
+  // twice. Open records travel through the package's explicit `reopen` path,
+  // which preserves their wallet-only fields while re-asking the chain for a
+  // definite outcome. Coverage restoration above also re-registers rebuilt
+  // covenants so later spends reach the live watcher.
   const scanningRef = useRef(false)
   const rescanRef = useRef(false)
   // Bumped to re-enter the effect when a queued rescan has to start, since no
@@ -215,17 +232,15 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
   // A token rather than a cancellation flag: this cleanup fires only when the
   // wallet changed or the provider went away, and `txs`, which must not abandon
   // a running scan, is deliberately not a dependency.
-  const scanTokenRef = useRef({ live: true })
+  const scanTokenRef = useRef(new AbortController())
   useEffect(() => {
-    const token = { live: true }
+    const token = new AbortController()
     scanTokenRef.current = token
-    return () => {
-      token.live = false
-    }
-  }, [aspInfo.url, aspInfo.signerPubkey, dataReady])
+    return () => token.abort()
+  }, [svcWallet, aspInfo.url, aspInfo.signerPubkey, dataReady])
 
   useEffect(() => {
-    if (!aspInfo.url || !aspInfo.signerPubkey || !dataReady || ungroupedTxs.length === 0) return
+    if (!svcWallet || !aspInfo.url || !aspInfo.signerPubkey || !dataReady) return
     // A run is already in flight and cannot see this newer history: ask it to go
     // round again instead of dropping the change. Returning without this is what
     // made a skipped run a lost one.
@@ -233,65 +248,33 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
       rescanRef.current = true
       return
     }
-    // the repository clears asynchronously on a wallet reset, so this is
-    // re-checked before every write below rather than once
     const token = scanTokenRef.current
-    const stale = () => !token.live
+    const stale = () => token.signal.aborted
     const scan = async () => {
-      const [existing, scanned] = await Promise.all([readSwaps(), assetSwapRepository.getScannedTxids()])
-      // Both skip lists exempt open records, and they have to agree: an id in
-      // `existingIds` or a txid in `scanned` is dropped before the scan reads
-      // it. The cost of exempting them is one psbt and one vtxo lookup per open
-      // swap per history change, and it stops the moment the swap settles.
-      const open = new Map(existing.filter(isOpen).map((swap) => [swap.id, swap]))
-      const { restored, scannedTxids } = await restoreAssetSwaps(
-        new RestIndexerProvider(aspInfo.url),
-        txsRef.current,
-        new Set(existing.filter((swap) => !isOpen(swap)).map((swap) => swap.id)),
-        {
-          serverPubkey: xOnlyServerKey(aspInfo.signerPubkey),
-          scanned: new Set([...scanned].filter((txid) => !open.has(txid))),
-        },
-      )
-      if (stale()) return
-      // a run with nothing new to answer for opens no transaction at all
-      if (scannedTxids.length > 0) await assetSwapRepository.markTxidsScanned(scannedTxids)
-      if (restored.length === 0) return
-      let next: WalletAssetSwap[] | undefined
-      const resolved: AssetSwap[] = []
-      for (const swap of restored) {
-        if (stale()) return
-        const stored = open.get(swap.id)
-        if (!stored) {
-          // quote-time facts are not on chain; the fee rate is the one fact a
-          // restore can backfill, from the pair's current market card — an
-          // approximation if the solver changed its fee since the swap.
-          // TODO: delete this backfill once fee bps rides in a packet inside
-          // the funding tx — restoreAssetSwaps will then decode the actual
-          // historic rate from chain, like it already does the offer.
+      const result = await restoreAssetSwapRepository({
+        wallet: svcWallet,
+        arkServerUrl: aspInfo.url,
+        indexer: new RestIndexerProvider(aspInfo.url),
+        repository: assetSwapRepository,
+        txs: txsRef.current,
+        serverPubkey: xOnlyServerKey(aspInfo.signerPubkey),
+        signal: token.signal,
+        prepareNew: (swap) => {
+          // Quote-time facts are not on chain. Backfill the fee from the
+          // pair's current card until it rides in the funding packet.
           const feeBps = findMarket(marketsRef.current, swap.fromAsset, swap.toAsset)?.market?.fee_bps
-          next = (await addAssetSwap(
-            assetSwapRepository,
-            feeBps === undefined ? swap : ({ ...swap, quote: { feeBps } } as AssetSwap),
-          )) as WalletAssetSwap[]
-          continue
-        }
-        // `pending` is the absence of an answer, not one: writing it back would
-        // say nothing, and over a cancel in flight it would lose that status.
-        if (swap.status === 'pending' || swap.status === stored.status) continue
-        // Only the outcome. The scan rebuilds every field from chain, so
-        // writing the record whole would drop what only this wallet holds: the
-        // quote snapshot, and the funded address a cancel needs, which a
-        // restored record carries as an empty string.
-        next = (await updateAssetSwap(assetSwapRepository, swap.id, {
-          status: swap.status,
-          ...(swap.spentTxid ? { spentTxid: swap.spentTxid } : {}),
-          ...(swap.completedAt ? { completedAt: swap.completedAt } : {}),
-        })) as WalletAssetSwap[]
-        resolved.push(swap)
+          return feeBps === undefined ? swap : ({ ...swap, quote: { feeBps } } as AssetSwap)
+        },
+      })
+      if (result.aborted || stale()) return
+      if (result.coverageError) {
+        consoleError(result.coverageError, 'swap covenant coverage restore failed')
       }
-      if (!next || stale()) return
-      const list = applySwaps(next)
+      if (result.changes.length === 0) return
+      const list = applySwaps(result.swaps)
+      const resolved = result.changes
+        .filter(({ previous, current }) => previous && previous.status !== current.status)
+        .map(({ current }) => current)
       for (const swap of resolved) announceOutcome(swap)
       // a covenant this run settled is still in the watched set. Liveness is a
       // property of every record at a script, so the list goes whole.
@@ -309,14 +292,14 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
         scanningRef.current = false
         // the CURRENT token, not this run's: a run whose token died is exactly
         // the one whose queued work still has to happen, under its replacement
-        if (!rescanRef.current || !scanTokenRef.current.live) return
+        if (!rescanRef.current || scanTokenRef.current.signal.aborted) return
         rescanRef.current = false
         // through the effect, not a direct call: this closure is bound to the
         // wallet it started with, a fresh run reads the current one
         setScanTick((tick) => tick + 1)
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [aspInfo.url, aspInfo.signerPubkey, dataReady, ungroupedTxs, scanTick])
+  }, [svcWallet, aspInfo.url, aspInfo.signerPubkey, dataReady, ungroupedTxs, scanTick])
 
   // read through a ref so the watcher (which deliberately does not rebind on
   // market refreshes) always names assets from the current list
@@ -559,15 +542,13 @@ export const AssetSwapsProvider = ({ children }: { children: ReactNode }) => {
    * the stale cached rows it diffed against, which carry no spend txid. Either
    * way the record keeps `pending`, and `assetSwapResolver` indexes only
    * `fundingTxid` and `spentTxid`, so the fill tx cannot bind to the swap and
-   * one swap renders as two rows: the funding row `ungroupedOfferTx`
-   * synthesizes, plus the fill as a bare received one.
+   * one swap renders as two rows: the gated funding row the SDK exposes, plus
+   * the fill as a bare received one.
    *
-   * This pass and the restore scan cover each other's blind spot, because they
-   * read different sources. This one reads the wallet's contract rows, so it
-   * needs the covenant registered — which `createOffer` does, and a rebuilt
-   * record never had. The scan reads chain, so it needs the funding tx to
-   * surface in history as a *sent* row — which it does not while the covenant
-   * is registered and the deposit still counts as the wallet's own.
+   * This pass reads the wallet's contract rows, so it needs the covenant
+   * registered; `createOffer` does that immediately and the SDK repository
+   * restore repairs it for records rebuilt from seed. The scan reads chain
+   * directly and reopens stored records from their offer packet.
    *
    * The spend is classified from the covenant leaf it took, exactly as the
    * watcher and the scan classify theirs (`classifyDeposit`), off one indexer

--- a/src/providers/wallet.tsx
+++ b/src/providers/wallet.tsx
@@ -17,6 +17,7 @@ import {
   type Activity,
   type Identity,
   type ServiceWorkerWalletMode,
+  toXOnlySignerHex,
 } from '@arkade-os/sdk'
 import {
   clearStorage,
@@ -67,6 +68,7 @@ import {
 import { AssetIconApprovalManager } from '../lib/assetIconApproval'
 import { IndexedDBStorageAdapter } from '@arkade-os/sdk/adapters/indexedDB'
 import { BackupContext } from './backup'
+import { restoreImportedWallet } from '../lib/importRestore'
 
 const SERVICE_WORKER_ACTIVATION_TIMEOUT_MS = 5_000
 const MESSAGE_BUS_INIT_TIMEOUT_MS = 30_000
@@ -722,7 +724,12 @@ export const WalletProvider = ({ children }: { children: ReactNode }) => {
       if (restoring) {
         setLoadingStatus('Recovering addresses...')
         try {
-          await svcWallet.restore()
+          await restoreImportedWallet(svcWallet, {
+            arkServerUrl,
+            repository: assetSwapRepository,
+            indexer: activityIndexer,
+            ...(aspInfo.signerPubkey ? { serverPubkey: hex.decode(toXOnlySignerHex(aspInfo.signerPubkey)) } : {}),
+          })
         } catch (err) {
           consoleError(err, 'Error scanning for rotated addresses on restore')
         }

--- a/src/screens/Settings/Solvers.tsx
+++ b/src/screens/Settings/Solvers.tsx
@@ -5,6 +5,7 @@ import Content from '../../components/Content'
 import Header from './Header'
 import Text, { TextSecondary } from '../../components/Text'
 import { Card, LocalCardInput, validateCard, Network } from '@arkade-os/solver-discovery'
+import { marketPairLabel } from '@arkade-os/swap'
 import { readSolverCards, saveSolverCards } from '@/lib/solverCards'
 import { BUNDLED_CARDS } from '@/lib/swapMarkets'
 import FlexRow from '@/components/FlexRow'
@@ -125,7 +126,7 @@ function Editor({ card, toClose, onChange }: { card?: Card; toClose?: () => void
  */
 function BundledCardLine({ input }: { input: LocalCardInput }) {
   const card = input.card as Card
-  const pairs = card.markets?.map((m) => m.pair).join(', ') ?? ''
+  const pairs = card.markets?.map(marketPairLabel).join(', ') ?? ''
   const [showCard, setShowCard] = useState(false)
 
   const toggleShowCard = () => {
@@ -158,7 +159,7 @@ function CardLine({ input, onChange }: { input: LocalCardInput; onChange: () => 
   const [error, setError] = useState<string>('')
 
   const card = input.card as Card
-  const pairs = card.markets?.map((m) => m.pair).join(', ') ?? ''
+  const pairs = card.markets?.map(marketPairLabel).join(', ') ?? ''
 
   const handleConfirmRemove = () => {
     setConfirmRemove(true)

--- a/src/test/corridor-solver.card.json
+++ b/src/test/corridor-solver.card.json
@@ -1,0 +1,32 @@
+{
+  "version": 0,
+  "name": "corridor-solver",
+  "discovery_pubkey": "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659",
+  "transports": {
+    "nostr": {
+      "relays": ["wss://relay.example.com"]
+    }
+  },
+  "markets": [
+    {
+      "base_asset": {
+        "id": "arkade:bitcoin/slip44:0",
+        "name": "Bitcoin",
+        "ticker": "BTC",
+        "decimals": 8
+      },
+      "quote_asset": {
+        "id": "bolt11:bitcoin/slip44:0",
+        "name": "Bitcoin",
+        "ticker": "BTC",
+        "decimals": 8
+      },
+      "fee_bps": 20,
+      "min_base_amount": "1000",
+      "max_base_amount": "4000000",
+      "min_quote_amount": "1000",
+      "max_quote_amount": "4000000"
+    }
+  ],
+  "sig": "99479b6cc8117d6ea3aa00eade3a842110c9e2d25280dbabdb12856f87477604487b16225ef72049b4be2da04e1607a65a0ed5335f04cdf24c46f6d0243f1651"
+}

--- a/src/test/lib/importRestore.test.ts
+++ b/src/test/lib/importRestore.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const events: string[] = []
+const registerAssetSwapRestore = vi.hoisted(() =>
+  vi.fn(() => {
+    events.push('register')
+    return () => undefined
+  }),
+)
+
+vi.mock('@arkade-os/swap', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@arkade-os/swap')>()),
+  registerAssetSwapRestore,
+}))
+
+import { restoreImportedWallet, type RestorableWallet } from '../../lib/importRestore'
+
+describe('restoreImportedWallet', () => {
+  beforeEach(() => {
+    events.length = 0
+    registerAssetSwapRestore.mockClear()
+  })
+
+  it('registers swap recovery before explicit wallet recovery', async () => {
+    const wallet = {
+      restore: vi.fn(async () => void events.push('restore')),
+    } as unknown as RestorableWallet
+    const repository = { name: 'asset swaps' }
+    const indexer = { name: 'indexer' }
+    const serverPubkey = new Uint8Array(32).fill(0xab)
+
+    await restoreImportedWallet(wallet, {
+      arkServerUrl: 'https://ark.test',
+      repository: repository as never,
+      indexer: indexer as never,
+      serverPubkey,
+    })
+
+    expect(events).toEqual(['register', 'restore'])
+    expect(registerAssetSwapRestore).toHaveBeenCalledWith(wallet, {
+      arkServerUrl: 'https://ark.test',
+      repository,
+      indexer,
+      serverPubkey,
+    })
+  })
+})

--- a/src/test/lib/lnReceive.test.ts
+++ b/src/test/lib/lnReceive.test.ts
@@ -77,6 +77,17 @@ describe('lnReceiveRendezvous', () => {
     expect(lnReceiveRendezvous([market({ transports: undefined })])).toBeUndefined()
     expect(lnReceiveRendezvous([market({ quote_corridor: 'onchain' })])).toBeUndefined()
   })
+
+  it('rejects a Lightning quote whose receive side is not Arkade', () => {
+    expect(
+      lnReceiveRendezvous([
+        market({
+          base_asset: { id: 'bitcoin:bitcoin/slip44:0' },
+          quote_asset: { id: 'bolt11:bitcoin/slip44:0' },
+        }),
+      ]),
+    ).toBeUndefined()
+  })
 })
 
 const MUTINYNET_COVCLAIMD_PK = '034eb1f33220c697a5eab424e9f3b053760fa635f7bd9cc39c15bcecd30b5bf59d'

--- a/src/test/lib/lnSendRendezvous.test.ts
+++ b/src/test/lib/lnSendRendezvous.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from 'vitest'
 import { discover, sideLimits, validateCard, type DiscoveredMarket } from '@arkade-os/solver-discovery'
+import { marketCorridor } from '@arkade-os/swap'
 import betaSolverCard from '../../lib/beta-solver.card.json'
 import { lnSendRendezvous } from '../../lib/lnSwap'
 
@@ -24,7 +25,7 @@ describe('bundled Arkade Labs solver card', () => {
     const { markets, warnings } = await load()
     expect(warnings).toEqual([])
     expect(markets).toHaveLength(1)
-    expect(markets[0].quote_corridor).toBe('lightning')
+    expect(marketCorridor(markets[0], 'quote')).toBe('bolt11')
   })
 
   it('carries the rendezvous through discovery, so the maker can address the solver', async () => {

--- a/src/test/lib/marketCorridor.test.ts
+++ b/src/test/lib/marketCorridor.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import { hex } from '@scure/base'
+import type { DiscoveredMarket } from '@arkade-os/solver-discovery'
+import { isRfqMarket, marketCorridor, marketPairLabel } from '@arkade-os/swap'
+import { lnReceiveRendezvous, lnSendRendezvous } from '../../lib/lnSwap'
+import corridorSolverCard from '../corridor-solver.card.json'
+
+// A market written by hand would pass fixed or not, since #23 removes fields
+// rather than changing types — so the new-shape cases use the registry's own
+// `corridor-solver` fixture, copied verbatim from the #23 branch.
+
+const EMULATOR = new Uint8Array(32).fill(0xcc)
+
+/** The card's markets as discovery hands them over: card rendezvous propagated onto each. */
+const discovered = (card: typeof corridorSolverCard): DiscoveredMarket[] =>
+  card.markets.map(
+    (market) =>
+      ({
+        ...market,
+        discovery_pubkey: card.discovery_pubkey,
+        transports: card.transports,
+      }) as unknown as DiscoveredMarket,
+  )
+
+const newFormat = () => discovered(corridorSolverCard)
+
+const oldFormat = (): DiscoveredMarket[] =>
+  newFormat().map(
+    (market) =>
+      ({
+        ...market,
+        pair: 'BTC/lightning:BTC',
+        base_asset: { ...(market.base_asset as object), id: 'btc' },
+        quote_asset: { ...(market.quote_asset as object), id: 'btc' },
+        quote_corridor: 'lightning',
+      }) as unknown as DiscoveredMarket,
+  )
+
+describe('corridor derivation across the #23 schema change', () => {
+  it('reads the corridor off a new-format asset id', () => {
+    const [market] = newFormat()
+    expect(marketCorridor(market, 'base')).toBe('arkade')
+    expect(marketCorridor(market, 'quote')).toBe('bolt11')
+  })
+
+  it('still reads the corridor off a pre-#23 card, which is what the live index serves today', () => {
+    const [market] = oldFormat()
+    expect(marketCorridor(market, 'base')).toBe('arkade')
+    expect(marketCorridor(market, 'quote')).toBe('bolt11')
+  })
+
+  it('defaults a spot market to the arkade rail in both shapes', () => {
+    const spot = {
+      base_asset: { id: 'arkade:bitcoin/slip44:0' },
+      quote_asset: { id: 'arkade:bitcoin/asset:' + 'a'.repeat(68) },
+    }
+    expect(isRfqMarket(spot)).toBe(false)
+    expect(isRfqMarket({ base_asset: { id: 'btc' }, quote_asset: { id: 'f'.repeat(68) } })).toBe(false)
+  })
+
+  it('treats an unrecognised namespace as arkade rather than inventing a rail', () => {
+    expect(marketCorridor({ quote_asset: { id: 'ripple:mainnet/slip44:144' } }, 'quote')).toBe('arkade')
+  })
+
+  it('prefers the asset id over the deprecated compat field the published index still carries', () => {
+    // The index keeps `quote_corridor` as a compat field in the v0 spelling
+    // (`lightning`, not `bolt11`); the id is canonical, so it wins either way.
+    const agreeing = { quote_asset: { id: 'bolt11:bitcoin/slip44:0' }, quote_corridor: 'lightning' }
+    expect(marketCorridor(agreeing, 'quote')).toBe('bolt11')
+    const disagreeing = { quote_asset: { id: 'bolt11:bitcoin/slip44:0' }, quote_corridor: 'onchain' }
+    expect(marketCorridor(disagreeing, 'quote')).toBe('bolt11')
+  })
+
+  it('labels a corridor market for display now that `pair` is gone', () => {
+    expect(marketPairLabel(newFormat()[0])).toBe('BTC/bolt11:BTC')
+  })
+})
+
+describe('lightning send survives the #23 schema change', () => {
+  it('finds a rendezvous on a new-format card', () => {
+    const rendezvous = lnSendRendezvous(newFormat(), EMULATOR)
+    expect(rendezvous).toBeDefined()
+    expect(rendezvous?.solverPubkey).toBe(corridorSolverCard.discovery_pubkey)
+    expect(rendezvous?.emulatorPubkey).toBe(hex.encode(EMULATOR))
+    expect(rendezvous?.minSats).toBe(Number(corridorSolverCard.markets[0].min_quote_amount))
+    expect(rendezvous?.maxSats).toBe(Number(corridorSolverCard.markets[0].max_quote_amount))
+  })
+
+  it('still finds a rendezvous on a pre-#23 card', () => {
+    expect(lnSendRendezvous(oldFormat(), EMULATOR)).toBeDefined()
+  })
+
+  it('finds the receive leg on a new-format card, reading the base side bounds', () => {
+    const rendezvous = lnReceiveRendezvous(newFormat(), EMULATOR)
+    expect(rendezvous?.minSats).toBe(Number(corridorSolverCard.markets[0].min_base_amount))
+  })
+
+  it('skips a market on another rail instead of quoting it as Lightning', () => {
+    const onchain = newFormat().map(
+      (market) =>
+        ({
+          ...market,
+          quote_asset: { ...(market.quote_asset as object), id: 'bitcoin:bitcoin/slip44:0' },
+        }) as DiscoveredMarket,
+    )
+    expect(lnSendRendezvous(onchain, EMULATOR)).toBeUndefined()
+  })
+})
+
+describe('the spot swap surface excludes corridor markets', () => {
+  it('excludes a new-format corridor market', () => {
+    expect(newFormat().filter((m) => !isRfqMarket(m))).toEqual([])
+  })
+
+  it('excludes a pre-#23 corridor market', () => {
+    expect(oldFormat().filter((m) => !isRfqMarket(m))).toEqual([])
+  })
+
+  it('excludes a market whose non-arkade side is the base leg, which the dropped-field check missed', () => {
+    const baseSideCorridor = {
+      base_asset: { id: 'bolt11:bitcoin/slip44:0' },
+      quote_asset: { id: 'arkade:bitcoin/slip44:0' },
+    }
+    expect(isRfqMarket(baseSideCorridor)).toBe(true)
+  })
+})
+
+const ERC20_ID = 'eip155:1/erc20:0x' + 'a'.repeat(40)
+
+describe('the index deprecation window, where an entry carries both shapes', () => {
+  // solver-registry bc07a02 keeps `pair` and the corridor fields on index
+  // entries for one release, derived from the ids as bolt11->lightning,
+  // bitcoin->onchain, eip155->eip155.
+  const indexEntry = (overrides: Record<string, unknown> = {}) =>
+    ({
+      ...newFormat()[0],
+      pair: 'BTC/lightning:BTC',
+      base_corridor: 'arkade',
+      quote_corridor: 'lightning',
+      ...overrides,
+    }) as unknown as DiscoveredMarket
+
+  it('resolves each namespace off the id', () => {
+    expect(marketCorridor({ quote_asset: { id: 'arkade:bitcoin/slip44:0' } }, 'quote')).toBe('arkade')
+    expect(marketCorridor({ quote_asset: { id: 'bolt11:bitcoin/slip44:0' } }, 'quote')).toBe('bolt11')
+    expect(marketCorridor({ quote_asset: { id: ERC20_ID } }, 'quote')).toBe('eip155')
+  })
+
+  it('never answers with a v0 rail name, which no call site tests for', () => {
+    for (const market of [indexEntry(), oldFormat()[0], indexEntry({ quote_corridor: 'onchain' })]) {
+      expect(['arkade', 'bolt11', 'bitcoin', 'eip155']).toContain(marketCorridor(market, 'quote'))
+    }
+  })
+
+  it('still finds the Lightning rendezvous on a compat index entry', () => {
+    expect(lnSendRendezvous([indexEntry()], EMULATOR)).toBeDefined()
+  })
+
+  it('keeps an EVM market off the Lightning corridor and off the spot surface', () => {
+    const evm = indexEntry({ quote_asset: { id: ERC20_ID, ticker: 'USDC' }, quote_corridor: 'eip155' })
+    expect(marketCorridor(evm, 'quote')).not.toBe('arkade')
+    expect(lnSendRendezvous([evm], EMULATOR)).toBeUndefined()
+    expect(isRfqMarket(evm)).toBe(true)
+  })
+})

--- a/src/test/lib/offerFunding.test.tsx
+++ b/src/test/lib/offerFunding.test.tsx
@@ -99,41 +99,13 @@ describe('funding an Arkade swap offer', () => {
     expect(btc?.balance).toBe(HELD)
   })
 
-  it('shows the commitment from its record, before any tx of it reaches history', () => {
-    // The covenant is a contract this wallet registered, so Arkade counts the
-    // 50_000 as change: the funding tx nets to zero and history reports nothing.
-    const [row, ...rest] = activitiesToTxs([], { ...empty, swaps: [offerSwap()] })
-
-    expect(rest).toEqual([])
-    expect(row).toMatchObject({
-      type: 'swap',
-      amount: COMMITTED,
-      createdAt: 4,
-      redeemTxid: FUNDING_TXID,
-      historyKey: `swap:${FUNDING_TXID}`,
-      assetSwap: { fromAssetId: 'btc', fromAmount: BigInt(COMMITTED), fundingTxid: FUNDING_TXID },
-    })
-  })
-
-  it('reads as pending and recoverable, never as money burned', () => {
-    const [row] = activitiesToTxs([], { ...empty, swaps: [offerSwap()] })
-
-    expect(row.assetSwap?.status).toBe('pending')
-    expect(row.settled).toBe(false)
-  })
-
-  it('names a cancelled offer cancelled rather than dropping it from history', () => {
-    const [row] = activitiesToTxs([], { ...empty, swaps: [offerSwap({ status: 'cancelled' })] })
-
-    expect(row.assetSwap?.status).toBe('cancelled')
-  })
-
-  it('yields to the group once one exists, under the same key', () => {
+  it('renders the SDK gated-history row as the pending swap commitment', () => {
     const funding = {
       amount: COMMITTED,
       createdAt: 4_000,
       settled: true,
       type: 'SENT',
+      tag: 'gated',
       key: { arkTxid: FUNDING_TXID, boardingTxid: '', commitmentTxid: '' },
     }
     const group = {
@@ -148,6 +120,16 @@ describe('funding an Arkade swap offer', () => {
     const rows = activitiesToTxs([group as never], { ...empty, swaps: [offerSwap()] })
 
     expect(rows).toHaveLength(1)
-    expect(rows[0].historyKey).toBe(`swap:${FUNDING_TXID}`)
+    expect(rows[0]).toMatchObject({
+      type: 'swap',
+      amount: COMMITTED,
+      historyKey: `swap:${FUNDING_TXID}`,
+      assetSwap: {
+        status: 'pending',
+        fromAssetId: 'btc',
+        fromAmount: BigInt(COMMITTED),
+        fundingTxid: FUNDING_TXID,
+      },
+    })
   })
 })

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -4,12 +4,13 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hex } from '@scure/base'
 import { planOffer, type OfferPlan } from '@arkade-os/solver-discovery'
-import { addAssetSwap, getAssetSwaps, updateAssetSwap } from '@arkade-os/swap'
+import { addAssetSwap, getAssetSwaps, updateAssetSwap, type RestoreAssetSwapRepositoryResult } from '@arkade-os/swap'
 import { AspContext } from '../../providers/asp'
 import { AssetSwapsContext, AssetSwapsProvider } from '../../providers/assetSwaps'
 import { WalletContext } from '../../providers/wallet'
 import { assetSwapRepository as repository, type WalletAssetSwap } from '../../lib/swapRepository'
 import { btcUsdt, maratNapo, MARAT_ID, NAPO_ID, USDT_ID } from '../lib/swapFixtures'
+import corridorSolverCard from '../corridor-solver.card.json'
 import { saveSolverCards } from '../../lib/solverCards'
 import { toast } from '../../components/Toast'
 import { mockAspContextValue, mockTxInfo, mockWalletContextValue } from '../screens/mocks'
@@ -21,7 +22,7 @@ const getVirtualTxs = vi.hoisted(() => vi.fn())
 const classifyDepositSpend = vi.hoisted(() => vi.fn())
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const discoverMarkets = vi.hoisted(() => vi.fn(async (_network: string, _useCache?: boolean) => []))
-const restoreAssetSwaps = vi.hoisted(() => vi.fn())
+const restoreAssetSwapRepository = vi.hoisted(() => vi.fn())
 const watchOfferSwaps = vi.hoisted(() => vi.fn())
 const decodeOffer = vi.hoisted(() => vi.fn())
 
@@ -39,7 +40,7 @@ vi.mock('@arkade-os/swap', async (importOriginal) => ({
   classifyDepositSpend,
   createOffer,
   decodeOffer,
-  restoreAssetSwaps,
+  restoreAssetSwapRepository,
   watchOfferSwaps,
 }))
 
@@ -162,6 +163,12 @@ beforeEach(() => {
   decodeOffer.mockReset().mockReturnValue({ wantAsset: { toString: () => pendingSwap.toAsset } })
   getVirtualTxs.mockReset().mockResolvedValue({ txs: [] })
   classifyDepositSpend.mockReset().mockReturnValue('fulfilled')
+  restoreAssetSwapRepository.mockReset().mockResolvedValue({
+    swaps: [],
+    changes: [],
+    scannedTxids: [],
+    aborted: false,
+  })
 })
 
 describe('AssetSwapsProvider createSwap offer encoding', () => {
@@ -360,7 +367,13 @@ describe('AssetSwapsProvider restore scan', () => {
     return <span data-testid='restored'>{swaps.map((s) => s.id).join(',') || 'none'}</span>
   }
 
-  const tree = (txs: (typeof mockTxInfo)[], signerPubkey: string = SIGNER_PUBKEY, svcWallet?: unknown) =>
+  const defaultManager = { getContractsWithVtxos: vi.fn().mockResolvedValue([]) }
+  const defaultSvcWallet = { identity: {}, getContractManager: async () => defaultManager }
+  const tree = (
+    txs: (typeof mockTxInfo)[],
+    signerPubkey: string = SIGNER_PUBKEY,
+    svcWallet: unknown = defaultSvcWallet,
+  ) =>
     providerTree(
       {
         asp: { network: '', url: 'https://ark.test', signerPubkey },
@@ -378,21 +391,35 @@ describe('AssetSwapsProvider restore scan', () => {
     return { setContractWatchState, svcWallet: { identity: {}, getContractManager: async () => manager } }
   }
 
-  /** Renders with the first `restoreAssetSwaps` held open, so a rerender lands
+  type RestoreResult = RestoreAssetSwapRepositoryResult
+  const result = (swaps: WalletAssetSwap[] = [], changes: RestoreResult['changes'] = []): RestoreResult => ({
+    swaps,
+    changes,
+    scannedTxids: [],
+    aborted: false,
+  })
+  const mockResult = (value: RestoreResult) =>
+    restoreAssetSwapRepository.mockImplementation(async (opts: { repository: typeof repository }) => {
+      for (const { current } of value.changes) await opts.repository.saveSwap(current)
+      if (value.scannedTxids.length > 0) await opts.repository.markTxidsScanned(value.scannedTxids)
+      return value
+    })
+
+  /** Renders with the first SDK restore held open, so a rerender lands
    * while a scan is provably in flight. Returns the release for that run. */
   const renderBlockedScan = async () => {
-    let release: (result: { restored: WalletAssetSwap[]; scannedTxids: string[] }) => void = () => {}
-    restoreAssetSwaps
+    let release: (value: RestoreResult) => void = () => {}
+    restoreAssetSwapRepository
       .mockReturnValueOnce(new Promise((resolve) => (release = resolve)))
-      .mockResolvedValue({ restored: [], scannedTxids: [] })
+      .mockResolvedValue(result())
     const { rerender } = render(tree([sentTx('a')]))
-    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(1))
-    return { rerender, release: (result: Parameters<typeof release>[0]) => release(result) }
+    await waitFor(() => expect(restoreAssetSwapRepository).toHaveBeenCalledTimes(1))
+    return { rerender, release }
   }
 
   beforeEach(async () => {
     await repository.clear()
-    restoreAssetSwaps.mockReset()
+    restoreAssetSwapRepository.mockReset().mockResolvedValue(result())
   })
 
   afterEach(async () => await repository.clear())
@@ -408,7 +435,7 @@ describe('AssetSwapsProvider restore scan', () => {
     const { rerender, release } = await renderBlockedScan()
 
     rerender(tree([sentTx('a'), sentTx('b')]))
-    release({ restored: [restoredSwap], scannedTxids: ['restored-txid'] })
+    release(result([restoredSwap], [{ current: restoredSwap }]))
 
     await waitFor(() => expect(screen.getByTestId('restored')).toHaveTextContent('restored-txid'))
   })
@@ -421,16 +448,16 @@ describe('AssetSwapsProvider restore scan', () => {
     const { rerender, release } = await renderBlockedScan()
 
     rerender(tree([sentTx('a')], OTHER_PUBKEY))
-    release({ restored: [restoredSwap], scannedTxids: ['restored-txid'] })
+    release(result([restoredSwap], [{ current: restoredSwap }]))
 
-    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(2))
-    expect(restoreAssetSwaps.mock.calls[1][3].serverPubkey).toEqual(hex.decode('cd'.repeat(32)))
+    await waitFor(() => expect(restoreAssetSwapRepository).toHaveBeenCalledTimes(2))
+    expect(restoreAssetSwapRepository.mock.calls[1][0].serverPubkey).toEqual(hex.decode('cd'.repeat(32)))
     // and the abandoned run wrote nothing for the wallet that went away
     expect(screen.getByTestId('restored')).toHaveTextContent('none')
   })
 
   it('scans under StrictMode, whose setup/cleanup/setup would strand the unmounted flag', async () => {
-    restoreAssetSwaps.mockResolvedValue({ restored: [restoredSwap], scannedTxids: ['restored-txid'] })
+    restoreAssetSwapRepository.mockResolvedValue(result([restoredSwap], [{ current: restoredSwap }]))
 
     render(<StrictMode>{tree([sentTx('a')])}</StrictMode>)
 
@@ -438,22 +465,22 @@ describe('AssetSwapsProvider restore scan', () => {
   })
 
   it('goes round again with the history that arrived mid-scan', async () => {
-    let release: (result: { restored: WalletAssetSwap[]; scannedTxids: string[] }) => void = () => {}
-    restoreAssetSwaps
+    let release: (value: RestoreResult) => void = () => {}
+    restoreAssetSwapRepository
       .mockReturnValueOnce(new Promise((resolve) => (release = resolve)))
-      .mockResolvedValue({ restored: [], scannedTxids: [] })
+      .mockResolvedValue(result())
 
     const { rerender } = render(tree([sentTx('a')]))
-    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(1))
-    expect(restoreAssetSwaps.mock.calls[0][1]).toHaveLength(1)
+    await waitFor(() => expect(restoreAssetSwapRepository).toHaveBeenCalledTimes(1))
+    expect(restoreAssetSwapRepository.mock.calls[0][0].txs).toHaveLength(1)
 
     // a run skipped because another was in flight must not be a run lost
     rerender(tree([sentTx('a'), sentTx('b')]))
-    release({ restored: [], scannedTxids: ['a'] })
+    release(result())
 
-    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(restoreAssetSwapRepository).toHaveBeenCalledTimes(2))
     // and it sees the newer history, not the list its effect closed over
-    expect(restoreAssetSwaps.mock.calls[1][1]).toHaveLength(2)
+    expect(restoreAssetSwapRepository.mock.calls[1][0].txs).toHaveLength(2)
   })
 
   it('feeds the scan the ungrouped rows, not the grouped ones its own records produced', async () => {
@@ -463,7 +490,7 @@ describe('AssetSwapsProvider restore scan', () => {
     // loses the very tx it rebuilt the record from, so exempting the record
     // from both skip lists buys nothing — there is no candidate left to ask
     // about. It could create a record and never re-answer it.
-    restoreAssetSwaps.mockResolvedValue({ restored: [], scannedTxids: [] })
+    restoreAssetSwapRepository.mockResolvedValue(result())
     const funding = sentTx('funding-txid')
     const grouped = { ...mockTxInfo, type: 'swap', redeemTxid: 'funding-txid', createdAt: 1 }
 
@@ -471,32 +498,21 @@ describe('AssetSwapsProvider restore scan', () => {
       providerTree(
         {
           asp: { network: '', url: 'https://ark.test', signerPubkey: SIGNER_PUBKEY },
-          wallet: { dataReady: true, txs: [grouped], ungroupedTxs: [funding] },
+          wallet: { dataReady: true, txs: [grouped], ungroupedTxs: [funding], svcWallet: defaultSvcWallet },
         },
         <ScanHarness />,
       ),
     )
 
-    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(1))
-    expect(restoreAssetSwaps.mock.calls[0][1]).toEqual([funding])
+    await waitFor(() => expect(restoreAssetSwapRepository).toHaveBeenCalledTimes(1))
+    expect(restoreAssetSwapRepository.mock.calls[0][0].txs).toEqual([funding])
   })
 
-  it('re-asks about a record still open and writes the outcome the chain reports', async () => {
-    // The bug this closes: a record whose covenant was never registered — every
-    // record a restore rebuilt — has no contract row, so no watcher event and
-    // no `reconcileUnseenSpends` pass can reach it. Left in `existingIds` it was
-    // skipped by every later scan too, so `pending` was permanent and the swap
-    // rendered as a Swap-pending row plus a bare received one, forever.
+  it('applies an SDK-restored outcome and retires its covenant', async () => {
     const stored: WalletAssetSwap = { ...pendingSwap, quote: { feeBps: 30 } }
     await addAssetSwap(repository, stored)
-    await repository.markTxidsScanned([stored.id])
-    restoreAssetSwaps.mockResolvedValue({
-      restored: [
-        // as the scan builds it: every field from chain, and no funded address
-        { ...pendingSwap, swapAddress: '', status: 'fulfilled', spentTxid: 'fill-txid', completedAt: 99 },
-      ],
-      scannedTxids: [stored.id],
-    })
+    const restored = { ...stored, status: 'fulfilled' as const, spentTxid: 'fill-txid', completedAt: 99 }
+    mockResult(result([restored], [{ previous: stored, current: restored }]))
     const seams = scanWallet()
 
     render(tree([sentTx(stored.id)], SIGNER_PUBKEY, seams.svcWallet))
@@ -506,48 +522,57 @@ describe('AssetSwapsProvider restore scan', () => {
         status: 'fulfilled',
         spentTxid: 'fill-txid',
         completedAt: 99,
-        // the two the scan cannot know and must not overwrite
+        // the SDK preserved the two fields chain data cannot know
         swapAddress: pendingSwap.swapAddress,
         quote: { feeBps: 30 },
       }),
     )
-    // neither skip list may hold it back, or the scan never sees the candidate
-    expect(restoreAssetSwaps.mock.calls[0][2].has(stored.id)).toBe(false)
-    expect(restoreAssetSwaps.mock.calls[0][3].scanned.has(stored.id)).toBe(false)
+    expect(restoreAssetSwapRepository.mock.calls[0][0]).toMatchObject({
+      wallet: seams.svcWallet,
+      arkServerUrl: 'https://ark.test',
+      repository,
+    })
     // and the covenant it settled leaves the watched set
     await waitFor(() => expect(seams.setContractWatchState).toHaveBeenCalledWith(stored.swapPkScript, 'retained'))
   })
 
-  it('stops asking about a record the chain has answered', async () => {
-    const stored: WalletAssetSwap = { ...pendingSwap, status: 'cancelled', spentTxid: 'cancel-txid' }
-    await addAssetSwap(repository, stored)
-    await repository.markTxidsScanned([stored.id])
-    restoreAssetSwaps.mockResolvedValue({ restored: [], scannedTxids: [] })
+  it('delegates records, cursor and coverage to the SDK even with no history rows', async () => {
+    await addAssetSwap(repository, pendingSwap)
+    const { svcWallet } = scanWallet()
 
-    render(tree([sentTx(stored.id)]))
+    render(tree([], SIGNER_PUBKEY, svcWallet))
 
-    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(1))
-    expect(restoreAssetSwaps.mock.calls[0][2].has(stored.id)).toBe(true)
-    expect(restoreAssetSwaps.mock.calls[0][3].scanned.has(stored.id)).toBe(true)
+    await waitFor(() => expect(restoreAssetSwapRepository).toHaveBeenCalledTimes(1))
+    expect(restoreAssetSwapRepository.mock.calls[0][0]).toMatchObject({
+      wallet: svcWallet,
+      arkServerUrl: 'https://ark.test',
+      repository,
+      txs: [],
+      serverPubkey: hex.decode('ab'.repeat(32)),
+    })
   })
 
-  it('leaves a cancel in flight alone when the scan has no answer for it yet', async () => {
-    // `pending` off the scan means the deposit is still unspent, which is not an
-    // outcome. Writing it back would drop the cancel `cancelOffer` is running.
-    await addAssetSwap(repository, { ...pendingSwap, status: 'cancelling' })
-    restoreAssetSwaps.mockResolvedValue({
-      restored: [{ ...pendingSwap, swapAddress: '', status: 'pending' }],
-      scannedTxids: [],
+  it('does not apply an aborted restore result', async () => {
+    restoreAssetSwapRepository.mockResolvedValue({
+      ...result([restoredSwap], [{ current: restoredSwap }]),
+      aborted: true,
     })
 
-    render(tree([sentTx(pendingSwap.id)]))
+    render(tree([sentTx(restoredSwap.id)]))
 
-    await waitFor(() => expect(restoreAssetSwaps).toHaveBeenCalledTimes(1))
-    await waitFor(() => expect(screen.getByTestId('restored')).toHaveTextContent(pendingSwap.id))
-    expect((await getAssetSwaps(repository))[0]).toMatchObject({
-      status: 'cancelling',
-      swapAddress: pendingSwap.swapAddress,
+    await waitFor(() => expect(restoreAssetSwapRepository).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('restored')).toHaveTextContent('none')
+  })
+
+  it('keeps restored changes when covenant coverage fails', async () => {
+    mockResult({
+      ...result([restoredSwap], [{ current: restoredSwap }]),
+      coverageError: new Error('coverage unavailable'),
     })
+
+    render(tree([sentTx(restoredSwap.id)]))
+
+    await waitFor(() => expect(screen.getByTestId('restored')).toHaveTextContent(restoredSwap.id))
   })
 })
 
@@ -556,7 +581,15 @@ describe('AssetSwapsProvider solver cards', () => {
     return null
   }
 
-  const renderOnNetwork = () =>
+  const corridorMarket = {
+    ...corridorSolverCard.markets[0],
+    discovery_pubkey: corridorSolverCard.discovery_pubkey,
+    transports: corridorSolverCard.transports,
+  }
+
+  const quoteIdOf = (market: { quote_asset?: unknown }) => (market.quote_asset as { id?: string } | undefined)?.id ?? ''
+
+  const renderOnNetwork = (children: ReactNode = <Bare />) =>
     render(
       <AspContext.Provider
         value={
@@ -568,9 +601,7 @@ describe('AssetSwapsProvider solver cards', () => {
             { ...mockWalletContextValue, reloadWallet: vi.fn().mockResolvedValue(undefined), svcWallet: null } as any
           }
         >
-          <AssetSwapsProvider>
-            <Bare />
-          </AssetSwapsProvider>
+          <AssetSwapsProvider>{children}</AssetSwapsProvider>
         </WalletContext.Provider>
       </AspContext.Provider>,
     )
@@ -590,6 +621,45 @@ describe('AssetSwapsProvider solver cards', () => {
     // cache bypassed: the TTL cache holds the registry's answer, which is
     // exactly what a newly stored card changes
     expect(discoverMarkets.mock.calls[1][1]).toBe(false)
+  })
+
+  it('backfills missing persisted fees after market discovery', async () => {
+    await repository.clear()
+    const stored = { ...pendingSwap, toAsset: USDT_ID, quote: { fromTicker: 'sats' } }
+    const alreadyPriced = {
+      ...stored,
+      id: 'already-priced',
+      fundingTxid: 'already-priced',
+      quote: { feeBps: 12 },
+    }
+    await addAssetSwap(repository, stored)
+    await addAssetSwap(repository, alreadyPriced)
+    discoverMarkets.mockResolvedValueOnce([btcUsdt] as never)
+
+    renderOnNetwork()
+
+    await waitFor(async () => {
+      const swaps = await getAssetSwaps(repository)
+      expect(swaps.find(({ id }) => id === stored.id)).toMatchObject({ quote: { fromTicker: 'sats', feeBps: 30 } })
+      expect(swaps.find(({ id }) => id === alreadyPriced.id)).toMatchObject({ quote: { feeBps: 12 } })
+    })
+    await repository.clear()
+  })
+
+  it('keeps a corridor market out of the spot swap surface', async () => {
+    // The corridor is the registry's own post-#23 card, where the rail is named
+    // inside the asset id. The pre-#23 check read a field that shape does not
+    // carry, so every corridor market fell through it into a surface that
+    // cannot trade one.
+    function QuoteIds() {
+      return <div data-testid='quote-ids'>{useContext(AssetSwapsContext).markets.map(quoteIdOf).join(' ')}</div>
+    }
+    discoverMarkets.mockResolvedValueOnce([corridorMarket, btcUsdt] as never)
+
+    renderOnNetwork(<QuoteIds />)
+
+    await waitFor(() => expect(screen.getByTestId('quote-ids')).toHaveTextContent(USDT_ID))
+    expect(screen.getByTestId('quote-ids')).not.toHaveTextContent('bolt11')
   })
 })
 
@@ -625,7 +695,12 @@ describe('AssetSwapsProvider spends the watcher never saw', () => {
 
   beforeEach(async () => {
     await repository.clear()
-    restoreAssetSwaps.mockReset().mockResolvedValue({ restored: [], scannedTxids: [] })
+    restoreAssetSwapRepository.mockReset().mockResolvedValue({
+      swaps: [pendingSwap],
+      changes: [],
+      scannedTxids: [],
+      aborted: false,
+    })
     vi.mocked(toast.success).mockClear()
     await addAssetSwap(repository, pendingSwap)
   })

--- a/src/test/providers/assetSwaps.test.tsx
+++ b/src/test/providers/assetSwaps.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hex } from '@scure/base'
-import { planOffer, type OfferPlan } from '@arkade-os/solver-discovery'
+import { planOffer, type DiscoveredMarket, type OfferPlan } from '@arkade-os/solver-discovery'
 import { addAssetSwap, getAssetSwaps, updateAssetSwap, type RestoreAssetSwapRepositoryResult } from '@arkade-os/swap'
 import { AspContext } from '../../providers/asp'
 import { AssetSwapsContext, AssetSwapsProvider } from '../../providers/assetSwaps'
@@ -20,8 +20,13 @@ const createOffer = vi.hoisted(() => vi.fn())
 const getVtxos = vi.hoisted(() => vi.fn())
 const getVirtualTxs = vi.hoisted(() => vi.fn())
 const classifyDepositSpend = vi.hoisted(() => vi.fn())
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const discoverMarkets = vi.hoisted(() => vi.fn(async (_network: string, _useCache?: boolean) => []))
+const discoverMarkets = vi.hoisted(() =>
+  vi.fn(async (network: string, useCache?: boolean): Promise<DiscoveredMarket[]> => {
+    void network
+    void useCache
+    return []
+  }),
+)
 const restoreAssetSwapRepository = vi.hoisted(() => vi.fn())
 const watchOfferSwaps = vi.hoisted(() => vi.fn())
 const decodeOffer = vi.hoisted(() => vi.fn())
@@ -621,6 +626,32 @@ describe('AssetSwapsProvider solver cards', () => {
     // cache bypassed: the TTL cache holds the registry's answer, which is
     // exactly what a newly stored card changes
     expect(discoverMarkets.mock.calls[1][1]).toBe(false)
+  })
+
+  it('keeps the newest discovery when two requests resolve in reverse order', async () => {
+    let resolveFirst!: (markets: (typeof btcUsdt)[]) => void
+    let resolveSecond!: (markets: (typeof btcUsdt)[]) => void
+    const first = new Promise<(typeof btcUsdt)[]>((resolve) => (resolveFirst = resolve))
+    const second = new Promise<(typeof btcUsdt)[]>((resolve) => (resolveSecond = resolve))
+    discoverMarkets.mockImplementationOnce(() => first).mockImplementationOnce(() => second)
+
+    function Fee() {
+      return <div data-testid='fee'>{useContext(AssetSwapsContext).markets[0]?.fee_bps ?? 'none'}</div>
+    }
+
+    renderOnNetwork(<Fee />)
+    await waitFor(() => expect(discoverMarkets).toHaveBeenCalledTimes(1))
+    act(() => saveSolverCards([]))
+    await waitFor(() => expect(discoverMarkets).toHaveBeenCalledTimes(2))
+
+    await act(async () => resolveSecond([{ ...btcUsdt, fee_bps: 44 }]))
+    await waitFor(() => expect(screen.getByTestId('fee')).toHaveTextContent('44'))
+
+    await act(async () => {
+      resolveFirst([btcUsdt])
+      await first
+    })
+    expect(screen.getByTestId('fee')).toHaveTextContent('44')
   })
 
   it('backfills missing persisted fees after market discovery', async () => {

--- a/src/test/screens/settings/solvers.test.tsx
+++ b/src/test/screens/settings/solvers.test.tsx
@@ -56,6 +56,8 @@ describe('Solvers screen', () => {
     // the build ships the beta solver's card; without this row the screen
     // claims "no solver cards" while a pinned solver is quoting sends
     expect(screen.getByText('beta-solver')).toBeInTheDocument()
+    // the label is derived from the sides now that #23 drops the card's `pair`
+    expect(screen.getByText('BTC/bolt11:BTC')).toBeInTheDocument()
     expect(screen.getByText('Built-in')).toBeInTheDocument()
     expect(screen.getByText('This build ships 1 solver card; add your own to reach more solvers.')).toBeInTheDocument()
     // read-only: not removable, not editable — only the add button renders


### PR DESCRIPTION
## Summary

- replay the functional CAIP-19, corridor selection, import-restore, and swap-history changes from #976
- consume the published `@arkade-os/sdk@0.4.72` and `@arkade-os/swap@0.0.15` releases instead of vendored PR tarballs
- force swap's SDK dependency to the same registry `0.4.72` version, avoiding duplicate SDK instances
- remove the #956 synthetic offer-history fallback now that SDK #859 reports gated-contract transfers itself
- discard stale solver-discovery generations and serialize fee backfills so an older request cannot overwrite newer markets

This supersedes the reverted #976/#977 path. It uses the published results of arkade-os/ts-sdk#901 (including #892, #893, and #899) and the SDK history fix from arkade-os/ts-sdk#859.

Commits:

- `880dd8e1fbcbc7a1d5a7cd4ccdc3a0d1e948cf81`
- `dfff2513d8357931094ba6ba57d6d264d84df6be`

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test:unit` — 817 passed, 1 skipped
- `pnpm build` — CSP check, service-worker build, and production build passed
- `pnpm list @arkade-os/sdk @arkade-os/swap --depth 3` — app and swap both resolve SDK `0.4.72`
