### PR TITLE
change swept tag to recoverable

### DIFF
--- a/src/screens/Settings/Vtxos.tsx
+++ b/src/screens/Settings/Vtxos.tsx
@@ -198,9 +198,9 @@ export default function Vtxos() {
         subdust
       </Text>
     ),
-    swept: (
+    recoverable: (
       <Text color='orange' smaller>
-        swept
+        recoverable
       </Text>
     ),
     unconfirmed: (
@@ -297,7 +297,7 @@ export default function Vtxos() {
         {isSubdust(vtxo, aspInfo.dust)
           ? Tags.subdust
           : canRecoverOnchain(vtxo, now)
-            ? Tags.swept
+            ? Tags.recoverable
             : wallet.thresholdMs && isVtxoExpiringSoon(vtxo, wallet.thresholdMs)
               ? Tags.expiring
               : !vtxo.isSpent && !vtxo.isSwept && !vtxo.isPreconfirmed


### PR DESCRIPTION
Given that this tag is the direct result of `canRecoverOnchain(vtxo, now)` it seems appropriate to change it from "swept" to "recoverable"

@tiero please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VTXO status labels so recoverable coins are displayed as **“recoverable”** instead of **“swept.”**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->