### PR TITLE
Suppress validation errors after swap/send commitment

### DIFF
--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -868,12 +868,6 @@ export default function SendForm() {
   // dust carrier; without one the SDK fails with a bare "Insufficient funds".
   // Derived, not stored: the server-status effect owns `error` and would
   // clear this on recovery.
-  //
-  // `availableBalance` is live and the amount is not: once the user has
-  // committed, anything that moves the balance re-reads their own send as one
-  // the wallet can no longer carry change for, and the form turns red under a
-  // button they already pressed. Stop validating at `processing`, which is
-  // where the amount stops being theirs to change.
   const carrierError =
     !processing &&
     activeAsset &&

--- a/src/screens/Wallet/Send/Form.tsx
+++ b/src/screens/Wallet/Send/Form.tsx
@@ -868,8 +868,18 @@ export default function SendForm() {
   // dust carrier; without one the SDK fails with a bare "Insufficient funds".
   // Derived, not stored: the server-status effect owns `error` and would
   // clear this on recovery.
+  //
+  // `availableBalance` is live and the amount is not: once the user has
+  // committed, anything that moves the balance re-reads their own send as one
+  // the wallet can no longer carry change for, and the form turns red under a
+  // button they already pressed. Stop validating at `processing`, which is
+  // where the amount stops being theirs to change.
   const carrierError =
-    activeAsset && assetAmt > BigInt(0) && assetAmt < activeAsset.balance && availableBalance < 2 * Number(aspInfo.dust)
+    !processing &&
+    activeAsset &&
+    assetAmt > BigInt(0) &&
+    assetAmt < activeAsset.balance &&
+    availableBalance < 2 * Number(aspInfo.dust)
       ? PARTIAL_SEND_ERROR
       : ''
 

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -331,14 +331,6 @@ export default function WalletSwap() {
     setSwapFromAssetId(undefined)
   }, [focusFromAsset, setSwapFromAssetId, swapAssets, swapAvailable, swapFromAssetId])
 
-  // The composer validates against the LIVE wallet balance, and confirming a
-  // swap moves that balance: the deposit's sats leave while `createSwap` is
-  // still awaiting its send. A partial asset swap the user has already
-  // committed then re-reads as one the wallet can no longer carry change for,
-  // and the composer shouts "not enough bitcoin to do a partial swap" a beat
-  // before the success splash lands. Once the swap is in flight the composer
-  // has nothing left to validate — it is describing an amount the user can no
-  // longer change.
   const swapCommitted = confirming || Boolean(successQuote)
 
   useEffect(() => {

--- a/src/screens/Wallet/Swap/Index.tsx
+++ b/src/screens/Wallet/Swap/Index.tsx
@@ -331,18 +331,28 @@ export default function WalletSwap() {
     setSwapFromAssetId(undefined)
   }, [focusFromAsset, setSwapFromAssetId, swapAssets, swapAvailable, swapFromAssetId])
 
-  useEffect(() => {
-    if (validationState === 'idle') return
-    hapticSubtle()
-  }, [validationState])
+  // The composer validates against the LIVE wallet balance, and confirming a
+  // swap moves that balance: the deposit's sats leave while `createSwap` is
+  // still awaiting its send. A partial asset swap the user has already
+  // committed then re-reads as one the wallet can no longer carry change for,
+  // and the composer shouts "not enough bitcoin to do a partial swap" a beat
+  // before the success splash lands. Once the swap is in flight the composer
+  // has nothing left to validate — it is describing an amount the user can no
+  // longer change.
+  const swapCommitted = confirming || Boolean(successQuote)
 
   useEffect(() => {
-    if (balanceValidation || !validationMessage) {
+    if (swapCommitted || validationState === 'idle') return
+    hapticSubtle()
+  }, [swapCommitted, validationState])
+
+  useEffect(() => {
+    if (swapCommitted || balanceValidation || !validationMessage) {
       toast.dismiss('swap-validation')
       return
     }
     toast.error(validationMessage, { id: 'swap-validation' })
-  }, [amount, balanceValidation, validationMessage])
+  }, [amount, balanceValidation, swapCommitted, validationMessage])
 
   useEffect(
     () => () => {

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -87,7 +87,7 @@ function renderSwap({
   // nothing escrowed unless a test says so, so every owned unit is spendable
   if (!('availableAssetBalances' in wallet)) walletValue.availableAssetBalances = walletValue.assetBalances
 
-  const view = render(
+  const tree = (walletContext: Record<string, unknown>) => (
     <AspContext.Provider
       value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' } } as any}
     >
@@ -108,7 +108,7 @@ function renderSwap({
               }
             >
               <FlowContext.Provider value={{ ...mockFlowContextValue, ...flow } as any}>
-                <WalletContext.Provider value={walletValue as any}>
+                <WalletContext.Provider value={walletContext as any}>
                   <AssetSwapsContext.Provider
                     value={
                       {
@@ -131,10 +131,22 @@ function renderSwap({
           </ConfigContext.Provider>
         </NavigationContext.Provider>
       </AssetsContext.Provider>
-    </AspContext.Provider>,
+    </AspContext.Provider>
   )
 
-  return { ...view, goBack, navigate }
+  const view = render(tree(walletValue))
+
+  return {
+    ...view,
+    goBack,
+    navigate,
+    // the wallet balance is live: a confirmed swap moves it while the screen
+    // is still mounted, so tests can move it too
+    setWallet: (patch: Record<string, unknown>) => {
+      Object.assign(walletValue, patch)
+      view.rerender(tree({ ...walletValue }))
+    },
+  }
 }
 
 // the reserve off: the BTC balance is spendable whole only while no asset is held
@@ -417,6 +429,40 @@ describe('Wallet swap flow', () => {
     for (const key of ['1', '0', '0', '0']) await userEvent.click(screen.getByRole('button', { name: key }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled(), { timeout: 3_000 })
+    expect(screen.queryByText(/partial swap/)).not.toBeInTheDocument()
+  })
+
+  it('does not warn about the change carrier once the swap is already in flight', async () => {
+    let release: (swap: AssetSwap) => void = () => {}
+    const inFlight = new Promise<AssetSwap>((resolve) => {
+      release = resolve
+    })
+    const slowCreateSwap = vi.fn().mockReturnValue(inFlight)
+    const { setWallet } = renderSwap({
+      config: { currency: Currencies.BRL, unit: Unit.SATS },
+      flow: { swapFromAssetId: DEPIX_ID, setSwapFromAssetId: vi.fn() },
+      swap: { createSwap: slowCreateSwap },
+      // two dust carriers: enough for the deposit and its asset change
+      wallet: { availableBalance: 666, assetBalances: [{ assetId: DEPIX_ID, amount: BigInt(200_000_000_000) }] },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Bitcoin/i }))
+    for (const key of ['1', '0', '0', '0']) await userEvent.click(screen.getByRole('button', { name: key }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled(), { timeout: 3_000 })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm swap' }))
+    await waitFor(() => expect(slowCreateSwap).toHaveBeenCalledOnce())
+
+    // the deposit's carriers leave the wallet while the send is still awaiting
+    act(() => setWallet({ availableBalance: 333 }))
+    await act(async () => {
+      release(pendingSwap)
+      await inFlight
+    })
+
+    expect(await screen.findByText('Swap created')).toBeInTheDocument()
     expect(screen.queryByText(/partial swap/)).not.toBeInTheDocument()
   })
 

--- a/src/test/screens/wallet/swap.test.tsx
+++ b/src/test/screens/wallet/swap.test.tsx
@@ -87,7 +87,7 @@ function renderSwap({
   // nothing escrowed unless a test says so, so every owned unit is spendable
   if (!('availableAssetBalances' in wallet)) walletValue.availableAssetBalances = walletValue.assetBalances
 
-  const tree = (walletContext: Record<string, unknown>) => (
+  const view = render(
     <AspContext.Provider
       value={{ ...mockAspContextValue, aspInfo: { ...mockAspContextValue.aspInfo, network: 'mutinynet' } } as any}
     >
@@ -108,7 +108,7 @@ function renderSwap({
               }
             >
               <FlowContext.Provider value={{ ...mockFlowContextValue, ...flow } as any}>
-                <WalletContext.Provider value={walletContext as any}>
+                <WalletContext.Provider value={walletValue as any}>
                   <AssetSwapsContext.Provider
                     value={
                       {
@@ -131,22 +131,10 @@ function renderSwap({
           </ConfigContext.Provider>
         </NavigationContext.Provider>
       </AssetsContext.Provider>
-    </AspContext.Provider>
+    </AspContext.Provider>,
   )
 
-  const view = render(tree(walletValue))
-
-  return {
-    ...view,
-    goBack,
-    navigate,
-    // the wallet balance is live: a confirmed swap moves it while the screen
-    // is still mounted, so tests can move it too
-    setWallet: (patch: Record<string, unknown>) => {
-      Object.assign(walletValue, patch)
-      view.rerender(tree({ ...walletValue }))
-    },
-  }
+  return { ...view, goBack, navigate }
 }
 
 // the reserve off: the BTC balance is spendable whole only while no asset is held
@@ -429,40 +417,6 @@ describe('Wallet swap flow', () => {
     for (const key of ['1', '0', '0', '0']) await userEvent.click(screen.getByRole('button', { name: key }))
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled(), { timeout: 3_000 })
-    expect(screen.queryByText(/partial swap/)).not.toBeInTheDocument()
-  })
-
-  it('does not warn about the change carrier once the swap is already in flight', async () => {
-    let release: (swap: AssetSwap) => void = () => {}
-    const inFlight = new Promise<AssetSwap>((resolve) => {
-      release = resolve
-    })
-    const slowCreateSwap = vi.fn().mockReturnValue(inFlight)
-    const { setWallet } = renderSwap({
-      config: { currency: Currencies.BRL, unit: Unit.SATS },
-      flow: { swapFromAssetId: DEPIX_ID, setSwapFromAssetId: vi.fn() },
-      swap: { createSwap: slowCreateSwap },
-      // two dust carriers: enough for the deposit and its asset change
-      wallet: { availableBalance: 666, assetBalances: [{ assetId: DEPIX_ID, amount: BigInt(200_000_000_000) }] },
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: /Receive Choose asset/i }))
-    fireEvent.click(screen.getByRole('button', { name: /Bitcoin/i }))
-    for (const key of ['1', '0', '0', '0']) await userEvent.click(screen.getByRole('button', { name: key }))
-
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled(), { timeout: 3_000 })
-    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm swap' }))
-    await waitFor(() => expect(slowCreateSwap).toHaveBeenCalledOnce())
-
-    // the deposit's carriers leave the wallet while the send is still awaiting
-    act(() => setWallet({ availableBalance: 333 }))
-    await act(async () => {
-      release(pendingSwap)
-      await inFlight
-    })
-
-    expect(await screen.findByText('Swap created')).toBeInTheDocument()
     expect(screen.queryByText(/partial swap/)).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
Confirm a partial asset swap and you get an error and a success back to back, on a swap that worked. The composer validates the change-carrier rule against the live wallet balance, and confirming moves that balance: `createSwap` sends the deposit, the carrier sats leave, the screen re-renders while the send is still awaiting, and the amount the user just committed re-reads as one the wallet can no longer carry change for. "You don't have enough bitcoin to do a partial swap" fires a beat before the success splash. Gating the composer's two validation effects on `swapCommitted` fixes it: once the amount is no longer the user's to change, there is nothing left to validate. The send form gets the same gate on `processing`, though its exposure is narrower since the form unmounts at `navigate(Pages.SendDetails)` before `Details.tsx` starts the send, so that half is hardening rather than a reproducible fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpNRCif4tuwSwPXRaMdPTL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented partial-send errors from appearing while a transaction is processing.
  - Suppressed swap validation alerts and haptic feedback while a swap is being confirmed or after a successful quote is set.
  - Validation feedback resumes when the swap is no longer committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->