### PR TITLE
fix: accept canonical solver cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
-    "@arkade-os/solver-discovery": "0.2.3",
+    "@arkade-os/solver-discovery": "0.2.4",
     "@arkade-os/sdk": "0.4.72",
     "@arkade-os/swap": "0.0.16",
     "@base-ui/react": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: 0.4.72
         version: 0.4.72
       '@arkade-os/solver-discovery':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: 0.2.4
+        version: 0.2.4
       '@arkade-os/swap':
         specifier: 0.0.16
         version: 0.0.16(nostr-tools@2.17.2(typescript@5.9.3))
@@ -276,6 +276,10 @@ packages:
 
   '@arkade-os/solver-discovery@0.2.3':
     resolution: {integrity: sha512-i77/BCAmHY4fec41HfYb5osu+QkCEOf2jLha1HX5pkp6bHGrm10WG8eOGREKqPCC4bOI3E8cKwEVGxP0qlNt5g==}
+    engines: {node: '>=18'}
+
+  '@arkade-os/solver-discovery@0.2.4':
+    resolution: {integrity: sha512-iLjcZhnNmzndD6KLbgmMbyYL/JqmMYA2gSOn6MrESAMHWuF68CRtqn9ijvnDJDz8BzYXuFMZ/ghZfLjIvrdAdA==}
     engines: {node: '>=18'}
 
   '@arkade-os/swap@0.0.16':
@@ -4379,6 +4383,8 @@ snapshots:
       - utf-8-validate
 
   '@arkade-os/solver-discovery@0.2.3': {}
+
+  '@arkade-os/solver-discovery@0.2.4': {}
 
   '@arkade-os/swap@0.0.16(nostr-tools@2.17.2(typescript@5.9.3))':
     dependencies:

--- a/src/test/lib/solverCards.test.ts
+++ b/src/test/lib/solverCards.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { readSolverCards } from '../../lib/solverCards'
+
+const solver = {
+  name: 'ln-solver-mutinynet',
+  discovery_pubkey: '3f831510a6d7678d0c90d7d6fbc4057720517e2e30681ef4c87cc57aaf57e8d5',
+  transports: { nostr: { relays: ['wss://nostr.arkade.sh'] } },
+}
+
+const bounds = {
+  fee_bps: 30,
+  fee_flat: '50',
+  min_base_amount: '330',
+  max_base_amount: '5000000',
+  min_quote_amount: '330',
+  max_quote_amount: '1000000',
+}
+
+const asset = (id: string) => ({ id, name: 'Bitcoin', ticker: 'BTC', decimals: 8 })
+
+describe('stored solver card compatibility', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('keeps both legacy corridor cards and CAIP-19 cards', () => {
+    const legacy = {
+      version: 0,
+      ...solver,
+      markets: [
+        {
+          pair: 'BTC/lightning:BTC',
+          base_asset: asset('btc'),
+          quote_asset: asset('btc'),
+          base_corridor: 'arkade',
+          quote_corridor: 'lightning',
+          ...bounds,
+        },
+      ],
+    }
+    const caip19 = {
+      version: 0,
+      ...solver,
+      markets: [
+        {
+          base_asset: asset('arkade:mutinynet/slip44:1'),
+          quote_asset: asset('bolt11:mutinynet/slip44:1'),
+          ...bounds,
+        },
+      ],
+    }
+    localStorage.setItem(
+      'solverCards',
+      JSON.stringify([
+        { network: 'mutinynet', label: 'legacy', card: legacy },
+        { network: 'mutinynet', label: 'caip19', card: caip19 },
+      ]),
+    )
+
+    expect(readSolverCards().map(({ label }) => label)).toEqual(['legacy', 'caip19'])
+  })
+})


### PR DESCRIPTION
Updates @arkade-os/solver-discovery to 0.2.4 so the wallet accepts both legacy v0 cards and canonical CAIP-19 cards. Adds a regression test covering both stored shapes.\n\nVerification:\n- pnpm test:unit (818 passed, 1 skipped; unrelated animation teardown warning reproduced once, targeted rerun passed)\n- pnpm build\n- pnpm lint\n- pnpm format:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying stored solver cards are read correctly.
  - Confirmed support for both legacy corridor cards and CAIP-19 asset identifiers, while preserving stored order and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->